### PR TITLE
Use some Aspire 9.2 features like setting links display names and image pull policy.

### DIFF
--- a/.autover/changes/335cff36-45e1-4fbc-80ad-7fc6337a72d2.json
+++ b/.autover/changes/335cff36-45e1-4fbc-80ad-7fc6337a72d2.json
@@ -1,0 +1,14 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add ability to set host port for DynamoDB Local",
+		"Add ability to call WithImagePullPolicy for DynamoDB Local resource",
+		"Add Display Names for API Gateway Emulator and Lambda Service Emulator endpoints",
+		"Add Display Names for AWS CloudFormation Console stack links"
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalOptions.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalOptions.cs
@@ -56,4 +56,9 @@ public class DynamoDBLocalOptions
     /// </summary>
     public bool DelayTransientStatuses { get; set; }
 
+    /// <summary>
+    /// The host port used to connect to DynamoDB local. If not set, a random port will be used.
+    /// </summary>
+    public int? Port { get; set; } = null;
+
 }

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
@@ -22,7 +22,7 @@ public static class DynamoDBLocalResourceBuilderExtensions
         var container = new DynamoDBLocalResource(name, options ?? new DynamoDBLocalOptions());
         var containerBuilder = builder.AddResource(container)
                   .ExcludeFromManifest()
-                  .WithEndpoint(targetPort: DynamoDBLocalResource.DynamoDBInternalPort, scheme: "http")
+                  .WithEndpoint(targetPort: DynamoDBLocalResource.DynamoDBInternalPort, scheme: "http", port: options?.Port)
                   .WithArgs( container.CreateContainerImageArguments())
                   .WithImage(container.Options.Image, container.Options.Tag)
                   .WithImageRegistry(container.Options.Registry);
@@ -33,6 +33,23 @@ public static class DynamoDBLocalResourceBuilderExtensions
         }
 
         return containerBuilder;
+    }
+
+    /// <summary>
+    /// Sets the pull policy for pulling the DynamoDB Local container image.
+    /// </summary>
+    /// <typeparam name="T">The resource type.</typeparam>
+    /// <param name="builder">Builder for the container resource.</param>
+    /// <param name="pullPolicy">The pull policy behavior for the container resource.</param>
+    /// <returns>The <see cref="IResourceBuilder{IDynamoDBLocalResource}"/>.</returns>
+    public static IResourceBuilder<IDynamoDBLocalResource> WithImagePullPolicy(this IResourceBuilder<IDynamoDBLocalResource> builder, ImagePullPolicy imagePullPolicy)
+    {
+        if (builder is IResourceBuilder<ContainerResource> containerBuilder)
+        {
+            containerBuilder.WithImagePullPolicy(imagePullPolicy);
+        }
+
+        return builder;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.AWS/Lambda/APIGatewayExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/APIGatewayExtensions.cs
@@ -41,6 +41,8 @@ public static class APIGatewayExtensions
             port: options.Port);
 
         apiGatewayEmulator.WithAnnotation(annotation);
+        apiGatewayEmulator.WithUrlForEndpoint("http", u => u.DisplayText = "API Gateway Endpoint");
+
         var endpointReference = new EndpointReference(apiGatewayEmulator.Resource, annotation);
 
         apiGatewayEmulator.WithAnnotation(new EnvironmentCallbackAnnotation(context =>

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaExtensions.cs
@@ -144,6 +144,7 @@ public static class LambdaExtensions
             port: options.Port);
 
         lambdaEmulator.WithAnnotation(annotation);
+        lambdaEmulator.WithUrlForEndpoint("http", u => u.DisplayText = "Lambda Test Tool UI");
         var endpointReference = new EndpointReference(lambdaEmulator.Resource, annotation);
 
         lambdaEmulator.WithAnnotation(new LambdaEmulatorAnnotation(endpointReference)

--- a/src/Aspire.Hosting.AWS/Provisioning/CloudFormationResourceProvisioner.cs
+++ b/src/Aspire.Hosting.AWS/Provisioning/CloudFormationResourceProvisioner.cs
@@ -75,6 +75,9 @@ internal abstract partial class CloudFormationResourceProvisioner<T>(ResourceLog
             return
             [
                 new UrlSnapshot("aws-console", url, IsInternal: false)
+                {
+                    DisplayProperties = new UrlDisplayPropertiesSnapshot("AWS CloudFormation Console")
+                }
             ];
         }
         catch (Exception)


### PR DESCRIPTION
*Description of changes:*
Add some small feature improvements now that the Aspire package is targeting 9.2

* Add ability to set host port for DynamoDB Local. This doesn't really have anything to do with 9.2 but it adds parity to our other features like adding API Gateway emulator which allows setting host port.
* Add image pull policy for DynamoDB local. This is exposing the image pull policy added for container resources in 9.2
* Add Link display names for the API Gateway Emulator, Lambda Service Emulator and CloudFormation Console.

![image](https://github.com/user-attachments/assets/13c89667-fc00-446b-811e-c933d3e68204)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
