### PR TITLE
update test wait time

### DIFF
--- a/tests/Aspire.Hosting.AWS.Integ.Tests/Lambda/PlaygroundE2ETests.cs
+++ b/tests/Aspire.Hosting.AWS.Integ.Tests/Lambda/PlaygroundE2ETests.cs
@@ -70,7 +70,7 @@ public class PlaygroundE2ETests
             await sqsClient.SendMessageAsync(queueUrl, "themessage", cancellationToken.Token);
 
             // Wait for the Lambda function to consume the message it gets deleted.
-            await Task.Delay(5000);
+            await Task.Delay(20000);
             var queueAttributesRepsonse = await sqsClient.GetQueueAttributesAsync(new GetQueueAttributesRequest { QueueUrl = queueUrl, AttributeNames = new List<string> { "All" } });
             Assert.Equal(0, queueAttributesRepsonse.ApproximateNumberOfMessages + queueAttributesRepsonse.ApproximateNumberOfMessagesNotVisible);
         }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Update wait time from 5 seconds to 20 seconds. We are seeing issues in the pipeline where sometimes it fails to assert on 
```
Assert.Equal(0, queueAttributesRepsonse.ApproximateNumberOfMessages + queueAttributesRepsonse.ApproximateNumberOfMessagesNotVisible);
```
because the lambda hasnt process all of the messages yet. I am updating the wait time to hopefully give the lambda more time to process things.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
