### PR TITLE
Add IResourceWithWaitSupport support for CloudFormation provisioning.

### DIFF
--- a/.autover/changes/d1697b8d-a096-47dd-bd8e-db204759c269.json
+++ b/.autover/changes/d1697b8d-a096-47dd-bd8e-db204759c269.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add IResourceWithWaitSupport support for CloudFormation provisioning. This is useful when using LocalStack container as the CloudFormation endpoint."
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/CDK/IConstructResource.cs
+++ b/src/Aspire.Hosting.AWS/CDK/IConstructResource.cs
@@ -7,4 +7,4 @@ namespace Aspire.Hosting.AWS.CDK;
 /// <summary>
 /// Resource representing an AWS CDK construct.
 /// </summary>
-public interface IConstructResource : IResourceWithParent<IResourceWithConstruct>, IResourceWithConstruct;
+public interface IConstructResource : IResourceWithParent<IResourceWithConstruct>, IResourceWithConstruct, IResourceWithWaitSupport;

--- a/src/Aspire.Hosting.AWS/CDK/IStackResource.cs
+++ b/src/Aspire.Hosting.AWS/CDK/IStackResource.cs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 using Amazon.CDK;
+using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.AWS.CloudFormation;
 
 namespace Aspire.Hosting.AWS.CDK;
@@ -8,7 +9,7 @@ namespace Aspire.Hosting.AWS.CDK;
 /// <summary>
 /// Resource representing an AWS CDK stack.
 /// </summary>
-public interface IStackResource : ICloudFormationTemplateResource, IResourceWithConstruct
+public interface IStackResource : ICloudFormationTemplateResource, IResourceWithConstruct, IResourceWithWaitSupport
 {
     /// <summary>
     /// The AWS CDK stack

--- a/src/Aspire.Hosting.AWS/CloudFormation/ICloudFormationResource.cs
+++ b/src/Aspire.Hosting.AWS/CloudFormation/ICloudFormationResource.cs
@@ -2,13 +2,14 @@
 
 using Amazon.CloudFormation;
 using Amazon.CloudFormation.Model;
+using Aspire.Hosting.ApplicationModel;
 
 namespace Aspire.Hosting.AWS.CloudFormation;
 
 /// <summary>
 /// Resource representing an AWS CloudFormation stack.
 /// </summary>
-public interface ICloudFormationResource : IAWSResource
+public interface ICloudFormationResource : IAWSResource, IResourceWithWaitSupport
 {
     /// <summary>
     /// The configured Amazon CloudFormation service client used to make service calls. If this property set

--- a/src/Aspire.Hosting.AWS/Provisioning/CloudFormationResourceProvisioner.cs
+++ b/src/Aspire.Hosting.AWS/Provisioning/CloudFormationResourceProvisioner.cs
@@ -12,12 +12,10 @@ using Aspire.Hosting.AWS.CloudFormation;
 
 namespace Aspire.Hosting.AWS.Provisioning;
 
-internal abstract partial class CloudFormationResourceProvisioner<T>(ResourceLoggerService loggerService, ResourceNotificationService notificationService) : AWSResourceProvisioner<T>
+internal abstract partial class CloudFormationResourceProvisioner<T>(ResourceLoggerService loggerService, ResourceNotificationService notificationService) : AWSResourceProvisioner<T>(notificationService) 
     where T : ICloudFormationResource
 {
     protected ResourceLoggerService LoggerService => loggerService;
-
-    protected ResourceNotificationService NotificationService => notificationService;
 
     protected async Task PublishCloudFormationUpdatePropertiesAsync(T resource, ImmutableArray<ResourcePropertySnapshot>? properties = null, ImmutableArray<UrlSnapshot>? urls = default)
     {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/integrations-on-dotnet-aspire-for-aws/issues/81

*Description of changes:*
To support users using localstack as the CloudFormation endpoint this PR makes the CloudFormation support implement the `IResourceWithWaitSupport` from Aspire. This will prevent our libraries provisioning code from running till all dependencies are healthy. In LocalStack's case that means the container has been pulled and started.

The following is an example of using LocalStack with the `WaitFor` support
```csharp
var builder = DistributedApplication.CreateBuilder(args);

var localStackUri = new Uri("http://localhost:4566");

var cfConfig = new AmazonCloudFormationConfig
{
    ServiceURL = localStackUri.ToString()
};
var cfClient = new AmazonCloudFormationClient(cfConfig);

var localStack = builder.AddContainer("localstack", "localstack/localstack")
                        .WithEndpoint(port: localStackUri.Port, targetPort: 4566, scheme: "http")
                        .WithEnvironment("DEBUG", "1");

var awsResources = builder.AddAWSCloudFormationTemplate("LocalStackExample-Stack", "aws-resources.template")
                .WaitFor(localStack);

awsResources.Resource.CloudFormationClient = cfClient;
```

This was tested with LocalStack by updating this sample I have with a local NuGet build package and adding the `WaitFor`.
https://github.com/normj/aspire-aws-feedback/blob/main/LocalStackExample/LocalStackExample.AppHost/Program.cs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
