### PR TITLE
Add support for DynamoDB Local

### DIFF
--- a/.autover/changes/7581753a-308f-42e0-9f49-5092ccf126cd.json
+++ b/.autover/changes/7581753a-308f-42e0-9f49-5092ccf126cd.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add Amazon DynamoDB Local support"
+      ]
+    }
+  ]
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,24 +4,21 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <AspireVersion>9.0.0</AspireVersion>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="$(AspireVersion)" />
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="3.7.402.11" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Dns" Version="$(AspireVersion)" />
-
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="$(AspireVersion)" />
-
     <!-- AWS SDK for .NET dependencies -->
-    <PackageVersion Include="AWSSDK.CloudFormation" Version="3.7.400.36" />
-    <PackageVersion Include="AWSSDK.SQS" Version="3.7.400.36" />
-    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="3.7.400.36" />
-    <PackageVersion Include="AWSSDK.Core" Version="3.7.400.36" />
+    <PackageVersion Include="AWSSDK.CloudFormation" Version="3.7.400.47" />
+    <PackageVersion Include="AWSSDK.SQS" Version="3.7.400.47" />
+    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="3.7.400.47" />
+    <PackageVersion Include="AWSSDK.Core" Version="3.7.400.47" />
     <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.301" />
     <PackageVersion Include="AWS.Messaging" Version="0.9.2" />
     <!-- AWS CDK dependencies -->
-    <PackageVersion Include="Amazon.CDK.Lib" Version="2.160.0" />
-
+    <PackageVersion Include="Amazon.CDK.Lib" Version="2.166.0" />
     <!-- Open Telemetry -->
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.9.0" />
@@ -29,7 +26,6 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.1.0-beta.6" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.9.0" />
-
     <!-- Test dependencies -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="xunit" Version="2.9.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,14 +7,15 @@
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting" Version="$(AspireVersion)" />
     <PackageVersion Include="Aspire.Hosting.AppHost" Version="$(AspireVersion)" />
-    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="3.7.402.11" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="$(AspireVersion)" />	
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Dns" Version="$(AspireVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="$(AspireVersion)" />
     <!-- AWS SDK for .NET dependencies -->
     <PackageVersion Include="AWSSDK.CloudFormation" Version="3.7.400.47" />
-    <PackageVersion Include="AWSSDK.SQS" Version="3.7.400.47" />
-    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="3.7.400.47" />
     <PackageVersion Include="AWSSDK.Core" Version="3.7.400.47" />
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="3.7.402.11" />	
+    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="3.7.400.47" />
+    <PackageVersion Include="AWSSDK.SQS" Version="3.7.400.47" />
     <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.301" />
     <PackageVersion Include="AWS.Messaging" Version="0.9.2" />
     <!-- AWS CDK dependencies -->

--- a/integrations-on-dotnet-aspire-for-aws.sln
+++ b/integrations-on-dotnet-aspire-for-aws.sln
@@ -21,6 +21,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{7F5F26A8
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Aspire.Hosting.AWS.UnitTests", "tests\Aspire.Hosting.AWS.UnitTests\Aspire.Hosting.AWS.UnitTests.csproj", "{2CDEDFE3-5B21-455B-AC18-14F89A9D321D}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Aspire.Hosting.AWS.Integ.Tests", "tests\Aspire.Hosting.AWS.Integ.Tests\Aspire.Hosting.AWS.Integ.Tests.csproj", "{85E281A8-944D-4303-9D9A-28B4F5AEF69F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{2CDEDFE3-5B21-455B-AC18-14F89A9D321D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2CDEDFE3-5B21-455B-AC18-14F89A9D321D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2CDEDFE3-5B21-455B-AC18-14F89A9D321D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{85E281A8-944D-4303-9D9A-28B4F5AEF69F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{85E281A8-944D-4303-9D9A-28B4F5AEF69F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{85E281A8-944D-4303-9D9A-28B4F5AEF69F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{85E281A8-944D-4303-9D9A-28B4F5AEF69F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -62,6 +68,7 @@ Global
 		{B9C202D3-5E96-8F20-9DF2-7F3F5F78F6DB} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{B539FEDD-415D-A6BF-7813-265B9ED31888} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{2CDEDFE3-5B21-455B-AC18-14F89A9D321D} = {7F5F26A8-F41A-4B16-83F0-8A11EE396FAC}
+		{85E281A8-944D-4303-9D9A-28B4F5AEF69F} = {7F5F26A8-F41A-4B16-83F0-8A11EE396FAC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FBA55172-92F1-4495-A082-E0ABE4F4AF09}

--- a/playground/AWS/AWS.AppHost/AWS.AppHost.csproj
+++ b/playground/AWS/AWS.AppHost/AWS.AppHost.csproj
@@ -15,4 +15,10 @@
     <ProjectReference Include="..\Frontend\Frontend.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="app-resources.template">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/playground/AWS/AWS.AppHost/Program.cs
+++ b/playground/AWS/AWS.AppHost/Program.cs
@@ -6,7 +6,6 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 // Setup a configuration for the AWS .NET SDK.
 var awsConfig = builder.AddAWSSDKConfig()
-                        .WithProfile("default")
                         .WithRegion(RegionEndpoint.USWest2);
 
 // Provision application level resources like SQS queues and SNS topics defined in the CloudFormation template file app-resources.template.

--- a/playground/AWS/AWS.AppHost/Program.cs
+++ b/playground/AWS/AWS.AppHost/Program.cs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 using Amazon;
+using Aspire.Hosting.AWS.DynamoDB;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -13,6 +14,9 @@ var awsResources = builder.AddAWSCloudFormationTemplate("AspireSampleDevResource
                         .WithParameter("DefaultVisibilityTimeout", "30")
                         // Add the SDK configuration so the AppHost knows what account/region to provision the resources.
                         .WithReference(awsConfig);
+
+// Add a DynamoDB Local instance
+var localDynamoDB = builder.AddAWSDynamoDBLocal("DynamoDBLocal");
 
 // To add outputs of a CloudFormation stack that was created outside of AppHost use the AddAWSCloudFormationStack method.
 // then attach the CloudFormation resource to a project using the WithReference method.
@@ -28,6 +32,7 @@ builder.AddProject<Projects.Frontend>("Frontend")
         // The prefix is configurable by the optional configSection parameter.
         .WithReference(awsResources)
         // Demonstrating binding a single output variable to environment variable in the project.
-        .WithEnvironment("ChatTopicArnEnv", awsResources.GetOutput("ChatTopicArn"));
+        .WithEnvironment("ChatTopicArnEnv", awsResources.GetOutput("ChatTopicArn"))
+        .WithReference(localDynamoDB);
 
 builder.Build().Run();

--- a/playground/AWS/Frontend/Components/Layout/NavMenu.razor
+++ b/playground/AWS/Frontend/Components/Layout/NavMenu.razor
@@ -25,6 +25,12 @@
                 <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> Message Publisher
             </NavLink>
         </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="dynamodb-local-test">
+                <span class="bi bi-plus-square-fill-nav-menu" aria-hidden="true"></span> DynamoDB Local
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/playground/AWS/Frontend/Components/Pages/DynamoDBLocalTest.razor
+++ b/playground/AWS/Frontend/Components/Pages/DynamoDBLocalTest.razor
@@ -1,0 +1,61 @@
+﻿@page "/dynamodb-local-test"
+@using Amazon.DynamoDBv2
+@using Amazon.DynamoDBv2.Model
+
+@inject IAmazonDynamoDB ddbClient
+@inject ILogger<DynamoDBLocalTest> logger
+
+
+<h3>Test DynamoDB Local Integration</h3>
+
+<p>The IAmazonDynamoDB service client is configured to make requests to: <strong>@ServiceUrl</strong></p>
+
+<p>Tables in Local DynamoDB Instance</p>
+<ul>
+@foreach(var name in TableNames)
+{
+    <li>@name</li>
+}
+</ul>
+
+@code {
+
+    public string? ServiceUrl { get; set; }
+
+    public List<string> TableNames { get; set; } = new List<string>();
+
+    protected override async Task OnInitializedAsync()
+    {
+        var listTablesRequest = new ListTablesRequest();
+        ServiceUrl = ddbClient.DetermineServiceOperationEndpoint(listTablesRequest).URL;
+
+
+        // Create a table so something comes back in the ListTables call
+        var createRequest = new CreateTableRequest
+        {
+            TableName = "LocalDDBTable",
+            BillingMode = BillingMode.PAY_PER_REQUEST,
+            KeySchema = new List<KeySchemaElement>
+            {
+                new KeySchemaElement{AttributeName = "Id", KeyType = KeyType.HASH}
+            },
+            AttributeDefinitions = new List<AttributeDefinition>
+            {
+                new AttributeDefinition{AttributeName = "Id", AttributeType = ScalarAttributeType.S}
+            }
+        };
+
+        try
+        {
+            await ddbClient.CreateTableAsync(createRequest);
+            logger.LogInformation("Table {tableName} created", createRequest.TableName);
+        }
+        catch (ResourceInUseException)
+        {
+            logger.LogWarning("CreateTable failed because table already exists: {tableName}", createRequest.TableName);
+        }
+            
+
+        TableNames = (await ddbClient.ListTablesAsync(listTablesRequest)).TableNames;
+    }
+}

--- a/playground/AWS/Frontend/Frontend.csproj
+++ b/playground/AWS/Frontend/Frontend.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\AWS.ServiceDefaults\AWS.ServiceDefaults.csproj" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" />
     <PackageReference Include="AWSSDK.SQS" />
     <PackageReference Include="AWSSDK.SimpleNotificationService" />
     <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" />

--- a/playground/AWS/Frontend/Program.cs
+++ b/playground/AWS/Frontend/Program.cs
@@ -43,4 +43,42 @@ app.UseAntiforgery();
 app.MapRazorComponents<App>()
     .AddInteractiveServerRenderMode();
 
+app.MapGet("/healthcheck/dynamodb", (HttpContext ctx) =>
+{
+    var ddbClient = app.Services.GetRequiredService<IAmazonDynamoDB>();
+    if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AWS_ENDPOINT_URL_DYNAMODB")))
+    {
+        return Results.BadRequest("The AWS_ENDPOINT_URL_DYNAMODB is not set");
+    }
+    if (!ddbClient.Config.ServiceURL.StartsWith(Environment.GetEnvironmentVariable("AWS_ENDPOINT_URL_DYNAMODB")!))
+    {
+        return Results.BadRequest("The DynamoDB service client is not configured for DyanamoDB local");
+    }
+
+    return Results.Ok("Success");
+});
+
+
+app.MapGet("/healthcheck/cloudformation", (HttpContext ctx) =>
+{
+    // Confirm the WithEnvironment behavior
+    if (builder.Configuration["ChatTopicArnEnv"] == null)
+    {
+        return Results.BadRequest("Missing ChatTopicArnEnv");
+    }
+
+    // Confirm the WithReference behavior
+    if (builder.Configuration["AWS:Resources:ChatTopicArn"] == null)
+    {
+        return Results.BadRequest("Missing ChatTopicArn");
+    }
+    if (builder.Configuration["AWS:Resources:ChatMessagesQueueUrl"] == null)
+    {
+        return Results.BadRequest("Missing ChatTopicArn");
+    }
+
+    return Results.Ok("Success");
+});
+
+
 app.Run();

--- a/playground/AWS/Frontend/Program.cs
+++ b/playground/AWS/Frontend/Program.cs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+using Amazon.DynamoDBv2;
 using Amazon.SimpleNotificationService;
 using Amazon.SQS;
 using Frontend.Components;
@@ -8,6 +9,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.AddServiceDefaults();
 
+builder.Services.AddAWSService<IAmazonDynamoDB>(); 
 builder.Services.AddAWSService<IAmazonSQS>();
 builder.Services.AddAWSService<IAmazonSimpleNotificationService>();
 

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalOptions.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalOptions.cs
@@ -1,0 +1,14 @@
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+namespace Aspire.Hosting.AWS.DynamoDB;
+
+/// <summary>
+/// Options that can be set for configuring the instance of DynamoDB Local.
+/// </summary>
+public class DynamoDBLocalOptions
+{
+    /// <summary>
+    /// If set to true disabled DynamoDB Local's telemetry by setting the DDB_LOCAL_TELEMETRY environment variable
+    /// </summary>
+    public bool DisableDynamoDBLocalTelemetry { get; set; } = false;
+}

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalOptions.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalOptions.cs
@@ -31,6 +31,13 @@ public class DynamoDBLocalOptions
     public bool SharedDb { get; set; }
 
     /// <summary>
+    /// If set to true DynamoDB runs in memory instead of using a database file. DynamoDB local will run faster
+    /// using InMemory mode but all data will be lost when the container ends and the data stored in DynamoDB
+    /// local can ont exceed the available memory for the container.
+    /// </summary>
+    public bool InMemory { get; set; }
+
+    /// <summary>
     /// Directory on host machine to create the DynamoDB local database files. If this property is set the data
     /// written to DynamoDB local will persist between AppHost invocations.
     /// </summary>

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalOptions.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalOptions.cs
@@ -33,7 +33,7 @@ public class DynamoDBLocalOptions
     /// <summary>
     /// If set to true DynamoDB runs in memory instead of using a database file. DynamoDB local will run faster
     /// using InMemory mode but all data will be lost when the container ends and the data stored in DynamoDB
-    /// local can ont exceed the available memory for the container.
+    /// local can not exceed the available memory for the container.
     /// </summary>
     public bool InMemory { get; set; }
 

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalOptions.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalOptions.cs
@@ -1,12 +1,30 @@
 ﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+using System.Diagnostics;
+
 namespace Aspire.Hosting.AWS.DynamoDB;
 
 /// <summary>
 /// Options that can be set for configuring the instance of DynamoDB Local.
 /// </summary>
+[DebuggerDisplay("Type = {GetType().Name,nq}, Image = {Image}, Tag = {Tag}, DisableDynamoDBLocalTelemetry = {DisableDynamoDBLocalTelemetry}")]
 public class DynamoDBLocalOptions
 {
+    /// <summary>
+    /// The registry of the container image
+    /// </summary>
+    public string Registry { get; set; } = "public.ecr.aws";
+
+    /// <summary>
+    /// The container image to run for DynamoDB Local. The default is public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local.
+    /// </summary>
+    public string Image { get; set; } = "aws-dynamodb-local/aws-dynamodb-local";
+
+    /// <summary>
+    /// The container image tag. The default is latest.
+    /// </summary>
+    public string Tag { get; set; } = "latest";
+
     /// <summary>
     /// If set to true disabled DynamoDB Local's telemetry by setting the DDB_LOCAL_TELEMETRY environment variable
     /// </summary>

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalOptions.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalOptions.cs
@@ -5,18 +5,18 @@ using System.Diagnostics;
 namespace Aspire.Hosting.AWS.DynamoDB;
 
 /// <summary>
-/// Options that can be set for configuring the instance of DynamoDB Local.
+/// Options that can be set for configuring the instance of DynamoDB local.
 /// </summary>
-[DebuggerDisplay("Type = {GetType().Name,nq}, Image = {Image}, Tag = {Tag}, DisableDynamoDBLocalTelemetry = {DisableDynamoDBLocalTelemetry}")]
+[DebuggerDisplay("Type = {GetType().Name,nq}, Registry = {Registry}, Image = {Image}, Tag = {Tag}, LocalStorageDirectory = {LocalStorageDirectory}, SharedDb = {SharedDb}, DisableDynamoDBLocalTelemetry = {DisableDynamoDBLocalTelemetry}, DelayTransientStatuses = {DelayTransientStatuses}")]
 public class DynamoDBLocalOptions
 {
     /// <summary>
-    /// The registry of the container image
+    /// The registry of the container image. THe default is public.ecr.aws.
     /// </summary>
     public string Registry { get; set; } = "public.ecr.aws";
 
     /// <summary>
-    /// The container image to run for DynamoDB Local. The default is public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local.
+    /// The container image to run for DynamoDB local. The default is aws-dynamodb-local/aws-dynamodb-local.
     /// </summary>
     public string Image { get; set; } = "aws-dynamodb-local/aws-dynamodb-local";
 
@@ -26,7 +26,27 @@ public class DynamoDBLocalOptions
     public string Tag { get; set; } = "latest";
 
     /// <summary>
-    /// If set to true disabled DynamoDB Local's telemetry by setting the DDB_LOCAL_TELEMETRY environment variable
+    /// If set to true DynamoDB local uses a single database file instead of separate files for each credential and Region.
     /// </summary>
-    public bool DisableDynamoDBLocalTelemetry { get; set; } = false;
+    public bool SharedDb { get; set; }
+
+    /// <summary>
+    /// Directory on host machine to create the DynamoDB local database files. If this property is set the data
+    /// written to DynamoDB local will persist between AppHost invocations.
+    /// </summary>
+    public string? LocalStorageDirectory { get; set; }
+
+    /// <summary>
+    /// If set to true disabled DynamoDB local's telemetry by setting the DDB_LOCAL_TELEMETRY environment variable
+    /// </summary>
+    public bool DisableDynamoDBLocalTelemetry { get; set; }
+
+    /// <summary>
+    /// If set to true causes DynamoDB local to introduce delays for certain operations. DynamoDB local can perform 
+    /// some tasks almost instantaneously, such as create/update/delete operations on tables and indexes. However, the DynamoDB 
+    /// service requires more time for these tasks. Setting this parameter helps DynamoDB running on your computer 
+    /// simulate the behavior of the DynamoDB web service more closely.
+    /// </summary>
+    public bool DelayTransientStatuses { get; set; }
+
 }

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResource.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResource.cs
@@ -9,5 +9,39 @@ namespace Aspire.Hosting.AWS.DynamoDB;
 /// </summary>
 internal sealed class DynamoDBLocalResource(string name, DynamoDBLocalOptions options) : ContainerResource(name), IDynamoDBLocalResource
 {
+    internal const int DynamoDBInternalPort = 8000;
+    internal const string InternalStorageMountPoint = "/storage";
+
     internal DynamoDBLocalOptions Options { get; } = options;
+
+    /// <summary>
+    /// Create the list of command line arguments that must be used when running the DynamoDB local container image.
+    /// </summary>
+    /// <returns></returns>
+    internal string[] CreateContainerImageArguments()
+    {
+        var arguments = new List<string>
+        {
+            "-Djava.library.path=./DynamoDBLocal_lib",
+            "-jar",
+            "DynamoDBLocal.jar"
+        };
+
+        if (Options.SharedDb)
+            arguments.Add("-sharedDb");
+
+        if (Options.DisableDynamoDBLocalTelemetry)
+            arguments.Add("-disableTelemetry");
+
+        if (!string.IsNullOrEmpty(Options.LocalStorageDirectory))
+        {
+            arguments.Add("-dbPath");
+            arguments.Add(InternalStorageMountPoint);
+        }
+
+        if (Options.DelayTransientStatuses)
+            arguments.Add("-delayTransientStatuses");
+
+        return arguments.ToArray();
+    }
 }

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResource.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResource.cs
@@ -30,6 +30,9 @@ internal sealed class DynamoDBLocalResource(string name, DynamoDBLocalOptions op
         if (Options.SharedDb)
             arguments.Add("-sharedDb");
 
+        if (Options.InMemory)
+            arguments.Add("-inMemory");
+
         if (Options.DisableDynamoDBLocalTelemetry)
             arguments.Add("-disableTelemetry");
 

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResource.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResource.cs
@@ -1,0 +1,13 @@
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.AWS.DynamoDB;
+
+/// <summary>
+/// Represents a DynamoDB local resource. This is a dev only resources and will not be written to the project's manifest.
+/// </summary>
+internal sealed class DynamoDBLocalResource(string name, DynamoDBLocalOptions options) : ContainerResource(name), IDynamoDBLocalResource
+{
+    internal DynamoDBLocalOptions Options { get; } = options;
+}

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
@@ -37,8 +37,11 @@ public static class DynamoDBLocalResourceBuilderExtensions
 
     /// <summary>
     /// Add a reference to the DynamoDB local to the project. This is done by setting the AWS_ENDPOINT_URL_DYNAMODB environment
-    /// variable for the project to the http endpoint of the DynamoDB local container. Any DynamoDB service clients
-    /// created in the project relying on endpoint resolution will pick up this environment variable and use it.
+    /// variable for the project to the http endpoint of the DynamoDB local container. 
+    /// 
+    /// When applications create the AmazonDynamoDBClient type, the service client for DynamoDB, and rely on the SDK to resolve the
+    /// endpoint from the environment instead of explicitly setting an AWS region the SDK will use the value from 
+    /// the AWS_ENDPOINT_URL_DYNAMODB environment variable.
     /// </summary>
     /// <typeparam name="TDestination"></typeparam>
     /// <param name="builder"></param>

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
@@ -1,0 +1,75 @@
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.AWS.DynamoDB;
+
+public static class DynamoDBLocalResourceBuilderExtensions
+{
+    /// <summary>
+    /// Add an instance of DynamoDB local. This is a container pulled from Amazon ECR public gallery.
+    /// Projects that use DynamoDB local can get a reference to the instance using the WithAWSDynamoDBLocalReference method.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="name">The name of the resource.</param>
+    /// <param name="image">Optional: default value is "public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local"</param>
+    /// <param name="tag">Optional: default value is "latest"</param>
+    /// <param name="options">Optional: Options that can be set for configuring the instance of DynamoDB Local.</param>
+    /// <returns></returns>
+    /// <exception cref="DistributedApplicationException"></exception>
+    public static IResourceBuilder<IDynamoDBLocalResource> AddAWSDynamoDBLocal(this IDistributedApplicationBuilder builder,
+        string name, string image = "public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local", string tag = "latest", DynamoDBLocalOptions? options = null)
+    {
+        var container = new DynamoDBLocalResource(name, options ?? new DynamoDBLocalOptions());
+        var containerBuilder = builder.AddResource(container)
+                  .ExcludeFromManifest()
+                  .WithEndpoint(targetPort: 8000, scheme: "http")
+                  .WithAnnotation(new ContainerImageAnnotation { Image = image, Tag = tag });
+
+        // Repurpose the WithEnvironment to invoke the users callback to seed DynamoDB local.
+        // This needs a better mechanism to have a callback once a container has been started
+        // so a hosting component can do initial configuration or seeding in the container.
+        containerBuilder.WithEnvironment(context =>
+        {
+            if (context.ExecutionContext.IsPublishMode)
+            {
+                return;
+            }
+
+            if (container.Options.DisableDynamoDBLocalTelemetry)
+            {
+                // Info on DynamoDB Local telemetry
+                // https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocalTelemetry.html
+                context.EnvironmentVariables.Add("DDB_LOCAL_TELEMETRY", "0");
+            }
+        });
+
+        return containerBuilder;
+    }
+
+    /// <summary>
+    /// Add a reference to the DynamoDB local to the project. This is done by setting the AWS_ENDPOINT_URL_DYNAMODB environment
+    /// variable for the project to the http endpoint of the DynamoDB local container. Any DynamoDB service clients
+    /// created in the project relying on endpoint resolution will pick up this environment variable and use it.
+    /// </summary>
+    /// <typeparam name="TDestination"></typeparam>
+    /// <param name="builder"></param>
+    /// <param name="dynamoDBLocalResourceBuilder"></param>
+    /// <returns></returns>
+    /// <exception cref="DistributedApplicationException"></exception>
+    public static IResourceBuilder<TDestination> WithReference<TDestination>(this IResourceBuilder<TDestination> builder, IResourceBuilder<IDynamoDBLocalResource> dynamoDBLocalResourceBuilder)
+        where TDestination : IResourceWithEnvironment
+    {
+        builder.WithEnvironment(context =>
+        {
+            if (context.ExecutionContext.IsPublishMode)
+            {
+                return;
+            }
+
+            var endpoint = dynamoDBLocalResourceBuilder.Resource.GetEndpoints().First();
+            context.EnvironmentVariables.Add("AWS_ENDPOINT_URL_DYNAMODB", endpoint.Url);
+        });
+        return builder;
+    }
+}

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
@@ -63,8 +63,8 @@ public static class DynamoDBLocalResourceBuilderExtensions
                 return;
             }
 
-            var endpoint = dynamoDBLocalResourceBuilder.Resource.GetEndpoints().First();
-            context.EnvironmentVariables.Add("AWS_ENDPOINT_URL_DYNAMODB", endpoint.Url);
+            var endpoint = dynamoDBLocalResourceBuilder.GetEndpoint("http");
+            context.EnvironmentVariables.Add("AWS_ENDPOINT_URL_DYNAMODB", endpoint);
         });
         return builder;
     }

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
@@ -12,19 +12,18 @@ public static class DynamoDBLocalResourceBuilderExtensions
     /// </summary>
     /// <param name="builder"></param>
     /// <param name="name">The name of the resource.</param>
-    /// <param name="image">Optional: default value is "public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local"</param>
-    /// <param name="tag">Optional: default value is "latest"</param>
     /// <param name="options">Optional: Options that can be set for configuring the instance of DynamoDB Local.</param>
     /// <returns></returns>
     /// <exception cref="DistributedApplicationException"></exception>
     public static IResourceBuilder<IDynamoDBLocalResource> AddAWSDynamoDBLocal(this IDistributedApplicationBuilder builder,
-        string name, string image = "public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local", string tag = "latest", DynamoDBLocalOptions? options = null)
+        string name, DynamoDBLocalOptions? options = null)
     {
         var container = new DynamoDBLocalResource(name, options ?? new DynamoDBLocalOptions());
         var containerBuilder = builder.AddResource(container)
                   .ExcludeFromManifest()
                   .WithEndpoint(targetPort: 8000, scheme: "http")
-                  .WithAnnotation(new ContainerImageAnnotation { Image = image, Tag = tag });
+                  .WithImage(container.Options.Image, container.Options.Tag)
+                  .WithImageRegistry(container.Options.Registry);
 
         // Repurpose the WithEnvironment to invoke the users callback to seed DynamoDB local.
         // This needs a better mechanism to have a callback once a container has been started

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
@@ -64,7 +64,7 @@ public static class DynamoDBLocalResourceBuilderExtensions
             }
 
             var endpoint = dynamoDBLocalResourceBuilder.GetEndpoint("http");
-            context.EnvironmentVariables.Add("AWS_ENDPOINT_URL_DYNAMODB", endpoint);
+            context.EnvironmentVariables["AWS_ENDPOINT_URL_DYNAMODB"] = endpoint;
         });
         return builder;
     }

--- a/src/Aspire.Hosting.AWS/DynamoDB/IDynamoDBLocalResource.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/IDynamoDBLocalResource.cs
@@ -1,0 +1,13 @@
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+using Aspire.Hosting.ApplicationModel;
+
+namespace Aspire.Hosting.AWS.DynamoDB;
+
+/// <summary>
+/// Represents a DynamoDB local resource. This is a dev only resources and will not be written to the project's manifest.
+/// </summary>
+public interface IDynamoDBLocalResource : IResourceWithEnvironment, IResourceWithEndpoints
+{
+
+}

--- a/tests/Aspire.Hosting.AWS.Integ.Tests/Aspire.Hosting.AWS.Integ.Tests.csproj
+++ b/tests/Aspire.Hosting.AWS.Integ.Tests/Aspire.Hosting.AWS.Integ.Tests.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+		<IsTestProject>true</IsTestProject>
+		<NoWarn>$(NoWarn);CS8002</NoWarn>
+		<OutputType>Exe</OutputType>		
+		<!-- AWS CDK packages are not signed -->
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\playground\AWS\AWS.AppHost\AWS.AppHost.csproj" />
+		<ProjectReference Include="..\..\src\Aspire.Hosting.AWS\Aspire.Hosting.AWS.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<Using Include="System.Net" />
+		<Using Include="Microsoft.Extensions.DependencyInjection" />
+		<Using Include="Aspire.Hosting.ApplicationModel" />
+		<Using Include="Aspire.Hosting.Testing" />
+		<Using Include="Xunit" />
+	</ItemGroup>
+
+</Project>

--- a/tests/Aspire.Hosting.AWS.Integ.Tests/PlaygroundE2ETests.cs
+++ b/tests/Aspire.Hosting.AWS.Integ.Tests/PlaygroundE2ETests.cs
@@ -1,13 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-//using Aspire.Hosting.Testing;
-
 using Amazon;
 using Amazon.CloudFormation;
 using Amazon.CloudFormation.Model;
 
 using Aspire.Hosting.AWS.CloudFormation;
-using System.Reflection.Metadata;
 
 namespace Aspire.Hosting.AWS.Integ.Tests;
 

--- a/tests/Aspire.Hosting.AWS.Integ.Tests/PlaygroundE2ETests.cs
+++ b/tests/Aspire.Hosting.AWS.Integ.Tests/PlaygroundE2ETests.cs
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+//using Aspire.Hosting.Testing;
+
+using Amazon;
+using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
+
+using Aspire.Hosting.AWS.CloudFormation;
+using System.Reflection.Metadata;
+
+namespace Aspire.Hosting.AWS.Integ.Tests;
+
+public class PlaygroundE2ETests
+{
+    [Fact]
+    public async Task RunAWSAppHostProject()
+    {
+        string? stackName = null;
+        IAmazonCloudFormation? cfClient = null;
+        try
+        {
+            var appHost = await DistributedApplicationTestingBuilder.CreateAsync<Projects.AWS_AppHost>();
+            await using var app = await appHost.BuildAsync();
+            await app.StartAsync();
+
+            var resourceNotificationService = app.Services.GetRequiredService<ResourceNotificationService>();
+            await resourceNotificationService
+                .WaitForResourceAsync("Frontend", KnownResourceStates.Running)
+                .WaitAsync(TimeSpan.FromSeconds(120));
+
+            var cloudFormationResource = (ICloudFormationTemplateResource)appHost.Resources
+                                .Single(static r => r.Name == "AspireSampleDevResources");
+
+            Assert.NotNull(cloudFormationResource.AWSSDKConfig);
+            cfClient = new AmazonCloudFormationClient(ConfigureServiceConfig(new AmazonCloudFormationConfig(), cloudFormationResource.AWSSDKConfig));
+
+            stackName = cloudFormationResource.StackName;
+            var stack = (await cfClient!.DescribeStacksAsync(new DescribeStacksRequest { StackName = stackName })).Stacks[0];
+            Assert.True(stack.StackStatus == StackStatus.CREATE_COMPLETE || stack.StackStatus == StackStatus.UPDATE_COMPLETE);
+
+            using var frontendClient = app.CreateHttpClient("Frontend");
+
+            Assert.Equal("\"Success\"", await frontendClient.GetStringAsync("/healthcheck/dynamodb"));
+            Assert.Equal("\"Success\"", await frontendClient.GetStringAsync("/healthcheck/cloudformation"));
+        }
+        finally
+        {
+            if (cfClient != null && stackName != null)
+            {
+                await cfClient.DeleteStackAsync(new DeleteStackRequest { StackName = stackName });
+            }
+        }
+    }
+
+    private T ConfigureServiceConfig<T> (T sdkConfig, IAWSSDKConfig aspireConfig)
+        where T : Amazon.Runtime.ClientConfig
+    {
+        if (aspireConfig.Profile != null)
+        {
+            sdkConfig.Profile = new Profile(aspireConfig.Profile);
+        }
+
+        if (aspireConfig.Region != null)
+        {
+            sdkConfig.RegionEndpoint = aspireConfig.Region;
+        }
+
+        return sdkConfig;
+    }
+}

--- a/tests/Aspire.Hosting.AWS.UnitTests/DynamoDBLocalCommandLineArgumentTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/DynamoDBLocalCommandLineArgumentTests.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 using Aspire.Hosting.AWS.DynamoDB;
 using Xunit;

--- a/tests/Aspire.Hosting.AWS.UnitTests/DynamoDBLocalCommandLineArgumentTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/DynamoDBLocalCommandLineArgumentTests.cs
@@ -16,10 +16,13 @@ public class DynamoDBLocalCommandLineArgumentTests
     {
         CompareArguments(new DynamoDBLocalOptions { }, new string[0]);
         CompareArguments(new DynamoDBLocalOptions {SharedDb = true }, "-sharedDb");
+        CompareArguments(new DynamoDBLocalOptions { SharedDb = false }, new string[0]);
         CompareArguments(new DynamoDBLocalOptions { DisableDynamoDBLocalTelemetry = true }, "-disableTelemetry");
         // The value "/storage" is the path in the container that would be mapped to "C:/temp"
         CompareArguments(new DynamoDBLocalOptions { LocalStorageDirectory = "C:/temp" }, "-dbPath", "/storage");
         CompareArguments(new DynamoDBLocalOptions { DelayTransientStatuses = true }, "-delayTransientStatuses");
+        CompareArguments(new DynamoDBLocalOptions { InMemory = true }, "-inMemory");
+        CompareArguments(new DynamoDBLocalOptions { InMemory = false }, new string[0]);
     }
 
     private void CompareArguments(DynamoDBLocalOptions options, params string[] expectedArguments)

--- a/tests/Aspire.Hosting.AWS.UnitTests/DynamoDBLocalCommandLineArgumentTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/DynamoDBLocalCommandLineArgumentTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Aspire.Hosting.AWS.DynamoDB;
+using Xunit;
+
+namespace Aspire.Hosting.AWS.Tests;
+
+public class DynamoDBLocalCommandLineArgumentTests
+{
+    [Fact]
+    public void CommandLineArgumentTests()
+    {
+        CompareArguments(new DynamoDBLocalOptions { }, new string[0]);
+        CompareArguments(new DynamoDBLocalOptions {SharedDb = true }, "-sharedDb");
+        CompareArguments(new DynamoDBLocalOptions { DisableDynamoDBLocalTelemetry = true }, "-disableTelemetry");
+        // The value "/storage" is the path in the container that would be mapped to "C:/temp"
+        CompareArguments(new DynamoDBLocalOptions { LocalStorageDirectory = "C:/temp" }, "-dbPath", "/storage");
+        CompareArguments(new DynamoDBLocalOptions { DelayTransientStatuses = true }, "-delayTransientStatuses");
+    }
+
+    private void CompareArguments(DynamoDBLocalOptions options, params string[] expectedArguments)
+    {
+        var computedArguments = new DynamoDBLocalResource("resource", options).CreateContainerImageArguments();
+
+        Assert.Equal(computedArguments.Length, expectedArguments.Length + 3);
+        Assert.Equal("-Djava.library.path=./DynamoDBLocal_lib", computedArguments[0]);
+        Assert.Equal("-jar", computedArguments[1]);
+        Assert.Equal("DynamoDBLocal.jar", computedArguments[2]);
+
+        for(var i = 0; i < expectedArguments.Length; i++)
+        {
+            Assert.Equal(expectedArguments[i], computedArguments[i + 3]);
+        }
+    }
+}

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -11,5 +11,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
+	<PackageReference Include="Aspire.Hosting.Testing"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
*Description of changes:*
Adds a new `AddAWSDynamoDBLocal` extension method for adding the DynamoDB Local container image to the Aspire application. When the DynamoDB Local Aspire resource is added as a reference to projects the `AWS_ENDPOINT_URL_DYNAMODB` environment variable is set. DynamoDB service clients created in the application that rely on the SDK to resolve the region/endpoint will pick up the environment variable. The `AWS_ENDPOINT_URL_DYNAMODB` will take precedence over the `AWS_REGION` environment variable.

Tests and options class exposing all of the options available for DynamoDB local have been added. PR is in draft mode till I confirm the experience with the DynamoDB team.

Sample of what the user experience is like.
```csharp
// Add a DynamoDB Local instance
var localDynamoDB = builder.AddAWSDynamoDBLocal("DynamoDBLocal");

// Reference DynamoDB local in project
builder.AddProject<Projects.Frontend>("Frontend")
        .WithReference(localDynamoDB);
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
