### PR TITLE
Add validation for AWS credentials

### DIFF
--- a/.autover/changes/a0739bc2-982a-498a-a096-405ff7432c0b.json
+++ b/.autover/changes/a0739bc2-982a-498a-a096-405ff7432c0b.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add validation of AWS credentials"
+      ]
+    }
+  ]
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,12 +12,15 @@
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Dns" Version="$(AspireVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="$(AspireVersion)" />
     <!-- AWS SDK for .NET dependencies -->
-    <PackageVersion Include="AWSSDK.CloudFormation" Version="3.7.400.47" />
-    <PackageVersion Include="AWSSDK.Core" Version="3.7.400.47" />
-    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="3.7.402.11" />	
-    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="3.7.400.47" />
-    <PackageVersion Include="AWSSDK.SQS" Version="3.7.400.47" />
-    <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.301" />
+    <PackageVersion Include="AWSSDK.CloudFormation" Version="3.7.402.6" />
+    <PackageVersion Include="AWSSDK.Core" Version="3.7.402.2" />
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="3.7.405.23" />
+    <PackageVersion Include="AWSSDK.SecurityToken" Version="3.7.401.45" />
+    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="3.7.400.96" />
+    <PackageVersion Include="AWSSDK.SQS" Version="3.7.400.96" />
+	<PackageVersion Include="AWSSDK.SSO" Version="3.7.400.96" />
+    <PackageVersion Include="AWSSDK.SSOOIDC" Version="3.7.400.97" />	  
+    <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.400" />
     <PackageVersion Include="AWS.Messaging" Version="0.9.2" />
 
     <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.12.0" />

--- a/playground/Lambda/Lambda.AppHost/Program.cs
+++ b/playground/Lambda/Lambda.AppHost/Program.cs
@@ -1,17 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
 using Aspire.Hosting.AWS.Lambda;
 
 #pragma warning disable CA2252 // This API requires opting into preview features
 
 var builder = DistributedApplication.CreateBuilder(args);
 
+var awsSdkConfig = builder.AddAWSSDKConfig().WithRegion(Amazon.RegionEndpoint.USWest2);
+
 builder.AddAWSLambdaFunction<Projects.ToUpperLambdaFunctionExecutable>("ToUpperFunction", lambdaHandler: "ToUpperLambdaFunctionExecutable");
 
 var defaultRouteLambda = builder.AddAWSLambdaFunction<Projects.WebDefaultLambdaFunction>("LambdaDefaultRoute", lambdaHandler: "WebDefaultLambdaFunction");
 var addRouteLambda = builder.AddAWSLambdaFunction<Projects.WebAddLambdaFunction>("AddDefaultRoute", lambdaHandler: "WebAddLambdaFunction");
 var minusRouteLambda = builder.AddAWSLambdaFunction<Projects.WebMinusLambdaFunction>("MinusDefaultRoute", lambdaHandler: "WebMinusLambdaFunction");
-var listAwsResourcesRouteLambda = builder.AddAWSLambdaFunction<Projects.WebAWSCallsLambdaFunction>("ListAwsResourcesRoute", lambdaHandler: "WebAWSCallsLambdaFunction");
+var listAwsResourcesRouteLambda = builder.AddAWSLambdaFunction<Projects.WebAWSCallsLambdaFunction>("ListAwsResourcesRoute", lambdaHandler: "WebAWSCallsLambdaFunction")
+                                        .WithReference(awsSdkConfig);
 
 builder.AddAWSAPIGatewayEmulator("APIGatewayEmulator", Aspire.Hosting.AWS.Lambda.APIGatewayType.HttpV2)
         .WithReference(defaultRouteLambda, Method.Get, "/")

--- a/src/Aspire.Hosting.AWS/AWSLifecycleHook.cs
+++ b/src/Aspire.Hosting.AWS/AWSLifecycleHook.cs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+using Amazon.Runtime.Internal.Util;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.AWS.CDK;
 using Aspire.Hosting.AWS.Provisioning;
@@ -10,6 +11,7 @@ using Microsoft.Extensions.Logging;
 namespace Aspire.Hosting.AWS;
 
 internal sealed class AWSLifecycleHook(
+    ILogger<AWSLifecycleHook> logger,
     DistributedApplicationExecutionContext executionContext,
     IServiceProvider serviceProvider,
     ResourceNotificationService notificationService,
@@ -17,6 +19,8 @@ internal sealed class AWSLifecycleHook(
 {
     public Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
     {
+        SdkUtilities.BackgroundSDKDefaultConfigValidation(logger);
+
         var awsResources = appModel.Resources.OfType<IAWSResource>().ToList();
         if (awsResources.Count == 0) // Skip when no AWS resources are found
         {

--- a/src/Aspire.Hosting.AWS/Aspire.Hosting.AWS.csproj
+++ b/src/Aspire.Hosting.AWS/Aspire.Hosting.AWS.csproj
@@ -14,6 +14,9 @@
     <PackageReference Include="Amazon.CDK.Lib" />
     <PackageReference Include="AWSSDK.Core" />
     <PackageReference Include="AWSSDK.CloudFormation" />
+    <PackageReference Include="AWSSDK.SecurityToken" />	  
+    <PackageReference Include="AWSSDK.SSO" />	  
+    <PackageReference Include="AWSSDK.SSOOIDC" />	  
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaLifecycleHook.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaLifecycleHook.cs
@@ -22,6 +22,8 @@ internal class LambdaLifecycleHook(ILogger<LambdaEmulatorResource> logger, IProc
 
     public async Task BeforeStartAsync(DistributedApplicationModel appModel, CancellationToken cancellationToken = default)
     {
+        SdkUtilities.BackgroundSDKDefaultConfigValidation(logger);
+
         LambdaEmulatorAnnotation? emulatorAnnotation = null;
         if (appModel.Resources.FirstOrDefault(x => x.TryGetLastAnnotation<LambdaEmulatorAnnotation>(out emulatorAnnotation)) != null && emulatorAnnotation != null)
         {

--- a/src/Aspire.Hosting.AWS/SdkUtilities.cs
+++ b/src/Aspire.Hosting.AWS/SdkUtilities.cs
@@ -3,7 +3,11 @@
 using System.Reflection;
 using System.Text;
 using Amazon.Runtime;
+using Microsoft.Extensions.Logging;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
 using Aspire.Hosting.ApplicationModel;
+using Amazon.Runtime.CredentialManagement;
 
 namespace Aspire.Hosting.AWS;
 internal static class SdkUtilities
@@ -41,6 +45,12 @@ internal static class SdkUtilities
 
     internal static void ApplySDKConfig(EnvironmentCallbackContext context, IAWSSDKConfig awsSdkConfig, bool force)
     {
+        if (context.Logger != null)
+        {
+            // To help debugging do a validation of the SDK config. The results will be logged.
+            BackgroundSDKConfigValidation(context.Logger, awsSdkConfig);
+        }
+
         if (!string.IsNullOrEmpty(awsSdkConfig.Profile))
         {
             if (force || !context.EnvironmentVariables.ContainsKey("AWS__Profile"))
@@ -63,6 +73,86 @@ internal static class SdkUtilities
                 // The environment variable the service clients look for service clients created without AWSSDK.Extensions.NETCore.Setup.
                 context.EnvironmentVariables["AWS_REGION"] = awsSdkConfig.Region.SystemName;
             }
+        }
+    }
+
+    internal static void BackgroundSDKDefaultConfigValidation(ILogger logger)
+    {
+        var chain = new Amazon.Runtime.CredentialManagement.CredentialProfileStoreChain();
+        var profiles = chain.ListProfiles();
+
+        // If there are no profiles then the developer is unlikely connecting in the dev environment
+        // to AWS with the SDK. In this case it doesn't make sense to validate credentials.
+        if (profiles.Count == 0)
+            return;
+
+        // If there is not a default profile then skip validating it.
+        var defaultProfile = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("AWS_PROFILE")) ? Environment.GetEnvironmentVariable("AWS_PROFILE") : SharedCredentialsFile.DefaultProfileName;
+        if (profiles.FirstOrDefault(x => string.Equals(defaultProfile, x.Name)) == null)
+            return;
+
+        _ = ValidateSdkConfigAsync(logger, new AWSSDKConfig(), true);
+    }
+
+    internal static void BackgroundSDKConfigValidation(ILogger logger, IAWSSDKConfig config)
+    {
+        _ = ValidateSdkConfigAsync(logger, config, false);
+    }
+
+    private static readonly SemaphoreSlim _semaphore = new SemaphoreSlim(1, 1);
+    static HashSet<string> _validatedSdkConfigs = new HashSet<string>();
+    private static async Task ValidateSdkConfigAsync(ILogger logger, IAWSSDKConfig config, bool defaultConfig)
+    {
+        // Cache key used to make sure we only validate a SDK configuration once.
+        var cacheKey = $"Profile:{config.Profile},Region:{config.Region?.SystemName}";
+
+        await _semaphore.WaitAsync();
+        try
+        {
+            if (_validatedSdkConfigs.Contains(cacheKey))
+            {
+                return;
+            }
+
+            var stsConfig = new AmazonSecurityTokenServiceConfig();
+            if (config.Region != null)
+                stsConfig.RegionEndpoint = config.Region;
+            if (!string.IsNullOrEmpty(config.Profile))
+                stsConfig.Profile = new Amazon.Profile(config.Profile);
+
+            try
+            {
+                using var stsClient = new AmazonSecurityTokenServiceClient(stsConfig);
+                stsClient.BeforeRequestEvent += ConfigureUserAgentString;
+
+                // Make an AWS call to an API that doesn't require permissions to confirm
+                // the sdk config is able to connect to AWS.
+                var response = await stsClient.GetCallerIdentityAsync(new GetCallerIdentityRequest());
+
+                if (defaultConfig)
+                    logger.LogInformation("Default AWS SDK config validated for account: {accountId}", response.Account);
+                else
+                    logger.LogInformation("AWS SDK config validated for account: {accountId}", response.Account);
+
+                _validatedSdkConfigs.Add(cacheKey);
+            }
+            catch (Exception)
+            {
+                if (defaultConfig)
+                {
+                    logger.LogWarning("Failed to connect to AWS using default AWS SDK config");
+                }
+                else
+                {
+                    logger.LogError("Failed to connect to AWS using AWS SDK config: {configSettings}", cacheKey);
+                }
+
+                _validatedSdkConfigs.Add(cacheKey);
+            }
+        }
+        finally
+        {
+            _semaphore.Release();
         }
     }
 }


### PR DESCRIPTION
*Description of changes:*
To help users with trouble shooting AWS configuration add a validation for the AWS credentials that could be potentially used by the SDK. The validation is done as a non blocking background task to avoid slowing down the startup process.

This could be potentially expanded in the future for the AppHost to resolve credentials with SSO login being handled from AppHost. For now though it would let you know if the login command done by PowerShell or CLI hasn't been done is expired.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
