### PR TITLE
[Breaking Change] Changed return type for AddAWSDynamoDBLocal

### DIFF
--- a/.autover/changes/42fd9a53-213e-431c-a4f5-310727c5208d.json
+++ b/.autover/changes/42fd9a53-213e-431c-a4f5-310727c5208d.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "[Breaking Change] Changed return type for AddAWSDynamoDBLocal to return IResourceBuilder\u003CDynamoDBLocalResource\u003E from IResourceBuilder\u003CIDynamoDBLocalResource\u003E. This allows access to the inherited APIs from DynamoDBLocalResource\u0027s parent ContainerResource type."
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResource.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResource.cs
@@ -7,7 +7,7 @@ namespace Aspire.Hosting.AWS.DynamoDB;
 /// <summary>
 /// Represents a DynamoDB local resource. This is a dev only resources and will not be written to the project's manifest.
 /// </summary>
-internal sealed class DynamoDBLocalResource(string name, DynamoDBLocalOptions options) : ContainerResource(name), IDynamoDBLocalResource
+public sealed class DynamoDBLocalResource(string name, DynamoDBLocalOptions options) : ContainerResource(name), IDynamoDBLocalResource
 {
     internal const int DynamoDBInternalPort = 8000;
     internal const string InternalStorageMountPoint = "/storage";

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
@@ -16,7 +16,7 @@ public static class DynamoDBLocalResourceBuilderExtensions
     /// <param name="options">Optional: Options that can be set for configuring the instance of DynamoDB Local.</param>
     /// <returns></returns>
     /// <exception cref="DistributedApplicationException"></exception>
-    public static IResourceBuilder<IDynamoDBLocalResource> AddAWSDynamoDBLocal(this IDistributedApplicationBuilder builder,
+    public static IResourceBuilder<DynamoDBLocalResource> AddAWSDynamoDBLocal(this IDistributedApplicationBuilder builder,
         string name, DynamoDBLocalOptions? options = null)
     {
         var container = new DynamoDBLocalResource(name, options ?? new DynamoDBLocalOptions());
@@ -41,8 +41,8 @@ public static class DynamoDBLocalResourceBuilderExtensions
     /// <typeparam name="T">The resource type.</typeparam>
     /// <param name="builder">Builder for the container resource.</param>
     /// <param name="pullPolicy">The pull policy behavior for the container resource.</param>
-    /// <returns>The <see cref="IResourceBuilder{IDynamoDBLocalResource}"/>.</returns>
-    public static IResourceBuilder<IDynamoDBLocalResource> WithImagePullPolicy(this IResourceBuilder<IDynamoDBLocalResource> builder, ImagePullPolicy imagePullPolicy)
+    /// <returns>The <see cref="IResourceBuilder{DynamoDBLocalResource}"/>.</returns>
+    public static IResourceBuilder<DynamoDBLocalResource> WithImagePullPolicy(this IResourceBuilder<DynamoDBLocalResource> builder, ImagePullPolicy imagePullPolicy)
     {
         if (builder is IResourceBuilder<ContainerResource> containerBuilder)
         {
@@ -65,7 +65,7 @@ public static class DynamoDBLocalResourceBuilderExtensions
     /// <param name="dynamoDBLocalResourceBuilder"></param>
     /// <returns></returns>
     /// <exception cref="DistributedApplicationException"></exception>
-    public static IResourceBuilder<TDestination> WithReference<TDestination>(this IResourceBuilder<TDestination> builder, IResourceBuilder<IDynamoDBLocalResource> dynamoDBLocalResourceBuilder)
+    public static IResourceBuilder<TDestination> WithReference<TDestination>(this IResourceBuilder<TDestination> builder, IResourceBuilder<DynamoDBLocalResource> dynamoDBLocalResourceBuilder)
         where TDestination : IResourceWithEnvironment
     {      
         if (builder is IResourceBuilder<IResourceWithWaitSupport> waitSupport)


### PR DESCRIPTION
## Description
Changed return type for AddAWSDynamoDBLocal to return IResourceBuilder<DynamoDBLocalResource> from IResourceBuilder<IDynamoDBLocalResource>. This allows access to the inherited APIs from DynamoDBLocalResource's parent ContainerResource type.

## Motivation and Context
https://github.com/aws/integrations-on-dotnet-aspire-for-aws/issues/129