### PR TITLE
Avoid concurrent access to StringBuilder

### DIFF
--- a/.autover/changes/d4da8c7a-971a-47b5-8193-ad3dd0d8c6b8.json
+++ b/.autover/changes/d4da8c7a-971a-47b5-8193-ad3dd0d8c6b8.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fix concurrency issue when reading output from external processes"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
*Issue #, if available:* #46

*Description of changes:*

Write process output to a `ConcurrentQueue<string>` and then add to a `StringBuilder` in order received to avoid concurrent access causing an `ArgumentOutOfRangeException`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
