### PR TITLE
Rename AddAPIGatewayEmulator to AddAWSAPIGatewayEmulator

### DIFF
--- a/playground/Lambda/Lambda.AppHost/Program.cs
+++ b/playground/Lambda/Lambda.AppHost/Program.cs
@@ -13,7 +13,7 @@ var addRouteLambda = builder.AddAWSLambdaFunction<Projects.WebAddLambdaFunction>
 var minusRouteLambda = builder.AddAWSLambdaFunction<Projects.WebMinusLambdaFunction>("MinusDefaultRoute", lambdaHandler: "WebMinusLambdaFunction");
 
 
-builder.AddAPIGatewayEmulator("APIGatewayEmulator", Aspire.Hosting.AWS.Lambda.APIGatewayType.HttpV2)
+builder.AddAWSAPIGatewayEmulator("APIGatewayEmulator", Aspire.Hosting.AWS.Lambda.APIGatewayType.HttpV2)
         .WithReference(defaultRouteLambda, Method.Get, "/")
         .WithReference(addRouteLambda, Method.Get, "/add/{x}/{y}")
         .WithReference(minusRouteLambda, Method.Get, "/minus/{x}/{y}");

--- a/src/Aspire.Hosting.AWS/Aspire.Hosting.AWS.csproj
+++ b/src/Aspire.Hosting.AWS/Aspire.Hosting.AWS.csproj
@@ -6,7 +6,7 @@
     <PackageTags>aspire integration hosting aws</PackageTags>
     <Description>Add support for provisioning AWS application resources and configuring the AWS SDK for .NET.</Description>
     <NoWarn>$(NoWarn);CS8002</NoWarn> <!-- AWS CDK packages are not signed -->
-    <Version>9.0.0</Version>
+    <Version>9.0.100</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Aspire.Hosting.AWS/Lambda/APIGatewayExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/APIGatewayExtensions.cs
@@ -24,7 +24,7 @@ public static class APIGatewayExtensions
     /// <param name="name">Aspire resource name</param>
     /// <param name="apiGatewayType">The type of API Gateway API. For example Rest, HttpV1 or HttpV2</param>
     /// <returns></returns>
-    public static IResourceBuilder<APIGatewayApiResource> AddAPIGatewayEmulator(this IDistributedApplicationBuilder builder, string name, APIGatewayType apiGatewayType)
+    public static IResourceBuilder<APIGatewayApiResource> AddAWSAPIGatewayEmulator(this IDistributedApplicationBuilder builder, string name, APIGatewayType apiGatewayType)
     {
         var apiGatewayEmulator = builder.AddResource(new APIGatewayApiResource(name)).ExcludeFromManifest();
 


### PR DESCRIPTION
*Description of changes:*
All of our other extension methods for Aspire start with `AddAWS` to group the AWS functionality. The `AddAPIGatewayEmulator` was missing that consistency which this PR fixes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
