### PR TITLE
Fix namespace for AddAWSDynamoDBLocal extension method

### DIFF
--- a/.autover/changes/d5469d40-f5e5-477c-99f6-025290a8ac10.json
+++ b/.autover/changes/d5469d40-f5e5-477c-99f6-025290a8ac10.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fix namespace for AddAWSDynamoDBLocal extension method"
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting;
+using Aspire.Hosting.AWS.DynamoDB;
 
-namespace Aspire.Hosting.AWS.DynamoDB;
+namespace Aspire.Hosting;
 
 public static class DynamoDBLocalResourceBuilderExtensions
 {


### PR DESCRIPTION
*Description of changes:*
The new extension method `AddAWSDynamoDBLocal` should have been in the namespace `Aspire.Hosting` but was incorrectly put in the `Aspire.Hosting.AWS.DynamoDB`. That means the extension method will be harder for users to find and is inconsistent with the other extension methods.

This PR fixes that but is a slight breaking change. Want to get this out quickly before users are affected. Most likely users AppHost will already have a `using` for `Aspire.Hosting` and will not even notice a difference if they were using the method in the old namespace.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
