### PR TITLE
Fixed NullReferenceException thrown when provisioning a Cloud Foundat…

### DIFF
--- a/.autover/changes/d49abf3f-2255-419a-8847-ce3144760a8a.json
+++ b/.autover/changes/d49abf3f-2255-419a-8847-ce3144760a8a.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fixed NullReferenceException thrown when provisioning a Cloud Foundation template without any outputs"
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/Provisioning/CloudFormationTemplateResourceProvisioner.cs
+++ b/src/Aspire.Hosting.AWS/Provisioning/CloudFormationTemplateResourceProvisioner.cs
@@ -33,7 +33,7 @@ internal class CloudFormationTemplateResourceProvisioner<T>(
 
             if (stack != null)
             {
-                logger.LogInformation("CloudFormation stack has {Count} output parameters", stack.Outputs.Count);
+                logger.LogInformation("CloudFormation stack has {Count} output parameters", stack.Outputs?.Count ?? 0);
                 if (stack.Outputs != null && logger.IsEnabled(LogLevel.Information))
                 {
                     foreach (var output in stack.Outputs)


### PR DESCRIPTION
CloudFormationTemplateResourceProvisioner throws a NullReferenceException when provisioning a template that does not include any outputs. The exception occurs when attempting to log the number out outputs.

Issue: 
* #104 

Description of changes:
* Modified the log argument to use a null-coalesce with a fallback of 0 to prevent the exception.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
