### PR TITLE
Update default version of Amazon.Lambda.TestTool to version 0.10.3

### DIFF
--- a/.autover/changes/64e7d014-7e4f-42eb-95bf-796774c4dd88.json
+++ b/.autover/changes/64e7d014-7e4f-42eb-95bf-796774c4dd88.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update default Amazon.Lambda.TestTool version to 0.10.3"
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/Constants.cs
+++ b/src/Aspire.Hosting.AWS/Constants.cs
@@ -46,5 +46,5 @@ internal static class Constants
     /// <summary>
     /// The default version of Amazon.Lambda.TestTool that will be automatically installed
     /// </summary>
-    internal const string DefaultLambdaTestToolVersion = "0.10.1";
+    internal const string DefaultLambdaTestToolVersion = "0.10.3";
 }


### PR DESCRIPTION
*Description of changes:*
Update the default version of Amazon.Lambda.TestTool to version 0.10.3. That version fixes an issue with SQS long running messages being retried while being debugged.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
