### PR TITLE
Add checks for dev cert when choosing to enable Lambda HTTPS ports by default

### DIFF
--- a/.autover/changes/4a2a6cae-9b36-43dc-a6df-b032c467e88b.json
+++ b/.autover/changes/4a2a6cae-9b36-43dc-a6df-b032c467e88b.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add checks for dev cert when choosing to enable Lambda HTTPS ports by default"
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/Lambda/APIGatewayEmulatorOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/APIGatewayEmulatorOptions.cs
@@ -7,6 +7,11 @@ namespace Aspire.Hosting.AWS.Lambda;
 /// </summary>
 public class APIGatewayEmulatorOptions
 {
+    public APIGatewayEmulatorOptions()
+    {
+        DisableHttpsEndpoint = !Utils.DevCertificateDetector.HasAspNetCoreDevCert();
+    }
+
     /// <summary>
     /// The HTTP port that the API Gateway emulator will listen on. If not set, a random port will be used.
     /// </summary>

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaEmulatorOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaEmulatorOptions.cs
@@ -7,6 +7,11 @@ namespace Aspire.Hosting.AWS.Lambda;
 /// </summary>
 public class LambdaEmulatorOptions
 {
+    public LambdaEmulatorOptions()
+    {
+        DisableHttpsEndpoint = !Utils.DevCertificateDetector.HasAspNetCoreDevCert();
+    }
+
     /// <summary>
     /// By default Amazon.Lambda.TestTool will be updated/installed during AppHost startup. Amazon.Lambda.TestTool is 
     /// a .NET Tool that will be installed globally.

--- a/src/Aspire.Hosting.AWS/Utils/DevCertificateDetector.cs
+++ b/src/Aspire.Hosting.AWS/Utils/DevCertificateDetector.cs
@@ -1,0 +1,70 @@
+﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+using System.Security.Cryptography.X509Certificates;
+
+namespace Aspire.Hosting.AWS.Utils;
+
+internal class DevCertificateDetector
+{
+    private const string LocalhostSubject = "CN=localhost";
+
+    // This is the value for the Server Authentication EKU using TLS Web Server Authentication, which is required for ASP.NET Core's development certificate.
+    private const string ServerAuthOid = "1.3.6.1.5.5.7.3.1";
+
+    public static bool HasAspNetCoreDevCert()
+    {
+        try
+        {
+            using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
+            store.Open(OpenFlags.ReadOnly);
+
+            var now = DateTimeOffset.UtcNow;
+
+            foreach (var cert in store.Certificates)
+            {
+                if (!IsLocalhost(cert))
+                    continue;
+
+                if (!IsValid(cert, now))
+                    continue;
+
+                if (!HasServerAuthEku(cert))
+                    continue;
+
+                if (!cert.HasPrivateKey)
+                    continue;
+
+                // Prefer the ASP.NET Core OID if present,
+                // but don't require it for forward compatibility.
+                return true;
+            }
+
+            return false;
+        }
+        catch
+        {
+            // Never throw from detection logic in a public library
+            return false;
+        }
+    }
+
+    private static bool IsLocalhost(X509Certificate2 cert) =>
+        string.Equals(cert.Subject, LocalhostSubject, StringComparison.OrdinalIgnoreCase);
+
+    private static bool IsValid(X509Certificate2 cert, DateTimeOffset now) =>
+        now >= cert.NotBefore && now <= cert.NotAfter;
+
+    private static bool HasServerAuthEku(X509Certificate2 cert)
+    {
+        foreach (var extension in cert.Extensions.OfType<X509EnhancedKeyUsageExtension>())
+        {
+            foreach (var oid in extension.EnhancedKeyUsages)
+            {
+                if (oid?.Value == ServerAuthOid)
+                    return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Aspire.Hosting.AWS/Utils/DevCertificateDetector.cs
+++ b/src/Aspire.Hosting.AWS/Utils/DevCertificateDetector.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+using Amazon.CDK.AWS.CloudWatch;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Aspire.Hosting.AWS.Utils;
@@ -18,14 +19,12 @@ internal class DevCertificateDetector
             using var store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
             store.Open(OpenFlags.ReadOnly);
 
-            var now = DateTimeOffset.UtcNow;
-
             foreach (var cert in store.Certificates)
             {
                 if (!IsLocalhost(cert))
                     continue;
 
-                if (!IsValid(cert, now))
+                if (!IsValid(cert))
                     continue;
 
                 if (!HasServerAuthEku(cert))
@@ -51,8 +50,12 @@ internal class DevCertificateDetector
     private static bool IsLocalhost(X509Certificate2 cert) =>
         string.Equals(cert.Subject, LocalhostSubject, StringComparison.OrdinalIgnoreCase);
 
-    private static bool IsValid(X509Certificate2 cert, DateTimeOffset now) =>
-        now >= cert.NotBefore && now <= cert.NotAfter;
+    private static bool IsValid(X509Certificate2 cert)
+    {
+        // Use local time to match the certificate's NotBefore and NotAfter properties, which are in local time.
+        var now = DateTime.Now;
+        return now >= cert.NotBefore && now <= cert.NotAfter;
+    }
 
     private static bool HasServerAuthEku(X509Certificate2 cert)
     {


### PR DESCRIPTION
## Description
In PR https://github.com/aws/integrations-on-dotnet-aspire-for-aws/pull/156 we enabled HTTPS ports by default for the Lambda and API Gateway emulation. But if a user doesn't have the dev certs for localhost installed, commonly in CI systems, then the emulators will fail to launch.

This PR checks to see of a dev cert is installed and if not changes the default experience to not have HTTPS endpoints.

## Motivation and Context
https://github.com/aws/integrations-on-dotnet-aspire-for-aws/issues/136#issuecomment-3932936805

## Testing
I had to rely on manual testing since installing and uninstalling certs is not something I want to do as part of xunit tests. I verified correct behavior with and without the dev certs installed. In the case of not having the dev certs the emulators default to HTTP only. If the dev cert was installed both the HTTPS and HTTP endpoints were allocated.
