### PR TITLE
Migrate release workflow auth to deploy key + per-repo FG PAT

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -29,19 +29,19 @@ jobs:
         with:
           role-to-assume: ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_ROLE_ARN }}
           aws-region: us-west-2
-      # Retrieve the Access Token from Secrets Manager
-      - name: Retrieve secret from AWS Secrets Manager
+      # Retrieve the per-repo deploy key + FG PAT from Secrets Manager
+      - name: Retrieve secrets from AWS Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
-            AWS_SECRET, ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_NAME }}
-          parse-json-secrets: true
-      # Checkout a full clone of the repo
+            DEPLOY_KEY, prod/devops/integrations-on-dotnet-aspire-for-aws-deploy-key
+            FG_PAT, prod/devops/integrations-on-dotnet-aspire-for-aws-fg-pat
+      # Checkout a full clone of the repo using the deploy key (push runs over SSH)
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: '0'
-          token: ${{ env.AWS_SECRET_TOKEN }}
+          ssh-key: ${{ env.DEPLOY_KEY }}
       # Install .NET9 which is needed for AutoVer
       - name: Setup .NET 9.0
         uses: actions/setup-dotnet@v5
@@ -94,7 +94,7 @@ jobs:
       # Create the Release PR and label it
       - name: Create Pull Request
         env:
-          GITHUB_TOKEN: ${{ env.AWS_SECRET_TOKEN }}
+          GITHUB_TOKEN: ${{ env.FG_PAT }}
         run: |
           pr_url="$(gh pr create --title "${{ steps.read-release-name.outputs.VERSION }}" --body "${{ steps.read-changelog.outputs.CHANGELOG }}" --base dev --head ${{ steps.create-release-branch.outputs.BRANCH }})"
           gh label create "Release PR" --description "A Release PR that includes versioning and changelog changes" -c "#FF0000" -f

--- a/.github/workflows/sync-main-dev.yml
+++ b/.github/workflows/sync-main-dev.yml
@@ -30,20 +30,20 @@ jobs:
         with:
           role-to-assume: ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_ROLE_ARN }}
           aws-region: us-west-2
-      # Retrieve the Access Token from Secrets Manager
-      - name: Retrieve secret from AWS Secrets Manager
+      # Retrieve the per-repo deploy key + FG PAT from Secrets Manager
+      - name: Retrieve secrets from AWS Secrets Manager
         uses: aws-actions/aws-secretsmanager-get-secrets@v2
         with:
           secret-ids: |
-            AWS_SECRET, ${{ secrets.RELEASE_WORKFLOW_ACCESS_TOKEN_NAME }}
-          parse-json-secrets: true
-      # Checkout a full clone of the repo
+            DEPLOY_KEY, prod/devops/integrations-on-dotnet-aspire-for-aws-deploy-key
+            FG_PAT, prod/devops/integrations-on-dotnet-aspire-for-aws-fg-pat
+      # Checkout a full clone of the repo using the deploy key (push runs over SSH)
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           ref: dev
           fetch-depth: 0
-          token: ${{ env.AWS_SECRET_TOKEN }}
+          ssh-key: ${{ env.DEPLOY_KEY }}
       # Install .NET8 which is needed for AutoVer
       - name: Setup .NET 9.0
         uses: actions/setup-dotnet@v5
@@ -85,7 +85,7 @@ jobs:
       # Create the GitHub Release
       - name: Create GitHub Release
         env:
-          GITHUB_TOKEN: ${{ env.AWS_SECRET_TOKEN }}
+          GITHUB_TOKEN: ${{ env.FG_PAT }}
         run: |
           gh release create "${{ steps.read-tag-name.outputs.TAG }}" --title "${{ steps.read-release-name.outputs.VERSION }}" --notes "${{ steps.read-changelog.outputs.CHANGELOG }}"
       # Delete the `releases/next-release` branch
@@ -104,7 +104,7 @@ jobs:
       github.event.pull_request.base.ref == 'dev'
     runs-on: ubuntu-latest
     steps:
-      # Checkout a full clone of the repo
+      # Checkout a full clone of the repo using the deploy key (push runs over SSH)
       - name: Checkout code
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
Switches release workflow authentication off the shared FG PAT onto:
- A per-repo **deploy key** for `git push` (via `actions/checkout` ssh-key auth).
- A per-repo **FG PAT** for GitHub API calls (`gh pr create`, `gh release create`).

## Files changed

`.github/workflows/create-release-pr.yml` and `.github/workflows/sync-main-dev.yml`:

1. **AWS Secrets Manager read** -- switches from a single shared SM secret to two per-repo SM secrets (`prod/devops/integrations-on-dotnet-aspire-for-aws-deploy-key` + `prod/devops/integrations-on-dotnet-aspire-for-aws-fg-pat`). Drops `parse-json-secrets: true` since the new SM secrets are raw strings.
2. **`actions/checkout`** -- switches from `token: ${{ env.AWS_SECRET_TOKEN }}` to `ssh-key: ${{ env.DEPLOY_KEY }}`. `git push` now runs over SSH.
3. **`gh` CLI calls** -- `GITHUB_TOKEN` env var swaps from `${{ env.AWS_SECRET_TOKEN }}` to `${{ env.FG_PAT }}`.

## Do not merge yet

This PR depends on `prod/devops/integrations-on-dotnet-aspire-for-aws-deploy-key` and `prod/devops/integrations-on-dotnet-aspire-for-aws-fg-pat` being populated on the bot's credential-storage account by the change-management workstream coordinating this rollout. Merging before then would break the next release run.

## Why

Aligns release workflow auth with internal per-repo credential scoping: 120-day FG PAT expiry, minimum scope, deploy-key push, and a DeployKey-bypass branch ruleset replacing the shared-PAT bypass.
