### PR TITLE
Fixed having duplicate CDK output parameter with same name

### DIFF
--- a/.autover/changes/b067c74f-38ff-468b-81dd-0a2f86c6d174.json
+++ b/.autover/changes/b067c74f-38ff-468b-81dd-0a2f86c6d174.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fixed issue with duplicate CDK output parameter names being used"
+      ]
+    }
+  ]
+}

--- a/playground/Lambda/Lambda.AppHost/Program.cs
+++ b/playground/Lambda/Lambda.AppHost/Program.cs
@@ -10,7 +10,8 @@ var builder = DistributedApplication.CreateBuilder(args);
 var awsSdkConfig = builder.AddAWSSDKConfig().WithRegion(Amazon.RegionEndpoint.USWest2);
 
 var cdkStackResource = builder.AddAWSCDKStack("AWSLambdaPlaygroundResources");
-var sqsDemoQueue = cdkStackResource.AddSQSQueue("DemoQueue");
+var sqsDemoQueue1 = cdkStackResource.AddSQSQueue("DemoQueue1");
+var sqsDemoQueue2 = cdkStackResource.AddSQSQueue("DemoQueue2");
 
 builder.AddAWSLambdaFunction<Projects.ToUpperLambdaFunctionExecutable>("ToUpperFunction", lambdaHandler: "ToUpperLambdaFunctionExecutable", new LambdaFunctionOptions { ApplicationLogLevel = ApplicationLogLevel.DEBUG, LogFormat = LogFormat.JSON});
 
@@ -35,10 +36,11 @@ builder.AddAWSAPIGatewayEmulator("APIGatewayEmulator", Aspire.Hosting.AWS.Lambda
 
 builder.AddAWSLambdaFunction<Projects.SQSProcessorFunction>("SQSProcessorFunction", "SQSProcessorFunction::SQSProcessorFunction.Function::FunctionHandler")
         .WithReference(awsSdkConfig)
-        .WithSQSEventSource(sqsDemoQueue)
-        // This reference is not necessary. It is added to confirm duplicate
+        .WithSQSEventSource(sqsDemoQueue1)
+        // These references are not necessary. It is added to confirm duplicate
         // CDK output parameters are not attempted to be added.
-        .WithReference(sqsDemoQueue);
+        .WithReference(sqsDemoQueue1)
+        .WithReference(sqsDemoQueue2);
 
 
 builder.Build().Run();

--- a/src/Aspire.Hosting.AWS/CDK/ConstructOutputAnnotation.cs
+++ b/src/Aspire.Hosting.AWS/CDK/ConstructOutputAnnotation.cs
@@ -21,7 +21,7 @@ internal sealed class ConstructOutputAnnotation<T>(string name, ConstructOutputD
         }
 
         // Add a CloudFormation output on the stack referencing the construct and the resolved value.
-        _ = new CfnOutput(stack, OutputName, new CfnOutputProps
+        _ = new CfnOutput(stack, $"{construct.GetStackUniqueId()}{OutputName}", new CfnOutputProps
         {
             Key = $"{construct.GetStackUniqueId()}{OutputName}",
             Value = output((T)construct)

--- a/tests/Aspire.Hosting.AWS.Integ.Tests/Lambda/PlaygroundE2ETests.cs
+++ b/tests/Aspire.Hosting.AWS.Integ.Tests/Lambda/PlaygroundE2ETests.cs
@@ -61,7 +61,7 @@ public class PlaygroundE2ETests
             {
                 // The output key has a hash in the middle which could change. To avoid hardcoded logic on the hash check the start and end.
                 // Example value of the output key "DemoQueue955156E8QueueUrl".
-                return x.OutputKey.StartsWith("DemoQueue") && x.OutputKey.EndsWith("QueueUrl");
+                return x.OutputKey.StartsWith("DemoQueue1") && x.OutputKey.EndsWith("QueueUrl");
             })?.OutputValue;
             
             Assert.NotNull(queueUrl);


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/integrations-on-dotnet-aspire-for-aws/issues/55#issuecomment-2796146879

*Description of changes:*
When we add a CDK output construct to the CDK stack the id of the CDK output construct was generated by the logical name like `QueueUrl` without taking into context the parent construct. So if multiple queues were creating output parameters multiple output constructs with the id of `QueueUrl` was attempted and failed.

The fix is to generate the id of the output construct using the context of the parent construct the same we do for the actual output key name.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
