### PR TITLE
Add the option for users to specify custom cloudformation tags

### DIFF
--- a/.autover/changes/919fc99e-cf9c-4ecf-aae4-cb22d8a4dac8.json
+++ b/.autover/changes/919fc99e-cf9c-4ecf-aae4-cb22d8a4dac8.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add the option for users to customize cloudformation stack tags"
+      ]
+    }
+  ]
+}

--- a/playground/CloudFormationProvisioning/AWSCDK.AppHost/Program.cs
+++ b/playground/CloudFormationProvisioning/AWSCDK.AppHost/Program.cs
@@ -11,6 +11,7 @@ var awsConfig = builder.AddAWSSDKConfig()
 var stack = builder.AddAWSCDKStack("stack", "Aspire-stack").WithReference(awsConfig);
 var customStack = builder.AddAWSCDKStack("custom", scope => new CustomStack(scope, "Aspire-custom"));
 customStack.AddOutput("BucketName", stack => stack.Bucket.BucketName).WithReference(awsConfig);
+customStack.WithTag("Environment", "Test");
 
 var topic = stack.AddSNSTopic("topic");
 var queue = stack.AddSQSQueue("queue");

--- a/src/Aspire.Hosting.AWS/CloudFormation/CloudFormationExtensions.cs
+++ b/src/Aspire.Hosting.AWS/CloudFormation/CloudFormationExtensions.cs
@@ -49,6 +49,19 @@ public static class CloudFormationExtensions
     }
 
     /// <summary>
+    /// Add a tag to be applied to the CloudFormation stack.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="tagKey">Name of the CloudFormation stack tag.</param>
+    /// <param name="tagValue">Value of the CloudFormation stack tag.</param>
+    /// <returns></returns>
+    public static IResourceBuilder<ICloudFormationResource> WithTag(this IResourceBuilder<ICloudFormationResource> builder, string tagKey, string tagValue)
+    {
+        builder.Resource.Tags[tagKey] = tagValue;
+        return builder;
+    }
+
+    /// <summary>
     /// Add a CloudFormation stack for provisioning application resources.
     /// </summary>
     /// <param name="builder">The <see cref="IDistributedApplicationBuilder"/>.</param>

--- a/src/Aspire.Hosting.AWS/CloudFormation/CloudFormationResource.cs
+++ b/src/Aspire.Hosting.AWS/CloudFormation/CloudFormationResource.cs
@@ -22,6 +22,9 @@ internal abstract class CloudFormationResource(string name, string stackName) : 
     public List<Output>? Outputs { get; set; }
 
     /// <inheritdoc/>
+    public IDictionary<string, string> Tags { get; } = new Dictionary<string, string>();
+
+    /// <inheritdoc/>
     public TaskCompletionSource? ProvisioningTaskCompletionSource { get; set; }
 
     internal abstract void WriteToManifest(ManifestPublishingContext context);

--- a/src/Aspire.Hosting.AWS/CloudFormation/ICloudFormationResource.cs
+++ b/src/Aspire.Hosting.AWS/CloudFormation/ICloudFormationResource.cs
@@ -26,4 +26,9 @@ public interface ICloudFormationResource : IAWSResource, IResourceWithWaitSuppor
     /// The output parameters of the CloudFormation stack.
     /// </summary>
     List<Output>? Outputs { get; }
-}
+
+    /// <summary>
+    /// Custom tags to apply to the CloudFormation stack.
+    /// </summary>
+    IDictionary<string, string> Tags { get; }
+    }

--- a/src/Aspire.Hosting.AWS/Provisioning/CloudFormationStackExecutionContext.cs
+++ b/src/Aspire.Hosting.AWS/Provisioning/CloudFormationStackExecutionContext.cs
@@ -12,6 +12,8 @@ internal sealed class CloudFormationStackExecutionContext(
 
     public IDictionary<string, string> CloudFormationParameters { get; set; } = new Dictionary<string, string>();
 
+    public IDictionary<string, string> Tags { get; set; } = new Dictionary<string, string>();
+
     public string? RoleArn { get; set; }
 
     public int StackPollingInterval { get; set; } = 3;

--- a/src/Aspire.Hosting.AWS/Provisioning/CloudFormationStackExecutor.cs
+++ b/src/Aspire.Hosting.AWS/Provisioning/CloudFormationStackExecutor.cs
@@ -37,7 +37,8 @@ internal sealed class CloudFormationStackExecutor(
         var changeSetType = await DetermineChangeSetTypeAsync(existingStack, cancellationToken).ConfigureAwait(false);
 
         var templateBody = context.Template;
-        var computedSha256 = ComputeSHA256(templateBody, context.CloudFormationParameters);
+       
+        var computedSha256 = ComputeSHA256(templateBody, context.CloudFormationParameters, context.Tags);
 
         (var tags, var existingSha256) = SetupTags(existingStack, changeSetType, computedSha256);
 
@@ -62,7 +63,7 @@ internal sealed class CloudFormationStackExecutor(
     }
 
     /// <summary>
-    /// Setup the tags collection by copying any tags for existing stacks, adding user-specified tags, 
+    /// Setup the tags collection with only user-specified tags (starting with an empty collection)
     /// and then updating/adding the tag recording the SHA256 for template and parameters.
     /// </summary>
     /// <param name="existingStack"></param>
@@ -73,23 +74,21 @@ internal sealed class CloudFormationStackExecutor(
     {
         string? existingSha256 = null;
         var tags = new List<Tag>();
-        if (changeSetType == ChangeSetType.UPDATE && existingStack != null)
+        
+        // Check for existing SHA256 tag if there's an existing stack
+        if (changeSetType == ChangeSetType.UPDATE && existingStack != null && existingStack.Tags != null)
         {
-            tags = existingStack.Tags ?? new List<Tag>();
+            var existingSha256Tag = existingStack.Tags.FirstOrDefault(x => string.Equals(x.Key, SHA256_TAG));
+            if (existingSha256Tag != null)
+            {
+                existingSha256 = existingSha256Tag.Value;
+            }
         }
-
+        
         // Add user-specified tags from context
         foreach (var kvp in context.Tags)
         {
-            var existingTag = tags.FirstOrDefault(x => string.Equals(x.Key, kvp.Key));
-            if (existingTag != null)
-            {
-                existingTag.Value = kvp.Value;
-            }
-            else
-            {
-                tags.Add(new Tag { Key = kvp.Key, Value = kvp.Value });
-            }
+            tags.Add(new Tag { Key = kvp.Key, Value = kvp.Value });
         }
 
         var shaTag = tags.FirstOrDefault(x => string.Equals(x.Key, SHA256_TAG));
@@ -496,12 +495,23 @@ internal sealed class CloudFormationStackExecutor(
         return events;
     }
 
-    private static string ComputeSHA256(string templateBody, IDictionary<string, string> parameters)
+    private static string ComputeSHA256(string templateBody, IDictionary<string, string> parameters, IDictionary<string, string> tags)
     {
         var content = templateBody;
-        if (parameters != null)
+        
+        // Add parameters to content
+        if (parameters != null && parameters.Count > 0)
         {
-            content += string.Join(";", parameters.Select(x => x.Key + "=" + x.Value).ToArray());
+            content += string.Join(";", parameters.Select(x => x.Key + "=" + x.Value).OrderBy(x => x).ToArray());
+        }
+        
+        // Add tags to content (except the SHA256 tag itself)
+        if (tags != null && tags.Count > 0)
+        {
+            content += string.Join(";", tags.Where(x => !string.Equals(x.Key, SHA256_TAG))
+                                       .Select(x => "tag:" + x.Key + "=" + x.Value)
+                                       .OrderBy(x => x)
+                                       .ToArray());
         }
 
         var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(content));

--- a/src/Aspire.Hosting.AWS/Provisioning/CloudFormationTemplateResourceProvisioner.cs
+++ b/src/Aspire.Hosting.AWS/Provisioning/CloudFormationTemplateResourceProvisioner.cs
@@ -76,7 +76,8 @@ internal class CloudFormationTemplateResourceProvisioner<T>(
             DisableDiffCheck = resource.DisableDiffCheck,
             StackPollingInterval = resource.StackPollingInterval,
             DisabledCapabilities = resource.DisabledCapabilities,
-            CloudFormationParameters = resource.CloudFormationParameters
+            CloudFormationParameters = resource.CloudFormationParameters,
+            Tags = resource.Tags
         };
     }
 

--- a/src/Aspire.Hosting.AWS/README.md
+++ b/src/Aspire.Hosting.AWS/README.md
@@ -95,6 +95,17 @@ var awsResources = builder.AddAWSCloudFormationTemplate("AspireSampleDevResource
                           .WithReference(awsConfig);
 ```
 
+You can also add custom tags to the CloudFormation stack using the `WithTag` method:
+
+```csharp
+var awsResources = builder.AddAWSCloudFormationTemplate("AspireSampleDevResources", "app-resources.template")
+                          .WithParameter("DefaultVisibilityTimeout", "30")
+                          .WithReference(awsConfig)
+                          .WithTag("Environment", "Development")
+                          .WithTag("Project", "AspireSample")
+                          .WithTag("Owner", "DotNetTeam");
+```
+
 The outputs of a CloudFormation stack can be associated to a project using the `WithReference` method.
 
 ```csharp

--- a/tests/Aspire.Hosting.AWS.UnitTests/AWSCloudFormationTagTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/AWSCloudFormationTagTests.cs
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+using Amazon;
+using Aspire.Hosting.AWS.CloudFormation;
+using Aspire.Hosting.AWS.Provisioning;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Aspire.Hosting.AWS.UnitTests;
+
+public class AWSCloudFormationTagTests
+{
+    [Fact]
+    public void WithTag_CloudFormationStackResource_AddsTagToResource()
+    {
+        // Arrange
+        var builder = DistributedApplication.CreateBuilder();
+        var awsSdkConfig = builder.AddAWSSDKConfig()
+            .WithRegion(RegionEndpoint.USWest2)
+            .WithProfile("test-profile");
+
+        // Act
+        var resource = builder.AddAWSCloudFormationStack("ExistingStack")
+            .WithReference(awsSdkConfig)
+            .WithTag("Environment", "Test")
+            .WithTag("Project", "UnitTest")
+            .Resource;
+
+        // Assert
+        Assert.Equal(2, resource.Tags.Count);
+        Assert.Equal("Test", resource.Tags["Environment"]);
+        Assert.Equal("UnitTest", resource.Tags["Project"]);
+    }
+
+    [Fact]
+    public void WithTag_CloudFormationTemplateResource_AddsTagToResource()
+    {
+        // Arrange
+        var builder = DistributedApplication.CreateBuilder();
+        var awsSdkConfig = builder.AddAWSSDKConfig()
+            .WithRegion(RegionEndpoint.USWest2)
+            .WithProfile("test-profile");
+
+        // Act
+        var resource = builder.AddAWSCloudFormationTemplate("NewStack", "cf.template")
+            .WithReference(awsSdkConfig)
+            .WithParameter("key1", "value1")
+            .WithTag("Environment", "Test")
+            .WithTag("Project", "UnitTest")
+            .Resource;
+
+        // Assert
+        Assert.Equal(2, resource.Tags.Count);
+        Assert.Equal("Test", resource.Tags["Environment"]);
+        Assert.Equal("UnitTest", resource.Tags["Project"]);
+    }
+
+    [Fact]
+    public void CloudFormationExecutionContext_IncludesTags()
+    {
+        // Arrange
+        var builder = DistributedApplication.CreateBuilder();
+        var templateResource = builder.AddAWSCloudFormationTemplate("TaggedStack", "cf.template")
+            .WithTag("Environment", "Test")
+            .WithTag("Project", "UnitTest")
+            .Resource as CloudFormationTemplateResource;
+
+        Assert.NotNull(templateResource);
+        
+        // Create an execution context
+        var context = new CloudFormationStackExecutionContext(templateResource.StackName, "{}");
+        
+        // Copy tags from resource to context
+        context.Tags = templateResource.Tags;
+        
+        // Assert
+        Assert.Equal(2, context.Tags.Count);
+        Assert.Equal("Test", context.Tags["Environment"]);
+        Assert.Equal("UnitTest", context.Tags["Project"]);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*
DOTNET-8128

*Description of changes:*
1. Add the option for users to specify custom cloudformation tags

Example usage
```
var awsResources = builder.AddAWSCloudFormationTemplate("AspireSampleDevResources", "app-resources.template")
                          .WithParameter("DefaultVisibilityTimeout", "30")
                          .WithReference(awsConfig)
                          .WithTag("Environment", "Test")
                          .WithTag("Project", "AspireSample")
                          .WithTag("Owner", "DotNetTeam");
```


```
var customStack = builder.AddAWSCDKStack("custom", scope => new CustomStack(scope, "Aspire-custom"));
customStack.AddOutput("BucketName", stack => stack.Bucket.BucketName).WithReference(awsConfig);
customStack.WithTag("Environment", "Test");
```

In below picture i deployed a stack with `WithTag("Environment", "Test")`

![image](https://github.com/user-attachments/assets/b63bdfcc-16e5-4436-9a03-c8f74d383b3a)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
