### PR TITLE
Update V4 of AWS SDK for .NET and Aspire 9.2

### DIFF
--- a/.autover/changes/1ff0236c-47bd-4894-9109-d4ff8755d908.json
+++ b/.autover/changes/1ff0236c-47bd-4894-9109-d4ff8755d908.json
@@ -1,0 +1,12 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Update to V4 of the AWS SDK for .NET",
+		"Update to Aspire 9.2"
+      ]
+    }
+  ]
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <AspireVersion>9.1.0</AspireVersion>
+    <AspireVersion>9.2.0</AspireVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting" Version="$(AspireVersion)" />
@@ -10,35 +10,35 @@
     <PackageVersion Include="Aspire.Hosting.Testing" Version="$(AspireVersion)" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="$(AspireVersion)" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Dns" Version="$(AspireVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.4.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
     <!-- AWS SDK for .NET dependencies -->
-    <PackageVersion Include="AWSSDK.CloudFormation" Version="3.7.402.10" />
-    <PackageVersion Include="AWSSDK.Core" Version="3.7.402.6" />
-    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="3.7.405.27" />
-    <PackageVersion Include="AWSSDK.Lambda" Version="3.7.411.43" />
-    <PackageVersion Include="AWSSDK.SecurityToken" Version="3.7.401.49" />
-    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="3.7.400.100" />
-    <PackageVersion Include="AWSSDK.SQS" Version="3.7.400.100" />
-    <PackageVersion Include="AWSSDK.SSO" Version="3.7.400.100" />
-    <PackageVersion Include="AWSSDK.SSOOIDC" Version="3.7.400.101" />
-    <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="3.7.400" />
-    <PackageVersion Include="AWS.Messaging" Version="0.9.4" />
-    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.12.3" />
-    <PackageVersion Include="Amazon.Lambda.Core" Version="2.5.0" />
+    <PackageVersion Include="AWSSDK.CloudFormation" Version="4.0.0.0" />
+    <PackageVersion Include="AWSSDK.Core" Version="4.0.0.0" />
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.0.0" />
+    <PackageVersion Include="AWSSDK.Lambda" Version="4.0.0.0" />
+    <PackageVersion Include="AWSSDK.SecurityToken" Version="4.0.0.0" />
+    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.0.0.0" />
+    <PackageVersion Include="AWSSDK.SQS" Version="4.0.0.0" />
+    <PackageVersion Include="AWSSDK.SSO" Version="4.0.0.0" />
+    <PackageVersion Include="AWSSDK.SSOOIDC" Version="4.0.0.0" />
+    <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.0.0" />
+    <PackageVersion Include="AWS.Messaging" Version="1.0.0" />
+    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="1.13.0" />
+    <PackageVersion Include="Amazon.Lambda.Core" Version="2.5.1" />
     <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.4" />
     <PackageVersion Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.1" />
     <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="2.2.0" />
     <!-- AWS CDK dependencies -->
-    <PackageVersion Include="Amazon.CDK.Lib" Version="2.180.0" />
+    <PackageVersion Include="Amazon.CDK.Lib" Version="2.194.0" />
     <!-- Open Telemetry -->
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.11.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.11.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.12.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.12.0" />
     <!-- Test dependencies -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/playground/CloudFormationProvisioning/AWS.AppHost/AWS.AppHost.csproj
+++ b/playground/CloudFormationProvisioning/AWS.AppHost/AWS.AppHost.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+  <Sdk Name="Aspire.AppHost.Sdk" Version="9.2.0" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/playground/CloudFormationProvisioning/AWSCDK.AppHost/AWSCDK.AppHost.csproj
+++ b/playground/CloudFormationProvisioning/AWSCDK.AppHost/AWSCDK.AppHost.csproj
@@ -1,5 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-	<Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+	<Sdk Name="Aspire.AppHost.Sdk" Version="9.2.0" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/playground/Lambda/Lambda.AppHost/Lambda.AppHost.csproj
+++ b/playground/Lambda/Lambda.AppHost/Lambda.AppHost.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<Sdk Name="Aspire.AppHost.Sdk" Version="9.0.0" />
+	<Sdk Name="Aspire.AppHost.Sdk" Version="9.2.0" />
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>

--- a/src/Aspire.Hosting.AWS/Provisioning/CloudFormationResourceProvisioner.cs
+++ b/src/Aspire.Hosting.AWS/Provisioning/CloudFormationResourceProvisioner.cs
@@ -6,6 +6,7 @@ using Amazon;
 using Amazon.CloudFormation;
 using Amazon.CloudFormation.Model;
 using Amazon.Runtime;
+using Amazon.Runtime.Credentials;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.AWS.CloudFormation;
 
@@ -96,7 +97,7 @@ internal abstract partial class CloudFormationResourceProvisioner<T>(ResourceLog
             {
                 var config = resource.AWSSDKConfig.CreateServiceConfig<AmazonCloudFormationConfig>();
 
-                var awsCredentials = FallbackCredentialsFactory.GetCredentials(config);
+                var awsCredentials = DefaultAWSCredentialsIdentityResolver.GetCredentials(config);
                 client = new AmazonCloudFormationClient(awsCredentials, config);
             }
             else

--- a/src/Aspire.Hosting.AWS/Provisioning/CloudFormationTemplateResourceProvisioner.cs
+++ b/src/Aspire.Hosting.AWS/Provisioning/CloudFormationTemplateResourceProvisioner.cs
@@ -34,7 +34,7 @@ internal class CloudFormationTemplateResourceProvisioner<T>(
             if (stack != null)
             {
                 logger.LogInformation("CloudFormation stack has {Count} output parameters", stack.Outputs.Count);
-                if (logger.IsEnabled(LogLevel.Information))
+                if (stack.Outputs != null && logger.IsEnabled(LogLevel.Information))
                 {
                     foreach (var output in stack.Outputs)
                     {
@@ -46,7 +46,7 @@ internal class CloudFormationTemplateResourceProvisioner<T>(
 
                 if (resource is CloudFormationResource cloudformationResource)
                 {
-                    cloudformationResource.Outputs = stack.Outputs;
+                    cloudformationResource.Outputs = stack.Outputs ?? new List<Amazon.CloudFormation.Model.Output>();
                 }
 
                 var templatePath = resource.TemplatePath;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-net/issues/3362#issuecomment-2853610287

*Description of changes:*
Update Aspire.Hosting.AWS to use V4 of the AWS SDk for .NET and update it's Aspire dependency to 9.2.

*Testing*
Ran all unit and integ tests. Also ran all the sample Aspire AppHost in the repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
