### PR TITLE
Fix issue with determining the framework or assembly name having trailing "\r\n"

### DIFF
--- a/.autover/changes/56394492-ec5d-48b8-86c5-695d5f5f555f.json
+++ b/.autover/changes/56394492-ec5d-48b8-86c5-695d5f5f555f.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fixed issue with determining the framework or assembly for Lambda functions causing Lambda functions to fail to start"
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaLifecycleHook.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaLifecycleHook.cs
@@ -257,7 +257,7 @@ internal class LambdaLifecycleHook(ILogger<LambdaEmulatorResource> logger, IProc
             }
 
             logger.LogDebug("The assembly name of '{projectPath}' is {assemblyName}", projectPath, results.Output);
-            return results.Output;
+            return results.Output.Trim();
         }
         catch (JsonException ex)
         {
@@ -277,7 +277,7 @@ internal class LambdaLifecycleHook(ILogger<LambdaEmulatorResource> logger, IProc
             }
 
             logger.LogDebug("The target framework of '{projectPath}' is {targetFramework}", projectPath, results.Output);
-            return results.Output;
+            return results.Output.Trim();
         }
         catch (JsonException ex)
         {


### PR DESCRIPTION
*Description of changes:*
For some reason my environment had a change in behavior when Aspire.Hosting.AWS shells out to `dotnet msbuild` to determine the framework or assembly the stdout contained `\r\n` which would get used in other logic based on the returned framework and fail. The result would be the Lambda functions would fail to start complaining it couldn't find RuntimeSupport.

This PR adds a trim to the result to make sure we remove whitespace from the determined value before building file paths with the value.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
