### PR TITLE
fix: use the correct env var syntax

### DIFF
--- a/.autover/changes/634c5be9-ae47-4197-a74a-4fc7042656a4.json
+++ b/.autover/changes/634c5be9-ae47-4197-a74a-4fc7042656a4.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Use the correct environment variable syntax to fix an issue on Rider macOS"
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/Constants.cs
+++ b/src/Aspire.Hosting.AWS/Constants.cs
@@ -46,5 +46,5 @@ internal static class Constants
     /// <summary>
     /// The default version of Amazon.Lambda.TestTool that will be automatically installed
     /// </summary>
-    internal const string DefaultLambdaTestToolVersion = "0.9.0";
+    internal const string DefaultLambdaTestToolVersion = "0.9.1";
 }

--- a/src/Aspire.Hosting.AWS/Utils/ProjectUtilities.cs
+++ b/src/Aspire.Hosting.AWS/Utils/ProjectUtilities.cs
@@ -88,7 +88,7 @@ internal static class ProjectUtilities
         var userProfilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            userProfileEnvironmentVariable = "$HOME";
+            userProfileEnvironmentVariable = "$(HOME)";
         }
 
         if (path.StartsWith(userProfilePath))

--- a/tests/Aspire.Hosting.AWS.UnitTests/ProjectUtilitiesTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/ProjectUtilitiesTests.cs
@@ -90,7 +90,7 @@ public class ProjectUtilitiesTests : IDisposable
         string commandLineArgs = profile["commandLineArgs"]?.GetValue<string>() ?? "";
         string expectedRuntimePath = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? runtimeSupportAssemblyPath.Replace(userProfile, "%USERPROFILE%")
-            : runtimeSupportAssemblyPath.Replace(userProfile, "$HOME");
+            : runtimeSupportAssemblyPath.Replace(userProfile, "$(HOME)");
 
         Assert.Contains(expectedRuntimePath, commandLineArgs);
         Assert.Contains(functionHandler, commandLineArgs);


### PR DESCRIPTION
*Description of changes:*
* Fixed the Rider macOS issue which due to 2 issues, lack of support in Rider for launching a class library using a launchSettings.json file, and using the wrong environment variable syntax in the launchSettings.json. Rider released their fix in Rider 2025.1 EAP7 and this PR fixes our env var issue.
* Updated to Test Tool 0.9.1

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
