### PR TITLE
Fixed issue with duplicate CDK output parameters attempting to be added

### DIFF
--- a/.autover/changes/f7a1a338-83e3-4771-a8c6-13eb70d450ac.json
+++ b/.autover/changes/f7a1a338-83e3-4771-a8c6-13eb70d450ac.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fixed issue with duplicate CDK output parameters attempting to be added"
+      ]
+    }
+  ]
+}

--- a/playground/Lambda/Lambda.AppHost/Program.cs
+++ b/playground/Lambda/Lambda.AppHost/Program.cs
@@ -22,8 +22,6 @@ var minusFunction = builder.AddAWSLambdaFunction<Projects.WebCalculatorFunctions
 var multiplyFunction = builder.AddAWSLambdaFunction<Projects.WebCalculatorFunctions>("MultiplyFunction", lambdaHandler: "WebCalculatorFunctions::WebCalculatorFunctions.Functions::MultiplyFunctionHandler");
 var divideFunction = builder.AddAWSLambdaFunction<Projects.WebCalculatorFunctions>("DivideFunction", lambdaHandler: "WebCalculatorFunctions::WebCalculatorFunctions.Functions::DivideFunctionHandler");
 
-
-
 builder.AddAWSAPIGatewayEmulator("APIGatewayEmulator", Aspire.Hosting.AWS.Lambda.APIGatewayType.HttpV2)
         .WithReference(defaultRouteLambda, Method.Get, "/")
         // Add route demonstrating making AWS servic calls
@@ -37,7 +35,10 @@ builder.AddAWSAPIGatewayEmulator("APIGatewayEmulator", Aspire.Hosting.AWS.Lambda
 
 builder.AddAWSLambdaFunction<Projects.SQSProcessorFunction>("SQSProcessorFunction", "SQSProcessorFunction::SQSProcessorFunction.Function::FunctionHandler")
         .WithReference(awsSdkConfig)
-        .WithSQSEventSource(sqsDemoQueue);
+        .WithSQSEventSource(sqsDemoQueue)
+        // This reference is not necessary. It is added to confirm duplicate
+        // CDK output parameters are not attempted to be added.
+        .WithReference(sqsDemoQueue);
 
 
 builder.Build().Run();

--- a/src/Aspire.Hosting.AWS/CDK/CDKExtensions.cs
+++ b/src/Aspire.Hosting.AWS/CDK/CDKExtensions.cs
@@ -153,7 +153,10 @@ public static class CDKExtensions
     public static StackOutputReference GetOutput<T>(this IResourceBuilder<IConstructResource<T>> builder, string name, ConstructOutputDelegate<T> output)
         where T : Construct
     {
-        builder.WithAnnotation(new ConstructOutputAnnotation<T>(name, output));
+        if (!builder.Resource.Annotations.Any(x => x is ConstructOutputAnnotation<T> con && string.Equals(name, con.OutputName, StringComparison.Ordinal)))
+        {
+            builder.WithAnnotation(new ConstructOutputAnnotation<T>(name, output));
+        }
         return new StackOutputReference(builder.Resource.Construct.GetStackUniqueId() + name, builder.Resource.Parent.SelectParentResource<IStackResource>());
     }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/integrations-on-dotnet-aspire-for-aws/issues/55

*Description of changes:*
Add protection when a CDK output construct is being added as part of the `GetOutput` call check to see if the output construct has already been added.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
