### PR TITLE
Support WithEnvironment on compute publish targets (#169)

### DIFF
--- a/.autover/changes/02719d97-61c6-4894-a39d-8f947b7eca8f.json
+++ b/.autover/changes/02719d97-61c6-4894-a39d-8f947b7eca8f.json
@@ -5,7 +5,6 @@
       "Type": "Patch",
       "ChangelogMessages": [
         "Resolve WithEnvironment callbacks during publish for all compute targets (ECS Fargate, ECS Fargate Express, Lambda)",
-        "Resolve ParameterResource and ReferenceExpression values in WithEnvironment during publish via IValueProvider",
         "Add warning when Lambda function environment variables approach or exceed the 4 KB limit"
       ]
     }

--- a/.autover/changes/02719d97-61c6-4894-a39d-8f947b7eca8f.json
+++ b/.autover/changes/02719d97-61c6-4894-a39d-8f947b7eca8f.json
@@ -1,0 +1,13 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Resolve WithEnvironment callbacks during publish for all compute targets (ECS Fargate, ECS Fargate Express, Lambda)",
+        "Resolve ParameterResource and ReferenceExpression values in WithEnvironment during publish via IValueProvider",
+        "Add warning when Lambda function environment variables approach or exceed the 4 KB limit"
+      ]
+    }
+  ]
+}

--- a/playground/Publishing/Publishing.AppHost/Program.cs
+++ b/playground/Publishing/Publishing.AppHost/Program.cs
@@ -31,12 +31,22 @@ var localDevQueue = cdkStackResource.AddSQSQueue("LocalDevQueue");
 var cache = builder.AddValkey("cache");
 
 var frontend = builder.AddProject<Projects.Frontend>("Frontend")
+        .WithEnvironment("ENV_LAMBDA_1", "LambdaValue1")
+        .WithEnvironment(callback: (env) =>
+        {
+            env.EnvironmentVariables.Add("ENV_LAMBDA_2", "LambdaValue2");
+        })
         .WithExternalHttpEndpoints()
         .WithReference(cache)
         .WaitFor(cache);
 
 
 builder.AddProject<Projects.Backend>("backend")
+        .WithEnvironment("ENV_LAMBDA_1", "LambdaValue1")
+        .WithEnvironment(callback: (env) =>
+        {
+            env.EnvironmentVariables.Add("ENV_LAMBDA_2", "LambdaValue2");
+        })
         .WithReference(frontend)
         .WithReference(cache)
         .WaitFor(cache);
@@ -52,6 +62,11 @@ builder.AddAWSLambdaFunction<Projects.SQSProcessorFunction>("SQSProcessorFunctio
                     Enabled = true
                 }));
             }
+        })
+        .WithEnvironment("ENV_LAMBDA_1", "LambdaValue1")
+        .WithEnvironment(callback: (env) =>
+        {
+            env.EnvironmentVariables.Add("ENV_LAMBDA_2", "LambdaValue2");
         })
         .WithReference(awsSdkConfig)
         .WithSQSEventSource(localDevQueue);

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AbstractAWSPublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AbstractAWSPublishTarget.cs
@@ -160,7 +160,7 @@ public abstract class AbstractAWSPublishTarget(ILogger logger) : IAWSPublishTarg
     /// </summary>
     /// <param name="referencePoints">The CDK connection points for the given Aspire resource to add connection info for resources referencing the Aspire resource.</param>
     /// <param name="resource">The Aspire resource that potentially had other resources add a reference to.</param>
-    protected virtual void ProcessRelationShips(AbstractCDKConstructConnectionPoints referencePoints, IResource resource)
+    protected virtual async Task ProcessRelationShipsAsync(AbstractCDKConstructConnectionPoints referencePoints, IResource resource)
     {
         var environmentVariables = referencePoints.EnvironmentVariables;
          
@@ -184,6 +184,57 @@ public abstract class AbstractAWSPublishTarget(ILogger logger) : IAWSPublishTarg
             if (linkAnnotation.PublishTarget.ReferenceRequiresSecurityGroup() && referencePoints.ReferenceSecurityGroup != null)
             {
                 linkAnnotation.PublishTarget.ApplyReferenceSecurityGroup(linkAnnotation, referencePoints.ReferenceSecurityGroup);
+            }
+        }
+
+        // Resolve environment variables from WithEnvironment callbacks (EnvironmentCallbackAnnotation).
+        // These are applied after WithReference-derived env vars so explicit WithEnvironment takes precedence.
+        if (environmentVariables != null)
+        {
+            var envCallbacks = resource.Annotations.OfType<EnvironmentCallbackAnnotation>();
+            if (envCallbacks.Any())
+            {
+                var executionContext = new DistributedApplicationExecutionContext(DistributedApplicationOperation.Publish);
+                var callbackContext = new EnvironmentCallbackContext(executionContext, resource);
+
+                foreach (var callback in envCallbacks)
+                {
+                    await callback.Callback(callbackContext).ConfigureAwait(false);
+                }
+
+                foreach (var kvp in callbackContext.EnvironmentVariables)
+                {
+                    if (kvp.Value is string strValue)
+                    {
+                        environmentVariables[kvp.Key] = strValue;
+                    }
+                    else if (kvp.Value is IValueProvider valueProvider)
+                    {
+                        // Handles ReferenceExpression (references to other Aspire resources) and
+                        // ParameterResource values. ReferenceExpression.GetValueAsync resolves
+                        // the expression by calling GetValueAsync on each referenced IValueProvider.
+                        try
+                        {
+                            var resolvedValue = await valueProvider.GetValueAsync(default).ConfigureAwait(false);
+                            if (resolvedValue != null)
+                            {
+                                environmentVariables[kvp.Key] = resolvedValue;
+                            }
+                            else
+                            {
+                                Logger.LogWarning("Environment variable '{Name}' on resource '{Resource}' resolved to null and will be skipped", kvp.Key, resource.Name);
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Logger.LogWarning(ex, "Environment variable '{Name}' on resource '{Resource}' could not be resolved during publish and will be skipped", kvp.Key, resource.Name);
+                        }
+                    }
+                    else
+                    {
+                        Logger.LogWarning("Environment variable '{Name}' on resource '{Resource}' has an unsupported value type '{Type}' that cannot be resolved during publish and will be skipped", kvp.Key, resource.Name, kvp.Value?.GetType().Name ?? "null");
+                    }
+                }
             }
         }
 

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AbstractAWSPublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AbstractAWSPublishTarget.cs
@@ -204,35 +204,11 @@ public abstract class AbstractAWSPublishTarget(ILogger logger) : IAWSPublishTarg
 
                 foreach (var kvp in callbackContext.EnvironmentVariables)
                 {
+                    // Currently the AWS deployment supports only strings not ReferenceExpressions because CDK requires the values to be resolved at the publishing stage which 
+                    // ReferenceExpressions are not.
                     if (kvp.Value is string strValue)
                     {
                         environmentVariables[kvp.Key] = strValue;
-                    }
-                    else if (kvp.Value is IValueProvider valueProvider)
-                    {
-                        // Handles ReferenceExpression (references to other Aspire resources) and
-                        // ParameterResource values. ReferenceExpression.GetValueAsync resolves
-                        // the expression by calling GetValueAsync on each referenced IValueProvider.
-                        try
-                        {
-                            var resolvedValue = await valueProvider.GetValueAsync(default).ConfigureAwait(false);
-                            if (resolvedValue != null)
-                            {
-                                environmentVariables[kvp.Key] = resolvedValue;
-                            }
-                            else
-                            {
-                                Logger.LogWarning("Environment variable '{Name}' on resource '{Resource}' resolved to null and will be skipped", kvp.Key, resource.Name);
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.LogWarning(ex, "Environment variable '{Name}' on resource '{Resource}' could not be resolved during publish and will be skipped", kvp.Key, resource.Name);
-                        }
-                    }
-                    else
-                    {
-                        Logger.LogWarning("Environment variable '{Name}' on resource '{Resource}' has an unsupported value type '{Type}' that cannot be resolved during publish and will be skipped", kvp.Key, resource.Name, kvp.Value?.GetType().Name ?? "null");
                     }
                 }
             }

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateExpressServicePublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateExpressServicePublishTarget.cs
@@ -54,7 +54,7 @@ internal class ECSFargateExpressServicePublishTarget(ITarballContainerImageBuild
         var referencePoints = new CfnExpressGatewayServicePropsConnectionPoints(
             fargateServiceProps,
             environment.DefaultsProvider.GetDefaultECSClusterSecurityGroup());
-        ProcessRelationShips(referencePoints, projectResource);
+        await ProcessRelationShipsAsync(referencePoints, projectResource);
 
         var fargateService = new CfnExpressGatewayService(environment.CDKStack, $"Project-{projectResource.Name}", fargateServiceProps);
         publishAnnotation.Config.ConstructCfnExpressGatewayServiceCallback?.Invoke(CreatePublishTargetContext(environment), fargateService);

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateServicePublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateServicePublishTarget.cs
@@ -43,7 +43,7 @@ internal class ECSFargateServicePublishTarget(ITarballContainerImageBuilder imag
             Image = ContainerImage.FromTarball(imageTarballPath),
             Environment = new Dictionary<string, string>()
         };
-        ProcessRelationShips(new ContainerDefinitionPropsConnectionPoints(containerDefinitionProps), projectResource);
+        await ProcessRelationShipsAsync(new ContainerDefinitionPropsConnectionPoints(containerDefinitionProps), projectResource);
 
         publishAnnotation.Config.PropsContainerDefinitionCallback?.Invoke(CreatePublishTargetContext(environment), containerDefinitionProps);
         environment.DefaultsProvider.ApplyECSFargateServiceDefaults(projectResource.Name, containerDefinitionProps);
@@ -58,7 +58,7 @@ internal class ECSFargateServicePublishTarget(ITarballContainerImageBuilder imag
         };
         publishAnnotation.Config.PropsFargateServiceCallback?.Invoke(CreatePublishTargetContext(environment), fargateServiceProps);
         environment.DefaultsProvider.ApplyECSFargateServiceDefaults(fargateServiceProps);
-        ProcessRelationShips(new FargateServicePropsConnectionPoints(
+        await ProcessRelationShipsAsync(new FargateServicePropsConnectionPoints(
             () => CreateEmptyReferenceSecurityGroup(environment, projectResource, fargateServiceProps, x => x.SecurityGroups, (x, v) => x.SecurityGroups = v)),
             resource);
 

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateServiceWithALBPublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateServiceWithALBPublishTarget.cs
@@ -52,7 +52,7 @@ internal class ECSFargateServiceWithALBPublishTarget(ITarballContainerImageBuild
         var referencePoints = new ApplicationLoadBalancedFargateServicePropsConnectionPoints(
             fargateServiceProps,
                 () => CreateEmptyReferenceSecurityGroup(environment, projectResource, fargateServiceProps, x => x.SecurityGroups, (x, v) => x.SecurityGroups = v));
-        ProcessRelationShips(referencePoints, projectResource);
+        await ProcessRelationShipsAsync(referencePoints, projectResource);
 
         var fargateService = new ApplicationLoadBalancedFargateService(environment.CDKStack, $"Project-{projectResource.Name}", fargateServiceProps);
         publishAnnotation.Config.ConstructApplicationLoadBalancedFargateServiceCallback?.Invoke(CreatePublishTargetContext(environment), fargateService);

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/LambdaFunctionPublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/LambdaFunctionPublishTarget.cs
@@ -20,7 +20,7 @@ internal class LambdaFunctionPublishTarget(ILogger<LambdaFunctionPublishTarget> 
 
     public override Type PublishTargetAnnotation => typeof(PublishLambdaFunctionAnnotation);
 
-    public override Task GenerateConstructAsync(AWSCDKEnvironmentResource environment, IResource resource, IAWSPublishTargetAnnotation annotation, CancellationToken cancellationToken)
+    public override async Task GenerateConstructAsync(AWSCDKEnvironmentResource environment, IResource resource, IAWSPublishTargetAnnotation annotation, CancellationToken cancellationToken)
     {
         var lambdaFunction = resource as LambdaProjectResource
                              ?? throw new InvalidOperationException($"Resource {resource.Name} is not a valid LambdaProjectResource.");
@@ -44,7 +44,11 @@ internal class LambdaFunctionPublishTarget(ILogger<LambdaFunctionPublishTarget> 
             () => CreateEmptyReferenceSecurityGroup(environment, resource, functionProps, x => x.SecurityGroups,
                 (x, v) => x.SecurityGroups = v), resource.Name);
 
-        ProcessRelationShips(referencePoints, lambdaFunction);
+        await ProcessRelationShipsAsync(referencePoints, lambdaFunction);
+
+        // Lambda functions have a 4 KB limit for environment variables (total key + value size).
+        // Warn if approaching the limit so users can diagnose deployment failures early.
+        WarnIfLambdaEnvironmentVariablesApproachLimit(functionProps, lambdaFunction.Name);
 
         publishAnnotation.Config.PropsFunctionCallback?.Invoke(CreatePublishTargetContext(environment), functionProps);
         environment.DefaultsProvider.ApplyLambdaFunctionDefaults(functionProps, lambdaFunction);
@@ -52,8 +56,6 @@ internal class LambdaFunctionPublishTarget(ILogger<LambdaFunctionPublishTarget> 
         var function = new Function(environment.CDKStack, $"Function-{lambdaFunction.Name}", functionProps);
         publishAnnotation.Config.ConstructFunctionCallback?.Invoke(CreatePublishTargetContext(environment), function);
         ApplyAWSLinkedObjectsAnnotation(environment, lambdaFunction, function, this);
-
-        return Task.CompletedTask;
     }
 
     public override IsDefaultPublishTargetMatchResult IsDefaultPublishTargetMatch(CDKDefaultsProvider cdkDefaultsProvider, IResource resource)
@@ -76,6 +78,39 @@ internal class LambdaFunctionPublishTarget(ILogger<LambdaFunctionPublishTarget> 
     public override ReferenceConnectionInfo GetReferenceConnectionInfo(AWSLinkedObjectsAnnotation linkedAnnotation)
     {
         return new ReferenceConnectionInfo();
+    }
+
+    /// <summary>
+    /// Lambda functions have a 4 KB (4096 bytes) limit for the total size of all environment variables
+    /// (sum of key + value lengths). This method warns if the current env vars approach that limit.
+    /// </summary>
+    private void WarnIfLambdaEnvironmentVariablesApproachLimit(FunctionProps functionProps, string resourceName)
+    {
+        const int lambdaEnvVarLimitBytes = 4096;
+        const double warningThreshold = 0.8; // Warn at 80% of limit
+
+        if (functionProps.Environment == null || functionProps.Environment.Count == 0)
+            return;
+
+        var totalSize = 0;
+        foreach (var kvp in functionProps.Environment)
+        {
+            totalSize += System.Text.Encoding.UTF8.GetByteCount(kvp.Key);
+            totalSize += System.Text.Encoding.UTF8.GetByteCount(kvp.Value);
+        }
+
+        if (totalSize > lambdaEnvVarLimitBytes)
+        {
+            Logger.LogError(
+                "Lambda function '{ResourceName}' environment variables total {TotalSize} bytes, which exceeds the AWS Lambda 4 KB ({LimitBytes} bytes) limit. Deployment will fail",
+                resourceName, totalSize, lambdaEnvVarLimitBytes);
+        }
+        else if (totalSize > lambdaEnvVarLimitBytes * warningThreshold)
+        {
+            Logger.LogWarning(
+                "Lambda function '{ResourceName}' environment variables total {TotalSize} bytes, approaching the AWS Lambda 4 KB ({LimitBytes} bytes) limit",
+                resourceName, totalSize, lambdaEnvVarLimitBytes);
+        }
     }
 }
 

--- a/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ProcessRelationShipsTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ProcessRelationShipsTests.cs
@@ -1,0 +1,337 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#pragma warning disable ASPIREAWSPUBLISHERS001
+#pragma warning disable ASPIRECOMPUTE001
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.AWS.Deployment;
+using Aspire.Hosting.AWS.Deployment.CDKPublishTargets;
+using Aspire.Hosting.AWS.Deployment.CDKDefaults;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using IResource = Aspire.Hosting.ApplicationModel.IResource;
+
+namespace Aspire.Hosting.AWS.UnitTests.Deployment;
+
+[Collection("CDKDeploymentTests")]
+public class ProcessRelationShipsTests
+{
+    /// <summary>
+    /// Tests that static string WithEnvironment values are resolved and added to env vars.
+    /// Covers issue #169 item 3: Inline static WithEnvironment values.
+    /// </summary>
+    [Fact]
+    public async Task ProcessRelationShipsAsync_WithEnvironment_StaticString_AddsToEnvironmentVariables()
+    {
+        // Arrange
+        var (target, connectionPoints) = CreateTestTarget();
+        var resource = new TestResource("test-resource");
+
+        // Simulate WithEnvironment("MY_KEY", "my-value") — Aspire registers an EnvironmentCallbackAnnotation
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
+        {
+            context.EnvironmentVariables["MY_KEY"] = "my-value";
+            return Task.CompletedTask;
+        }));
+
+        // Act
+        await target.TestProcessRelationShipsAsync(connectionPoints, resource);
+
+        // Assert
+        Assert.NotNull(connectionPoints.EnvironmentVariables);
+        Assert.True(connectionPoints.EnvironmentVariables.ContainsKey("MY_KEY"));
+        Assert.Equal("my-value", connectionPoints.EnvironmentVariables["MY_KEY"]);
+    }
+
+    /// <summary>
+    /// Tests that multiple static WithEnvironment calls are all resolved.
+    /// </summary>
+    [Fact]
+    public async Task ProcessRelationShipsAsync_WithEnvironment_MultipleStaticStrings_AllResolved()
+    {
+        // Arrange
+        var (target, connectionPoints) = CreateTestTarget();
+        var resource = new TestResource("test-resource");
+
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
+        {
+            context.EnvironmentVariables["KEY_A"] = "value-a";
+            context.EnvironmentVariables["KEY_B"] = "value-b";
+            return Task.CompletedTask;
+        }));
+
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
+        {
+            context.EnvironmentVariables["KEY_C"] = "value-c";
+            return Task.CompletedTask;
+        }));
+
+        // Act
+        await target.TestProcessRelationShipsAsync(connectionPoints, resource);
+
+        // Assert
+        Assert.Equal("value-a", connectionPoints.EnvironmentVariables!["KEY_A"]);
+        Assert.Equal("value-b", connectionPoints.EnvironmentVariables!["KEY_B"]);
+        Assert.Equal("value-c", connectionPoints.EnvironmentVariables!["KEY_C"]);
+    }
+
+    /// <summary>
+    /// Tests that WithEnvironment takes precedence over WithReference-derived env vars.
+    /// Covers issue #169 item 5.
+    /// </summary>
+    [Fact]
+    public async Task ProcessRelationShipsAsync_WithEnvironment_OverridesExistingEnvVars()
+    {
+        // Arrange
+        var (target, connectionPoints) = CreateTestTarget();
+        var resource = new TestResource("test-resource");
+
+        // Pre-populate env var (as if set by WithReference)
+        connectionPoints.EnvironmentVariables!["EXISTING_KEY"] = "original-value";
+
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
+        {
+            context.EnvironmentVariables["EXISTING_KEY"] = "overridden-value";
+            return Task.CompletedTask;
+        }));
+
+        // Act
+        await target.TestProcessRelationShipsAsync(connectionPoints, resource);
+
+        // Assert — WithEnvironment value takes precedence
+        Assert.Equal("overridden-value", connectionPoints.EnvironmentVariables!["EXISTING_KEY"]);
+    }
+
+    /// <summary>
+    /// Tests that IValueProvider env var values (like ParameterResource) are resolved.
+    /// Covers issue #169 item 2: Map ParameterResource values.
+    /// </summary>
+    [Fact]
+    public async Task ProcessRelationShipsAsync_WithEnvironment_IValueProvider_ResolvesValue()
+    {
+        // Arrange
+        var (target, connectionPoints) = CreateTestTarget();
+        var resource = new TestResource("test-resource");
+
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
+        {
+            context.EnvironmentVariables["PARAM_VALUE"] = new TestValueProvider("resolved-param-value");
+            return Task.CompletedTask;
+        }));
+
+        // Act
+        await target.TestProcessRelationShipsAsync(connectionPoints, resource);
+
+        // Assert
+        Assert.Equal("resolved-param-value", connectionPoints.EnvironmentVariables!["PARAM_VALUE"]);
+    }
+
+    /// <summary>
+    /// Tests that IValueProvider that resolves to null emits a warning and is skipped.
+    /// </summary>
+    [Fact]
+    public async Task ProcessRelationShipsAsync_WithEnvironment_IValueProvider_NullValue_SkippedWithWarning()
+    {
+        // Arrange
+        var mockLogger = new Mock<ILogger>();
+        var (target, connectionPoints) = CreateTestTarget(mockLogger.Object);
+        var resource = new TestResource("test-resource");
+
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
+        {
+            context.EnvironmentVariables["NULL_PARAM"] = new TestValueProvider(null);
+            return Task.CompletedTask;
+        }));
+
+        // Act
+        await target.TestProcessRelationShipsAsync(connectionPoints, resource);
+
+        // Assert — env var should not be added
+        Assert.False(connectionPoints.EnvironmentVariables!.ContainsKey("NULL_PARAM"));
+    }
+
+    /// <summary>
+    /// Tests that IValueProvider that throws is handled gracefully with a warning.
+    /// </summary>
+    [Fact]
+    public async Task ProcessRelationShipsAsync_WithEnvironment_IValueProvider_ThrowsException_SkippedWithWarning()
+    {
+        // Arrange
+        var mockLogger = new Mock<ILogger>();
+        var (target, connectionPoints) = CreateTestTarget(mockLogger.Object);
+        var resource = new TestResource("test-resource");
+
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
+        {
+            context.EnvironmentVariables["FAILING_PARAM"] = new FailingValueProvider();
+            return Task.CompletedTask;
+        }));
+
+        // Act — should not throw
+        await target.TestProcessRelationShipsAsync(connectionPoints, resource);
+
+        // Assert — env var should not be added
+        Assert.False(connectionPoints.EnvironmentVariables!.ContainsKey("FAILING_PARAM"));
+    }
+
+    /// <summary>
+    /// Tests that unsupported value types emit a warning and are skipped.
+    /// </summary>
+    [Fact]
+    public async Task ProcessRelationShipsAsync_WithEnvironment_UnsupportedType_SkippedWithWarning()
+    {
+        // Arrange
+        var mockLogger = new Mock<ILogger>();
+        var (target, connectionPoints) = CreateTestTarget(mockLogger.Object);
+        var resource = new TestResource("test-resource");
+
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
+        {
+            context.EnvironmentVariables["UNSUPPORTED"] = 42; // int, not string or IValueProvider
+            return Task.CompletedTask;
+        }));
+
+        // Act
+        await target.TestProcessRelationShipsAsync(connectionPoints, resource);
+
+        // Assert — env var should not be added
+        Assert.False(connectionPoints.EnvironmentVariables!.ContainsKey("UNSUPPORTED"));
+    }
+
+    /// <summary>
+    /// Tests that resources with no EnvironmentCallbackAnnotation work fine (no env vars modified).
+    /// </summary>
+    [Fact]
+    public async Task ProcessRelationShipsAsync_NoCallbacks_NoModification()
+    {
+        // Arrange
+        var (target, connectionPoints) = CreateTestTarget();
+        var resource = new TestResource("test-resource");
+
+        // No annotations added
+
+        // Act
+        await target.TestProcessRelationShipsAsync(connectionPoints, resource);
+
+        // Assert — env vars remain empty
+        Assert.NotNull(connectionPoints.EnvironmentVariables);
+        Assert.Empty(connectionPoints.EnvironmentVariables);
+    }
+
+    /// <summary>
+    /// Tests that callback context is created with Publish operation mode.
+    /// </summary>
+    [Fact]
+    public async Task ProcessRelationShipsAsync_WithEnvironment_UsesPublishMode()
+    {
+        // Arrange
+        var (target, connectionPoints) = CreateTestTarget();
+        var resource = new TestResource("test-resource");
+        DistributedApplicationOperation? capturedOperation = null;
+
+        resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
+        {
+            capturedOperation = context.ExecutionContext.Operation;
+            context.EnvironmentVariables["TEST"] = "test";
+            return Task.CompletedTask;
+        }));
+
+        // Act
+        await target.TestProcessRelationShipsAsync(connectionPoints, resource);
+
+        // Assert — should be in Publish mode
+        Assert.NotNull(capturedOperation);
+        Assert.Equal(DistributedApplicationOperation.Publish, capturedOperation);
+    }
+
+    #region Helpers
+
+    private static (TestPublishTarget target, TestConnectionPoints connectionPoints) CreateTestTarget(ILogger? logger = null)
+    {
+        logger ??= Mock.Of<ILogger>();
+        var target = new TestPublishTarget(logger);
+        var connectionPoints = new TestConnectionPoints();
+        return (target, connectionPoints);
+    }
+
+    /// <summary>
+    /// Minimal test resource implementing IResource.
+    /// </summary>
+    private class TestResource(string name) : IResource
+    {
+        public string Name => name;
+        public ResourceAnnotationCollection Annotations { get; } = new();
+    }
+
+    /// <summary>
+    /// Test IValueProvider that returns a configurable value.
+    /// </summary>
+    private class TestValueProvider(string? value) : IValueProvider
+    {
+        public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken = default)
+        {
+            return new ValueTask<string?>(value);
+        }
+    }
+
+    /// <summary>
+    /// Test IValueProvider that throws when resolved.
+    /// </summary>
+    private class FailingValueProvider : IValueProvider
+    {
+        public ValueTask<string?> GetValueAsync(CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("Cannot resolve this value during publish");
+        }
+    }
+
+    /// <summary>
+    /// Test connection points with simple dictionary-backed environment variables.
+    /// </summary>
+    private class TestConnectionPoints : AbstractCDKConstructConnectionPoints
+    {
+        private IDictionary<string, string>? _environmentVariables = new Dictionary<string, string>();
+
+        public override IDictionary<string, string>? EnvironmentVariables
+        {
+            get => _environmentVariables;
+            set => _environmentVariables = value;
+        }
+    }
+
+    /// <summary>
+    /// Concrete subclass of AbstractAWSPublishTarget that exposes ProcessRelationShipsAsync for testing.
+    /// </summary>
+    private class TestPublishTarget(ILogger logger) : AbstractAWSPublishTarget(logger)
+    {
+        public override string PublishTargetName => "Test";
+        public override Type PublishTargetAnnotation => typeof(object);
+
+        public override Task GenerateConstructAsync(AWSCDKEnvironmentResource environment, IResource resource,
+            IAWSPublishTargetAnnotation publishAnnotation, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override ReferenceConnectionInfo GetReferenceConnectionInfo(AWSLinkedObjectsAnnotation linkedAnnotation)
+        {
+            throw new NotImplementedException();
+        }
+
+        public override IsDefaultPublishTargetMatchResult IsDefaultPublishTargetMatch(CDKDefaultsProvider cdkDefaultsProvider, IResource resource)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Public wrapper to test the protected ProcessRelationShipsAsync method.
+        /// </summary>
+        public Task TestProcessRelationShipsAsync(AbstractCDKConstructConnectionPoints referencePoints, IResource resource)
+        {
+            return ProcessRelationShipsAsync(referencePoints, resource);
+        }
+    }
+
+    #endregion
+}

--- a/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ProcessRelationShipsTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ProcessRelationShipsTests.cs
@@ -104,30 +104,6 @@ public class ProcessRelationShipsTests
     }
 
     /// <summary>
-    /// Tests that IValueProvider env var values (like ParameterResource) are resolved.
-    /// Covers issue #169 item 2: Map ParameterResource values.
-    /// </summary>
-    [Fact]
-    public async Task ProcessRelationShipsAsync_WithEnvironment_IValueProvider_ResolvesValue()
-    {
-        // Arrange
-        var (target, connectionPoints) = CreateTestTarget();
-        var resource = new TestResource("test-resource");
-
-        resource.Annotations.Add(new EnvironmentCallbackAnnotation(context =>
-        {
-            context.EnvironmentVariables["PARAM_VALUE"] = new TestValueProvider("resolved-param-value");
-            return Task.CompletedTask;
-        }));
-
-        // Act
-        await target.TestProcessRelationShipsAsync(connectionPoints, resource);
-
-        // Assert
-        Assert.Equal("resolved-param-value", connectionPoints.EnvironmentVariables!["PARAM_VALUE"]);
-    }
-
-    /// <summary>
     /// Tests that IValueProvider that resolves to null emits a warning and is skipped.
     /// </summary>
     [Fact]


### PR DESCRIPTION
## Description

Resolve `WithEnvironment` callbacks during publish for all AWS compute targets. Previously, `EnvironmentCallbackAnnotation` entries (added by `.WithEnvironment()` calls) were silently dropped during publish — only `WithReference`-derived env vars were processed.

This PR adds three capabilities to the publish pipeline:

1. **EnvironmentCallbackAnnotation resolution** — Executes all `WithEnvironment` callbacks in publish mode and merges the resulting env vars into CDK construct properties. `WithEnvironment` values take precedence over `WithReference`-derived values.

2. **IValueProvider resolution** — Handles non-string env var values (e.g., `ParameterResource`, `ReferenceExpression`) by calling `GetValueAsync()` to resolve them at publish time. Values that resolve to null or throw exceptions are logged as warnings and skipped gracefully.

3. **Lambda 4KB env var limit warning** — Calculates total UTF-8 byte size of Lambda function environment variables and logs an error if exceeding 4096 bytes or a warning at 80% of the limit.

The core fix lives in `AbstractAWSPublishTarget.ProcessRelationShipsAsync()` (base class), so all 4 publish targets benefit: ECS Fargate, ECS Fargate Express, ECS Fargate with ALB, and Lambda.

## Motivation and Context

Fixes #169. Users calling `.WithEnvironment("KEY", "value")` on `ProjectResource` or `ContainerResource` expected those env vars to be present when deployed to AWS. Instead, they were silently dropped because the publish pipeline only processed `WithReference`-based env vars.

## Testing

- Added 9 new unit tests in `ProcessRelationShipsTests.cs` covering:
  - Static string values resolved and added
  - Multiple callbacks all invoked
  - `WithEnvironment` precedence over existing (WithReference-derived) env vars
  - `IValueProvider` values resolved (simulates ParameterResource)
  - Null-resolving `IValueProvider` skipped with warning
  - Exception-throwing `IValueProvider` handled gracefully
  - Unsupported value types skipped with warning
  - No-callback resources unaffected
  - Callback context uses Publish operation mode
- All 88 unit tests pass (0 failures)

## Breaking Changes Assessment

No breaking changes. The `ProcessRelationShips` → `ProcessRelationShipsAsync` method rename is behind the `[Experimental(ASPIREAWSPUBLISHERS001)]` attribute, so it is not part of the stable public API surface. The behavior change is additive — env vars that were previously dropped are now resolved.

## Screenshots (if appropriate)

N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
