### PR TITLE
Add support for configuring a port for API Gateway emulator

### DIFF
--- a/.autover/changes/ad430412-80a8-4983-b95d-27c9d6a45f46.json
+++ b/.autover/changes/ad430412-80a8-4983-b95d-27c9d6a45f46.json
@@ -4,7 +4,7 @@
       "Name": "Aspire.Hosting.AWS",
       "Type": "Patch",
       "ChangelogMessages": [
-        "Add support for configuring a port for API Gateway emulator"
+        "Add support for configuring a port for API Gateway and Lambda emulators"
       ]
     }
   ]

--- a/.autover/changes/ad430412-80a8-4983-b95d-27c9d6a45f46.json
+++ b/.autover/changes/ad430412-80a8-4983-b95d-27c9d6a45f46.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add support for configuring a port for API Gateway emulator"
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/Lambda/APIGatewayEmulatorOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/APIGatewayEmulatorOptions.cs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+namespace Aspire.Hosting.AWS.Lambda;
+
+/// <summary>
+/// Options that can be added to the API Gateway emulator resource.
+/// </summary>
+public class APIGatewayEmulatorOptions
+{
+    /// <summary>
+    /// The port that the API Gateway emulator will listen on.
+    /// </summary>
+    public int? Port { get; set; }
+}

--- a/src/Aspire.Hosting.AWS/Lambda/APIGatewayEmulatorOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/APIGatewayEmulatorOptions.cs
@@ -8,7 +8,7 @@ namespace Aspire.Hosting.AWS.Lambda;
 public class APIGatewayEmulatorOptions
 {
     /// <summary>
-    /// The port that the API Gateway emulator will listen on.
+    /// The port that the API Gateway emulator will listen on. If not set, a random port will be used.
     /// </summary>
-    public int? Port { get; set; }
+    public int? Port { get; set; } = null;
 }

--- a/src/Aspire.Hosting.AWS/Lambda/APIGatewayExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/APIGatewayExtensions.cs
@@ -27,6 +27,8 @@ public static class APIGatewayExtensions
     /// <returns></returns>
     public static IResourceBuilder<APIGatewayEmulatorResource> AddAWSAPIGatewayEmulator(this IDistributedApplicationBuilder builder, string name, APIGatewayType apiGatewayType, APIGatewayEmulatorOptions? options = null)
     {
+        options ??= new APIGatewayEmulatorOptions();
+
         var apiGatewayEmulator = builder.AddResource(new APIGatewayEmulatorResource(name, apiGatewayType)).ExcludeFromManifest();
         apiGatewayEmulator.WithArgs(context =>
         {
@@ -36,7 +38,7 @@ public static class APIGatewayExtensions
         var annotation = new EndpointAnnotation(
             protocol: ProtocolType.Tcp,
             uriScheme: "http",
-            port: options?.Port);
+            port: options.Port);
 
         apiGatewayEmulator.WithAnnotation(annotation);
         var endpointReference = new EndpointReference(apiGatewayEmulator.Resource, annotation);

--- a/src/Aspire.Hosting.AWS/Lambda/APIGatewayExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/APIGatewayExtensions.cs
@@ -17,14 +17,15 @@ namespace Aspire.Hosting;
 public static class APIGatewayExtensions
 {
     /// <summary>
-    /// Adds an API Gateway emulator resource to the Aspire application. Lambda function resoures 
+    /// Adds an API Gateway emulator resource to the Aspire application. Lambda function resources
     /// should be added to this resource using the WithReference method.
     /// </summary>
     /// <param name="builder"></param>
     /// <param name="name">Aspire resource name</param>
     /// <param name="apiGatewayType">The type of API Gateway API. For example Rest, HttpV1 or HttpV2</param>
+    /// <param name="port">Desired port for the API Gateway emulator. For example 5050</param>
     /// <returns></returns>
-    public static IResourceBuilder<APIGatewayEmulatorResource> AddAWSAPIGatewayEmulator(this IDistributedApplicationBuilder builder, string name, APIGatewayType apiGatewayType)
+    public static IResourceBuilder<APIGatewayEmulatorResource> AddAWSAPIGatewayEmulator(this IDistributedApplicationBuilder builder, string name, APIGatewayType apiGatewayType, int? port)
     {
         var apiGatewayEmulator = builder.AddResource(new APIGatewayEmulatorResource(name, apiGatewayType)).ExcludeFromManifest();
         apiGatewayEmulator.WithArgs(context =>
@@ -34,7 +35,8 @@ public static class APIGatewayExtensions
 
         var annotation = new EndpointAnnotation(
             protocol: ProtocolType.Tcp,
-            uriScheme: "http");
+            uriScheme: "http",
+            port: port);
 
         apiGatewayEmulator.WithAnnotation(annotation);
         var endpointReference = new EndpointReference(apiGatewayEmulator.Resource, annotation);

--- a/src/Aspire.Hosting.AWS/Lambda/APIGatewayExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/APIGatewayExtensions.cs
@@ -23,9 +23,9 @@ public static class APIGatewayExtensions
     /// <param name="builder"></param>
     /// <param name="name">Aspire resource name</param>
     /// <param name="apiGatewayType">The type of API Gateway API. For example Rest, HttpV1 or HttpV2</param>
-    /// <param name="port">Desired port for the API Gateway emulator. For example 5050</param>
+    /// <param name="options">The options to configure the emulator with.</param>
     /// <returns></returns>
-    public static IResourceBuilder<APIGatewayEmulatorResource> AddAWSAPIGatewayEmulator(this IDistributedApplicationBuilder builder, string name, APIGatewayType apiGatewayType, int? port)
+    public static IResourceBuilder<APIGatewayEmulatorResource> AddAWSAPIGatewayEmulator(this IDistributedApplicationBuilder builder, string name, APIGatewayType apiGatewayType, APIGatewayEmulatorOptions? options = null)
     {
         var apiGatewayEmulator = builder.AddResource(new APIGatewayEmulatorResource(name, apiGatewayType)).ExcludeFromManifest();
         apiGatewayEmulator.WithArgs(context =>
@@ -36,7 +36,7 @@ public static class APIGatewayExtensions
         var annotation = new EndpointAnnotation(
             protocol: ProtocolType.Tcp,
             uriScheme: "http",
-            port: port);
+            port: options?.Port);
 
         apiGatewayEmulator.WithAnnotation(annotation);
         var endpointReference = new EndpointReference(apiGatewayEmulator.Resource, annotation);

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaEmulatorOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaEmulatorOptions.cs
@@ -13,17 +13,22 @@ public class LambdaEmulatorOptions
     /// 
     /// When DisableAutoInstall is set to true the auto installation is disabled.
     /// </summary>
-    public bool DisableAutoInstall { get; set; }
+    public bool DisableAutoInstall { get; set; } = false;
 
     /// <summary>
     /// Override the minimum version of Amazon.Lambda.TestTool that will be installed. If a newer version is already installed
     /// it will be used unless AllowDowngrade is set to true.
     /// </summary>
-    public string? OverrideMinimumInstallVersion { get; set; }
+    public string? OverrideMinimumInstallVersion { get; set; } = null;
 
     /// <summary>
     /// If set to true, and a newer version of Amazon.Lambda.TestTool is already installed then the requested version, the installed version
     /// will be downgraded to the request version.
     /// </summary>
-    public bool AllowDowngrade { get; set; }
+    public bool AllowDowngrade { get; set; } = false;
+
+    /// <summary>
+    /// The port that the Lambda emulator will listen on. If not set, a random port will be used.
+    /// </summary>
+    public int? Port { get; set; } = null;
 }

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaExtensions.cs
@@ -62,7 +62,7 @@ public static class LambdaExtensions
         {
             var serviceEmulatorEndpoint = serviceEmulator.GetEndpoint("http");
 
-            // Add the Lambda function resource on the path so the emulator can distingish request
+            // Add the Lambda function resource on the path so the emulator can distinguish request
             // for each Lambda function.
             var apiPath = $"{serviceEmulatorEndpoint.Host}:{serviceEmulatorEndpoint.Port}/{name}";
             context.EnvironmentVariables["AWS_EXECUTION_ENV"] = $"aspire.hosting.aws#{SdkUtilities.GetAssemblyVersion()}";
@@ -122,6 +122,8 @@ public static class LambdaExtensions
     /// <exception cref="InvalidOperationException">Thrown if the Lambda service emulator has already been added.</exception>
     public static IResourceBuilder<LambdaEmulatorResource> AddAWSLambdaServiceEmulator(this IDistributedApplicationBuilder builder, LambdaEmulatorOptions? options = null)
     {
+        options ??= new LambdaEmulatorOptions();
+
         if (builder.Resources.FirstOrDefault(x => x.TryGetAnnotationsOfType<LambdaEmulatorAnnotation>(out _)) is ExecutableResource serviceEmulator)
         {
             throw new InvalidOperationException("A Lambda service emulator has already been added. The AddAWSLambdaFunction will add the emulator " +
@@ -138,16 +140,17 @@ public static class LambdaExtensions
 
         var annotation = new EndpointAnnotation(
             protocol: ProtocolType.Tcp,
-            uriScheme: "http");
+            uriScheme: "http",
+            port: options.Port);
 
         lambdaEmulator.WithAnnotation(annotation);
         var endpointReference = new EndpointReference(lambdaEmulator.Resource, annotation);
 
         lambdaEmulator.WithAnnotation(new LambdaEmulatorAnnotation(endpointReference)
         {
-            DisableAutoInstall = options?.DisableAutoInstall ?? false,
-            OverrideMinimumInstallVersion = options?.OverrideMinimumInstallVersion,
-            AllowDowngrade = options?.AllowDowngrade ?? false,
+            DisableAutoInstall = options.DisableAutoInstall,
+            OverrideMinimumInstallVersion = options.OverrideMinimumInstallVersion,
+            AllowDowngrade = options.AllowDowngrade,
         });
 
         lambdaEmulator.WithAnnotation(new EnvironmentCallbackAnnotation(context =>


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This change allows overriding the API Gateway and Lambda emulators port. It could be useful in situations where external systems rely on a specific port, for example, during tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
