### PR TITLE
Use Aspire 9's WaitFor feature for making projects wait for CloudFormation

### DIFF
--- a/.autover/changes/e537d29a-c69e-46f0-a857-68c6a75b23d6.json
+++ b/.autover/changes/e537d29a-c69e-46f0-a857-68c6a75b23d6.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Use Aspire 9\u0027s WaitFor mechanism for waiting CloudFormation resource to be running"
+      ]
+    }
+  ]
+}

--- a/.autover/changes/e537d29a-c69e-46f0-a857-68c6a75b23d6.json
+++ b/.autover/changes/e537d29a-c69e-46f0-a857-68c6a75b23d6.json
@@ -4,7 +4,7 @@
       "Name": "Aspire.Hosting.AWS",
       "Type": "Patch",
       "ChangelogMessages": [
-        "Use Aspire 9\u0027s WaitFor mechanism for waiting CloudFormation resource to be running"
+        "Use Aspire 9's WaitFor mechanism for waiting CloudFormation resource to be running"
       ]
     }
   ]


### PR DESCRIPTION
*Description of changes:*
To be consistent with other Aspire integrations use the `WaitFor` mechanism added in Aspire 9 for forcing projects to wait till CloudFormation is ready. This is a switch from the homegrown solution of using our own `TaskCompletionSource` to force a block in the project resource.

The `TaskCompletionSource` is still used in other parts of the integration, specifically the public `GetValueAsync` API for a `StackOutputReference` so the code still exist but for the common case of having the project reference the stack the experience will be consistent with other integrations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
