### PR TITLE
Bump Amazon.Lambda.TestTool and Amazon.Lambda.RuntimeSupport versions

### DIFF
--- a/.autover/changes/cafbbacb-3cf8-42a6-926e-d1dc64974fd4.json
+++ b/.autover/changes/cafbbacb-3cf8-42a6-926e-d1dc64974fd4.json
@@ -1,0 +1,12 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update Amazon.Lambda.TestTool to version 0.10.1",
+		"Update Amazon.Lambda.RuntimeSupport to version 1.13.0"
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/Constants.cs
+++ b/src/Aspire.Hosting.AWS/Constants.cs
@@ -41,10 +41,10 @@ internal static class Constants
     /// <summary>
     /// The version of RuntimeSupport used in the executable wrapper project
     /// </summary>
-    internal const string RuntimeSupportPackageVersion = "1.12.3";
+    internal const string RuntimeSupportPackageVersion = "1.13.0";
     
     /// <summary>
     /// The default version of Amazon.Lambda.TestTool that will be automatically installed
     /// </summary>
-    internal const string DefaultLambdaTestToolVersion = "0.10.0";
+    internal const string DefaultLambdaTestToolVersion = "0.10.1";
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-lambda-dotnet/pull/2041

*Description of changes:*
Update the version of Amazon.Lambda.TestTool to `0.10.1` and the version of Amazon.Lambda.RuntimeSupport to `1.13.0`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
