### PR TITLE
LaunchProfile generation for working directory  

### DIFF
--- a/.autover/changes/f1a6c070-9537-4a7d-a3f1-2c2a8a12eb64.json
+++ b/.autover/changes/f1a6c070-9537-4a7d-a3f1-2c2a8a12eb64.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Change generation of Lambda launch settings profile to evaluate OutputPath property for launch profile working directory"
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/Constants.cs
+++ b/src/Aspire.Hosting.AWS/Constants.cs
@@ -46,7 +46,7 @@ internal static class Constants
     /// <summary>
     /// The default version of Amazon.Lambda.TestTool that will be automatically installed
     /// </summary>
-    internal const string DefaultLambdaTestToolVersion = "0.12.0";
+    internal const string DefaultLambdaTestToolVersion = "0.13.0";
 
     /// <summary>
     /// The default directory the Lambda Test Tool will be configured for storing configuration information like saved requests.

--- a/src/Aspire.Hosting.AWS/Utils/ProjectUtilities.cs
+++ b/src/Aspire.Hosting.AWS/Utils/ProjectUtilities.cs
@@ -25,6 +25,7 @@ internal static class ProjectUtilities
         string projectPath, 
         string runtimeSupportAssemblyPath, 
         string targetFramework,
+        string outputPath,
         ILogger? logger = null)
     {
         try
@@ -62,7 +63,7 @@ internal static class ProjectUtilities
             // Update properties that contain a path that is environment-specific
             lambdaTester["commandLineArgs"] =
                 $"exec --depsfile ./{assemblyName}.deps.json --runtimeconfig ./{assemblyName}.runtimeconfig.json {SubstituteHomePath(runtimeSupportAssemblyPath)} {functionHandler}";
-            lambdaTester["workingDirectory"] = Path.Combine(".", "bin", "$(Configuration)", targetFramework);
+            lambdaTester["workingDirectory"] = outputPath;
 
             // Serialize the updated JSON with indentation
             var options = new JsonSerializerOptions { WriteIndented = true };

--- a/tests/Aspire.Hosting.AWS.UnitTests/ProjectUtilitiesTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/ProjectUtilitiesTests.cs
@@ -50,6 +50,7 @@ public class ProjectUtilitiesTests : IDisposable
         string functionHandler = "TestNamespace.Function::Handler";
         string assemblyName = "TestAssembly";
         string targetFramework = "net8.0";
+        string outputPath = $"bin/Debug/{targetFramework}";
 
         string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
         string runtimeSupportAssemblyPath = Path.Combine(userProfile, "dummy.dll");
@@ -65,7 +66,8 @@ public class ProjectUtilitiesTests : IDisposable
             assemblyName,
             projectPath,
             runtimeSupportAssemblyPath,
-            targetFramework);
+            targetFramework,
+            outputPath);
 
         // Assert
         Assert.True(Directory.Exists(propertiesDir));
@@ -97,7 +99,7 @@ public class ProjectUtilitiesTests : IDisposable
 
         // Verify the workingDirectory was set correctly.
         string workingDirectory = profile["workingDirectory"]?.GetValue<string>() ?? "";
-        string expectedWorkingDir = Path.Combine(".", "bin", "$(Configuration)", targetFramework);
+        string expectedWorkingDir = Path.Combine("bin", "Debug", targetFramework).Replace("\\", "/");
         Assert.Equal(expectedWorkingDir, workingDirectory);
     }
 
@@ -116,6 +118,7 @@ public class ProjectUtilitiesTests : IDisposable
         string functionHandler = "ExistingNamespace.Handler::Run";
         string assemblyName = "ExistingAssembly";
         string targetFramework = "net8.0";
+        string outputPath = $"bin/Debug/{targetFramework}";
 
         string runtimeSupportAssemblyPath = @"C:\path\to\support.dll";
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -130,7 +133,8 @@ public class ProjectUtilitiesTests : IDisposable
             assemblyName,
             projectPath,
             runtimeSupportAssemblyPath,
-            targetFramework);
+            targetFramework,
+            outputPath);
 
         // Assert
         string jsonContent = File.ReadAllText(launchSettingsPath);
@@ -153,7 +157,7 @@ public class ProjectUtilitiesTests : IDisposable
         Assert.Contains(functionHandler, commandLineArgs);
 
         string workingDirectory = profile["workingDirectory"]?.GetValue<string>() ?? "";
-        string expectedWorkingDir = Path.Combine(".", "bin", "$(Configuration)", targetFramework);
+        string expectedWorkingDir = Path.Combine("bin", "Debug", targetFramework).Replace("\\", "/");
         Assert.Equal(expectedWorkingDir, workingDirectory);
     }
 
@@ -166,6 +170,7 @@ public class ProjectUtilitiesTests : IDisposable
         string functionHandler = "TestNamespace.Function::Handler";
         string assemblyName = "TestAssembly";
         string targetFramework = "net8.0";
+        string outputPath = $"bin/Debug/{targetFramework}";
         string runtimeSupportAssemblyPath = @"C:\dummy.dll";
 
         // Act & Assert
@@ -176,7 +181,8 @@ public class ProjectUtilitiesTests : IDisposable
                 assemblyName,
                 invalidProjectPath,
                 runtimeSupportAssemblyPath,
-                targetFramework));
+                targetFramework,
+                outputPath));
     }
 
     [Fact]
@@ -194,6 +200,7 @@ public class ProjectUtilitiesTests : IDisposable
         string functionHandler = "MalformedNamespace.Handler::Invoke";
         string assemblyName = "MalformedAssembly";
         string targetFramework = "net8.0";
+        string outputPath = $"bin/Debug/{targetFramework}";
         string runtimeSupportAssemblyPath = @"C:\malformed.dll";
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
@@ -207,7 +214,8 @@ public class ProjectUtilitiesTests : IDisposable
             assemblyName,
             projectPath,
             runtimeSupportAssemblyPath,
-            targetFramework);
+            targetFramework,
+            outputPath);
 
         // Assert
         string jsonContent = File.ReadAllText(launchSettingsPath);


### PR DESCRIPTION
## Description
Today for a class library Lambda function we generate the working directory for the launch profile as `.//bin//$(Configuration)//<computed-target-framework` using the `$(Configuration)`. Using the `$(Configuration)` variable works when launching from Visual Studio but Visual Studio Code's launch debugger is not msbuild based and does not resolve msbuild parameters.

I changed the code to us to resolve the output directory via the `OutputPath` msbuild parameter through the .NET CLI like we do for other parameters and then use that value when writing out the launch settings profile.

PR is in draft mode because I'm also updating the test tool version that is currently in [PR](https://github.com/aws/aws-lambda-dotnet/pull/2279). 

## Motivation and Context
https://github.com/aws/integrations-on-dotnet-aspire-for-aws/issues/115

## Testing
<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

