### PR TITLE
Fixed issue with not using correct StackName property

### DIFF
--- a/.autover/changes/7bc9b0fa-fdb3-48e5-a3d6-231b105bc7e9.json
+++ b/.autover/changes/7bc9b0fa-fdb3-48e5-a3d6-231b105bc7e9.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fix issue with CloudFormationStack resource not using the override stackname property"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/integrations-on-dotnet-aspire-for-aws/issues/16

*Description of changes:*
When using the `AddAWSCloudFormationStack` method for loading outputs from an existing stack the Aspire resource name was used instead of the specified stack name. This PR fixes the issue and also adds the output parameters to the log similar to how the output when provisioning a stack from a template.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
