### PR TITLE
Fix Lambda class library WrapperProject failing to start on first aspire run

### DIFF
--- a/.autover/changes/1e8bc61a-1737-4c36-9c17-4f98da692c5e.json
+++ b/.autover/changes/1e8bc61a-1737-4c36-9c17-4f98da692c5e.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fix Lambda class library WrapperProject failing to start on first `aspire run` due to missing runtimeconfig.json"
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaBeforeStartEventHandler.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaBeforeStartEventHandler.cs
@@ -344,4 +344,10 @@ internal class LambdaBeforeStartEventHandler(ILogger<LambdaEmulatorResource> log
 internal sealed class LambdaProjectMetadata(string projectPath) : IProjectMetadata
 {
     public string ProjectPath { get; } = projectPath;
+
+    // The wrapper project is already built explicitly before DCP starts it.
+    // Setting SuppressBuild=true causes Aspire to pass --no-build to `dotnet run`,
+    // preventing an incremental build that skips GenerateBuildRuntimeConfigurationFiles
+    // and leaves runtimeconfig.json missing on first launch.
+    public bool SuppressBuild => true;
 }


### PR DESCRIPTION
## Summary

Fixes #171

### Root Cause

`SuppressBuild` was added to `IProjectMetadata` in Aspire 13.x. `LambdaProjectMetadata` never overrode it (defaults `false`), so Aspire DCP always invoked `dotnet run` **without** `--no-build` on the generated wrapper project.

This triggered an incremental build that skipped `GenerateBuildRuntimeConfigurationFiles` (MSBuild considers the outputs up-to-date from the explicit `dotnet build` that preceded it), leaving `WrapperMyLambdaFunction.runtimeconfig.json` missing. Without it, the .NET host treats the app as self-contained and fails with 

```
A fatal error was encountered. The library 'libhostpolicy.dylib' required to execute the application
was not found in '<DOTNET_ROOT>'.
Failed to run as a self-contained app.
- The application was run as a self-contained app because
  '.../<temp-guid>/bin/Debug/net10.0/WrapperMyFunction.runtimeconfig.json' was not found.
```

### Fix

Override `SuppressBuild => true` on `LambdaProjectMetadata`. The wrapper project is already explicitly built via `dotnet build` in `LambdaBeforeStartEventHandler` before DCP starts it, so passing `--no-build` to `dotnet run` is correct and sufficient.

### Testing

Reproduced with a minimal Aspire AppHost referencing a Lambda class library, running via `aspire run` (CLI, no debugger). Confirmed fix resolves the crash on first launch.