### PR TITLE
Add pull-requests write permission to workflow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   id-token: write
+  pull-requests: write
 
 jobs:
   release-pr:


### PR DESCRIPTION
https://github.com/cli/cli/issues/9166 trying to fix GraphQL: Resource not accessible by personal access token (repository.pullRequest.reviewRequests.nodes.0.requestedReviewer), Resource not accessible by personal access token (repository.pullRequest.reviewRequests.nodes.1.requestedReviewer)