### PR TITLE
Integrate Lambda Test Tool's HTTPS support

### DIFF
--- a/.autover/changes/94ae39be-b937-4039-9930-bc132e8d8638.json
+++ b/.autover/changes/94ae39be-b937-4039-9930-bc132e8d8638.json
@@ -1,0 +1,13 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add HTTPS support for Lambda and API Gateway emulators",
+		"[Breaking Change] Rename `Port` property to HttpPort to match new `HttpsPort` property on APIGatewayEmulatorOptions and LambdaEmulatorOptions",
+		"Added new `DisableHttpsEndpoint` property to disable default allocation of HTTPS endpoints on APIGatewayEmulatorOptions and LambdaEmulatorOptions"
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/Lambda/APIGatewayEmulatorOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/APIGatewayEmulatorOptions.cs
@@ -8,7 +8,17 @@ namespace Aspire.Hosting.AWS.Lambda;
 public class APIGatewayEmulatorOptions
 {
     /// <summary>
-    /// The port that the API Gateway emulator will listen on. If not set, a random port will be used.
+    /// The http port that the API Gateway emulator will listen on. If not set, a random port will be used.
     /// </summary>
-    public int? Port { get; set; } = null;
+    public int? HttpPort { get; set; } = null;
+
+    /// <summary>
+    /// The https port that the API Gateway emulator will listen on. If not set, a random port will be used.
+    /// </summary>
+    public int? HttpsPort { get; set; } = null;
+
+    /// <summary>
+    /// Setting to true will disable the creation of the HTTPS endpoint for the API Gateway emulator.
+    /// </summary>
+    public bool DisableHttpsEndpoint { get; set; } = false;
 }

--- a/src/Aspire.Hosting.AWS/Lambda/APIGatewayEmulatorOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/APIGatewayEmulatorOptions.cs
@@ -8,12 +8,12 @@ namespace Aspire.Hosting.AWS.Lambda;
 public class APIGatewayEmulatorOptions
 {
     /// <summary>
-    /// The http port that the API Gateway emulator will listen on. If not set, a random port will be used.
+    /// The HTTP port that the API Gateway emulator will listen on. If not set, a random port will be used.
     /// </summary>
     public int? HttpPort { get; set; } = null;
 
     /// <summary>
-    /// The https port that the API Gateway emulator will listen on. If not set, a random port will be used.
+    /// The HTTPS port that the API Gateway emulator will listen on. If not set, a random port will be used.
     /// </summary>
     public int? HttpsPort { get; set; } = null;
 

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaEmulatorAnnotation.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaEmulatorAnnotation.cs
@@ -7,13 +7,13 @@ namespace Aspire.Hosting.AWS.Lambda;
 /// <summary>
 /// Annotation for the metadata of a Lambda runtime emulator resource
 /// </summary>
-/// <param name="endpoint"></param>
-internal class LambdaEmulatorAnnotation(EndpointReference endpoint) : IResourceAnnotation
+/// <param name="lambdaRuntimeEndpoint"></param>
+internal class LambdaEmulatorAnnotation(EndpointReference lambdaRuntimeEndpoint) : IResourceAnnotation
 {
-    /// <summary>
-    /// The HTTP endpoint for the Lambda runtime emulator.
+    /// <summary> 
+    /// The HTTP endpoint for the Lambda runtime api.
     /// </summary>
-    public EndpointReference Endpoint { get; init; } = endpoint;
+    public EndpointReference LambdaRuntimeEndpoint { get; init; } = lambdaRuntimeEndpoint;
 
     /// <summary>
     /// By default Amazon.Lambda.TestTool will be updated/installed during AppHost startup. Amazon.Lambda.TestTool is 

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaEmulatorOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaEmulatorOptions.cs
@@ -28,13 +28,24 @@ public class LambdaEmulatorOptions
     public bool AllowDowngrade { get; set; } = false;
 
     /// <summary>
-    /// The port that the Lambda emulator will listen on. If not set, a random port will be used.
+    /// The http port that the Lambda emulator will listen on. If not set, a random port will be used.
     /// </summary>
-    public int? Port { get; set; } = null;
+    public int? HttpPort { get; set; } = null;
+
+    /// <summary>
+    /// The https port that the Lambda emulator will listen on. If not set, a random port will be used.
+    /// </summary>
+    public int? HttpsPort { get; set; } = null;
 
     /// <summary>
     /// Directory for the Lambda Test Tool to save configuration information like saved requests. The default is ".aws-lambda-testtool" sub directory in the current directory.
     /// To disable the ability to save configuration set ConfigStoragePath to an empty string (i.e. string.Empty).
     /// </summary>
     public string? ConfigStoragePath { get; set; }
+
+    /// <summary>
+    /// By default both an HTTP and HTTPS endpoint will be created for the Lambda Emulator. The HTTP endpoint is required for running Lambda functions to poll and process events. 
+    /// The web ui can be accessed through the HTTPS endpoint. Setting DisableHttpsEndpoint to true will disable the creation of the HTTPS endpoint.
+    /// </summary>
+    public bool DisableHttpsEndpoint { get; set; } = false;
 }

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaEmulatorOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaEmulatorOptions.cs
@@ -28,12 +28,12 @@ public class LambdaEmulatorOptions
     public bool AllowDowngrade { get; set; } = false;
 
     /// <summary>
-    /// The http port that the Lambda emulator will listen on. If not set, a random port will be used.
+    /// The HTTP port that the Lambda emulator will listen on. If not set, a random port will be used.
     /// </summary>
     public int? HttpPort { get; set; } = null;
 
     /// <summary>
-    /// The https port that the Lambda emulator will listen on. If not set, a random port will be used.
+    /// The HTTPS port that the Lambda emulator will listen on. If not set, a random port will be used.
     /// </summary>
     public int? HttpsPort { get; set; } = null;
 

--- a/src/Aspire.Hosting.AWS/Lambda/SQSEventSourceExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/SQSEventSourceExtensions.cs
@@ -107,7 +107,7 @@ public static class SQSEventSourceExtensions
             // configure the SQS event source with the same config to access the SQS queue.
             var awsSdkConfig = lambdaFunction.Resource.Annotations.OfType<SDKResourceAnnotation>().FirstOrDefault()?.SdkConfig;
 
-            var sqsEventConfig = SQSEventSourceResource.CreateSQSEventConfig(queueUrl, lambdaFunction.Resource.Name, lambdaEmulatorAnnotation.Endpoint.Url, options, awsSdkConfig);
+            var sqsEventConfig = SQSEventSourceResource.CreateSQSEventConfig(queueUrl, lambdaFunction.Resource.Name, lambdaEmulatorAnnotation.LambdaRuntimeEndpoint.Url, options, awsSdkConfig);
             context.EnvironmentVariables[SQSEventSourceResource.SQS_EVENT_CONFIG_ENV_VAR] = sqsEventConfig;
         });
 

--- a/tests/Aspire.Hosting.AWS.Integ.Tests/Lambda/PlaygroundE2ETests.cs
+++ b/tests/Aspire.Hosting.AWS.Integ.Tests/Lambda/PlaygroundE2ETests.cs
@@ -199,7 +199,7 @@ public class PlaygroundE2ETests
     }
 
     [Fact]
-    public async Task ConfigureEmulatorPorts()
+    public void ConfigureEmulatorPorts()
     {
         CancellationTokenSource cancellationSource = new CancellationTokenSource();
         try

--- a/tests/Aspire.Hosting.AWS.Integ.Tests/Lambda/PlaygroundE2ETests.cs
+++ b/tests/Aspire.Hosting.AWS.Integ.Tests/Lambda/PlaygroundE2ETests.cs
@@ -151,7 +151,7 @@ public class PlaygroundE2ETests
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task VerifyDisableHttpsEndpoint(bool disableHttps)
+    public void VerifyDisableHttpsEndpoint(bool disableHttps)
     {
         CancellationTokenSource cancellationSource = new CancellationTokenSource();
         try


### PR DESCRIPTION
## Description
To more closely match Lambda and more importantly API Gateway experience expose HTTPS endpoints for the emulator. This PR is contingent on [PR](https://github.com/aws/aws-lambda-dotnet/pull/2282) for the test tool being released that adds support for enabling HTTPS support.

Aspire itself takes care of provisioning dev certs for the Aspire resource and sets the `SSL_CERT_DIR` environment variable for the ASP.NET Core part of the Lambda Test Tool to pick up and automatically use.

The user experience will be that HTTPS endpoints will provisioned by default for users. If users don't want to HTTPS endpoints they can set the `DisableHttpsEndpoint` property. A reason I can think a user wanting to do this is if their environment doesn't allow the certs that Aspire provisions. The HTTPS port can be configured with the new `HttpsPort` port, if not set a random port will be allocated via Aspire. **Breaking Change** the existing `Port` property was renamed to `HttpPort` to match the new `HttpsPort` property.


## Motivation and Context
https://github.com/aws/integrations-on-dotnet-aspire-for-aws/issues/136

## Testing
Testing with HTTPS ports through xunit is tricky and I doubt our CI system will have certs in place so I relied on manually testing building the test tool into NuGet packages and testing it directly along with the Aspire integration.

