### PR TITLE
Integrate Lambda Test Tool's feature for allowing saving requests

### DIFF
--- a/.autover/changes/362a5990-05ee-4809-8916-599aee1d6b86.json
+++ b/.autover/changes/362a5990-05ee-4809-8916-599aee1d6b86.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Integrate Lambda Test Tool\u0027s feature for allowing saving requests"
+      ]
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -408,3 +408,6 @@ FodyWeavers.xsd
 
 # CDK temp files
 **/cdk.out/**
+
+# Amazon.Lambda.TestTool default local storage
+**/.aws-lambda-testool/**

--- a/src/Aspire.Hosting.AWS/Constants.cs
+++ b/src/Aspire.Hosting.AWS/Constants.cs
@@ -41,10 +41,15 @@ internal static class Constants
     /// <summary>
     /// The version of RuntimeSupport used in the executable wrapper project
     /// </summary>
-    internal const string RuntimeSupportPackageVersion = "1.13.0";
+    internal const string RuntimeSupportPackageVersion = "1.13.1";
     
     /// <summary>
     /// The default version of Amazon.Lambda.TestTool that will be automatically installed
     /// </summary>
-    internal const string DefaultLambdaTestToolVersion = "0.10.3";
+    internal const string DefaultLambdaTestToolVersion = "0.11.0";
+
+    /// <summary>
+    /// The default directory the Lambda Test Tool will be configured for storing configuration information like saved requests.
+    /// </summary>
+    internal const string DefaultLambdaConfigStorage = ".aws-lambda-testool";
 }

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaEmulatorOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaEmulatorOptions.cs
@@ -31,4 +31,10 @@ public class LambdaEmulatorOptions
     /// The port that the Lambda emulator will listen on. If not set, a random port will be used.
     /// </summary>
     public int? Port { get; set; } = null;
+
+    /// <summary>
+    /// Directory for the Lambda Test Tool to save configuration information like saved requests. The default is ".aws-lambda-testool" sub directory in the current directory.
+    /// To disable the ability to save configuration set ConfigStoragePath to an empty string (i.e. string.Empty).
+    /// </summary>
+    public string? ConfigStoragePath { get; set; }
 }

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaEmulatorResource.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaEmulatorResource.cs
@@ -14,10 +14,21 @@ public class LambdaEmulatorResource(string name) : ExecutableResource(name,
         Environment.CurrentDirectory
         )
 {
-    internal void AddCommandLineArguments(IList<object> arguments)
+    internal void AddCommandLineArguments(IList<object> arguments, LambdaEmulatorOptions? options)
     {
         arguments.Add("lambda-test-tool");
         arguments.Add("start");
         arguments.Add("--no-launch-window");
+
+        if (options == null || options.ConfigStoragePath == null)
+        {
+            arguments.Add("--config-storage-path");
+            arguments.Add(Path.Combine(Environment.CurrentDirectory, Constants.DefaultLambdaConfigStorage));
+        }
+        else if (options.ConfigStoragePath != string.Empty) // If set explicitly to empty string assume the user doesn't want local storage.
+        {
+            arguments.Add("--config-storage-path");
+            arguments.Add(options.ConfigStoragePath);
+        }
     }
 }

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaExtensions.cs
@@ -135,7 +135,7 @@ public static class LambdaExtensions
         var lambdaEmulator = builder.AddResource(new LambdaEmulatorResource("LambdaServiceEmulator")).ExcludeFromManifest();
         lambdaEmulator.WithArgs(context =>
         {
-            lambdaEmulator.Resource.AddCommandLineArguments(context.Args);
+            lambdaEmulator.Resource.AddCommandLineArguments(context.Args, options);
         });
 
         var annotation = new EndpointAnnotation(


### PR DESCRIPTION
*Description of changes:*
Upgrade to version `0.11.0` of Amazon.Lambda.TestTool` and integrate it's new feature of allowing saving requests from the test tool. By default the test tool will enable saving requests in the `<current directory>/.aws-lambda-testool`. The current directory most likely will be the AppHost. The location can be overridden by explicitly calling the `AddAWSLambdaServiceEmulator` with an `LambdaEmulatorOptions` instance and setting the `ConfigStoragePath` property. If users want to disable saving feature they can set the `ConfigStoragePath` property to empty string. I can't rely on a `null` check for `ConfigStoragePath` because by default the containing `LambdaEmulatorOptions` object is null. So it would get tricky to tell the difference of `ConfigStoragePath` being null because user explicitly set it or the containing object never existed. 

Tested by manually confirming the expected behavior in the playground app and adding new integ tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
