### PR TITLE
Revert "update test wait time"

### DIFF
--- a/tests/Aspire.Hosting.AWS.Integ.Tests/Lambda/PlaygroundE2ETests.cs
+++ b/tests/Aspire.Hosting.AWS.Integ.Tests/Lambda/PlaygroundE2ETests.cs
@@ -77,7 +77,7 @@ public class PlaygroundE2ETests
             await sqsClient.SendMessageAsync(queueUrl, "themessage", cancellationToken.Token);
 
             // Wait for the Lambda function to consume the message it gets deleted.
-            await Task.Delay(20000);
+            await Task.Delay(5000);
             var queueAttributesRepsonse = await sqsClient.GetQueueAttributesAsync(new GetQueueAttributesRequest { QueueUrl = queueUrl, AttributeNames = new List<string> { "All" } });
             Assert.Equal(0, queueAttributesRepsonse.ApproximateNumberOfMessages + queueAttributesRepsonse.ApproximateNumberOfMessagesNotVisible);
         }


### PR DESCRIPTION
Reverts aws/integrations-on-dotnet-aspire-for-aws#93

reverting this PR since this change didnt fix the original issue of the release integration test failing.  I ended up deleting the aspire resources stack and when it got recreated the test passed. im not sure what the root cause was. But im reverting this PR to reduce the test time