### PR TITLE
Version bump Amazon.Lambda.TestTool to 0.0.3

### DIFF
--- a/.autover/changes/f9252d6e-1abb-4c3a-a856-9f936fa26129.json
+++ b/.autover/changes/f9252d6e-1abb-4c3a-a856-9f936fa26129.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Version bump Amazon.Lambda.TestTool to 0.0.3"
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/Constants.cs
+++ b/src/Aspire.Hosting.AWS/Constants.cs
@@ -46,5 +46,5 @@ internal static class Constants
     /// <summary>
     /// The default version of Amazon.Lambda.TestTool that will be automatically installed
     /// </summary>
-    internal const string DefaultLambdaTestToolVersion = "0.0.2-preview";
+    internal const string DefaultLambdaTestToolVersion = "0.0.3";
 }


### PR DESCRIPTION
*Description of changes:*
Version bump Amazon.Lambda.TestTool to 0.0.3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
