### PR TITLE
Fix issue with Lambda functions failing to start when launched in Visual Studio

### DIFF
--- a/.autover/changes/533214e6-9b17-46c7-90ea-83e86d9a01f3.json
+++ b/.autover/changes/533214e6-9b17-46c7-90ea-83e86d9a01f3.json
@@ -1,0 +1,12 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Update Aspire dependencies to version 13.2.0",
+        "Fix issue with Lambda functions failing to start when launched in Visual Studio and using Aspire 13.2.0"
+      ]
+    }
+  ]
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,23 +2,23 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <AspireSdkVersion>13.1.0</AspireSdkVersion>
+    <AspireSdkVersion>13.2.0</AspireSdkVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting" Version="13.1.0" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.1.0" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.1.0" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.1.0" />
-    <PackageVersion Include="Aspire.Hosting.Valkey" Version="13.1.0" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.1.0" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.1.0" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Dns" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />	  
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageVersion Include="Aspire.Hosting" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.Valkey" Version="13.2.0" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.2.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.2.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.2.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Dns" Version="10.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.5" />	  
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.4.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <!-- AWS SDK for .NET dependencies -->
     <PackageVersion Include="AWSSDK.CloudFormation" Version="4.0.8.8" />

--- a/playground/Lambda/WebDefaultLambdaFunction/LambdaFunction.cs
+++ b/playground/Lambda/WebDefaultLambdaFunction/LambdaFunction.cs
@@ -27,10 +27,10 @@ internal class LambdaFunction(TracerProvider traceProvider) : BackgroundService
         {
             StatusCode = 200,
             Headers = new Dictionary<string, string>
-        {
-            {"Content-Type", "text/plain" }
-        },
-            Body = "The root page for the REST API defined in the Aspire AppHost. Try using endpoints /add/{1}/2, /minus/3/2, /multiply/6/7, /divide/20/4 or /aws/{sqs|dynamodb}"
+            {
+                {"Content-Type", "text/plain" }
+            },
+            Body = "The root page for the REST API defined in the Aspire AppHost. Try using endpoints /add/1/2, /minus/3/2, /multiply/6/7, /divide/20/4 or /aws/{sqs|dynamodb}"
         };
 
         return response;

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaExtensions.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using System.Diagnostics;
 using System.Net.Sockets;
-using System.Runtime.Versioning;
+using System.Text.Json.Serialization;
 
 #pragma warning disable IDE0130
 namespace Aspire.Hosting;
@@ -19,7 +19,7 @@ namespace Aspire.Hosting;
 /// Extension methods for adding Lambda functions as Aspire resources.
 /// </summary>
 public static class LambdaExtensions
-{   
+{
     /// <summary>
     /// Add a Lambda function as an Aspire resource.
     /// </summary>
@@ -41,9 +41,12 @@ public static class LambdaExtensions
             // If we are running Aspire through an IDE where a debugger is attached,
             // we want to configure the Aspire resource to use a Launch Setting Profile that will be able to run the class library Lambda function.
             var project = new LambdaProjectResource(name);
+#pragma warning disable ASPIREEXTENSION001 // WithDebugSupport is experimental
             resource = builder.AddResource(project)
                 .WithAnnotation(new LaunchProfileAnnotation($"{Constants.LaunchSettingsNodePrefix}{name}"))
-                .WithAnnotation(new TLambdaProject());
+                .WithAnnotation(new TLambdaProject())
+                .WithDebugSupport(mode => new LambdaFunctionsLaunchConfiguration { ProjectPath = metadata.ProjectPath, Mode = mode, LaunchProfile = $"{Constants.LaunchSettingsNodePrefix}{name}" }, "project");
+#pragma warning restore ASPIREEXTENSION001
         }
         else
         {
@@ -240,5 +243,23 @@ public static class LambdaExtensions
         builder.WithOtlpExporter();
 
         return builder;
+    }
+
+    private sealed class LambdaFunctionsLaunchConfiguration
+    {
+        [JsonPropertyName("type")]
+        public string Type { get; set; } = "project";
+
+        [JsonPropertyName("mode")]
+        public string Mode { get; set; } = string.Empty;
+
+        [JsonPropertyName("project_path")]
+        public string ProjectPath { get; set; } = string.Empty;
+
+        [JsonPropertyName("launch_profile")]
+        public string LaunchProfile { get; set; } = string.Empty;
+
+        [JsonPropertyName("disable_launch_profile")]
+        public bool DisableLaunchProfile { get; set; } = false;
     }
 }


### PR DESCRIPTION
## Description
When updating to version 13.2.0 of `Aspire.Hosting` class library based Lambda functions failed to start. Looking through the changes in Aspire 13.2.0 it looks like there were new requirements added to make sure the `SupportsDebuggingAnnotation` attribute is applied for the .NET projects. This is normally not a big deal but in our Lambda's case we don't use the `AddProject` extension method for adding the Lambda projects where the `SupportsDebuggingAnnotation` would normally be added. We can't use that because we need to create a subclass of the `ProjectResource`.

Based on examples I saw in the Aspire repository I got the `SupportsDebuggingAnnotation`  added to the Lambda projects and then debugging worked correctly. 

My understanding without the attribute Aspire falls back to essentially doing a `dotnet run` on the project which fails because the project is a class library.

## Motivation and Context
https://github.com/aws/integrations-on-dotnet-aspire-for-aws/issues/167

## Testing
Launched the dashboard and confirmed the functions were launched and I could hit break points when invoking the functions.

