### PR TITLE
Add DynamoDB Streams as Lambda event source

### DIFF
--- a/.autover/changes/9b9bb131-676c-4fc3-85a0-78b86d128d58.json
+++ b/.autover/changes/9b9bb131-676c-4fc3-85a0-78b86d128d58.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add support emulating Lambda DynamoDB Stream event source using the WithDynamoDBStreamsEventSource extension method"
+      ]
+    }
+  ]
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,18 +36,19 @@
     <PackageVersion Include="Amazon.Lambda.Core" Version="2.8.0" />
     <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="2.4.5" />
     <PackageVersion Include="Amazon.Lambda.APIGatewayEvents" Version="2.7.3" />
+    <PackageVersion Include="Amazon.Lambda.DynamoDBEvents" Version="3.1.2" />
     <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="2.2.1" />
     <PackageVersion Include="Amazon.AspNetCore.DataProtection.SSM" Version="4.0.1" />
     <!-- AWS CDK dependencies -->
     <PackageVersion Include="Amazon.CDK.Lib" Version="2.236.0" />
     <!-- Open Telemetry -->
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.13.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <!-- Test dependencies -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/integrations-on-dotnet-aspire-for-aws.sln
+++ b/integrations-on-dotnet-aspire-for-aws.sln
@@ -74,6 +74,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeploymentTestApp.AppHost",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DeploymentTestApp.LambdaFunction1", "testapps\DeploymentTestApps\DeploymentTestApp.LambdaFunction1\DeploymentTestApp.LambdaFunction1.csproj", "{1C19A43F-0B3D-F24C-7273-0434B4843BAC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DynamoDBProcessorFunction", "playground\Lambda\DynamoDBProcessorFunction\DynamoDBProcessorFunction.csproj", "{5A0B69C6-71C9-3F8E-AF38-2081A36F1342}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -180,6 +182,10 @@ Global
 		{1C19A43F-0B3D-F24C-7273-0434B4843BAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1C19A43F-0B3D-F24C-7273-0434B4843BAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1C19A43F-0B3D-F24C-7273-0434B4843BAC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A0B69C6-71C9-3F8E-AF38-2081A36F1342}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A0B69C6-71C9-3F8E-AF38-2081A36F1342}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A0B69C6-71C9-3F8E-AF38-2081A36F1342}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A0B69C6-71C9-3F8E-AF38-2081A36F1342}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -214,6 +220,7 @@ Global
 		{C75623F1-F0F8-4987-9577-105A06D66A37} = {D368C2F8-4037-440F-8E3D-C6C889399394}
 		{37C6999B-0176-AF8C-645C-0CB0BE706A40} = {D368C2F8-4037-440F-8E3D-C6C889399394}
 		{1C19A43F-0B3D-F24C-7273-0434B4843BAC} = {D368C2F8-4037-440F-8E3D-C6C889399394}
+		{5A0B69C6-71C9-3F8E-AF38-2081A36F1342} = {C3C0B096-DB7C-4D1B-B8A0-91631B32B4DE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FBA55172-92F1-4495-A082-E0ABE4F4AF09}

--- a/playground/Lambda/DynamoDBProcessorFunction/DynamoDBProcessorFunction.csproj
+++ b/playground/Lambda/DynamoDBProcessorFunction/DynamoDBProcessorFunction.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <AWSProjectType>Lambda</AWSProjectType>
+    <!-- This property makes the build directory similar to a publish directory and helps the AWS .NET Lambda Mock Test Tool find project dependencies. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- Generate ready to run images during publishing to improve cold start time. -->
+    <PublishReadyToRun>true</PublishReadyToRun>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Amazon.Lambda.Core" />
+    <PackageReference Include="Amazon.Lambda.Serialization.SystemTextJson" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Lambda.ServiceDefaults\Lambda.ServiceDefaults.csproj" />
+  </ItemGroup>	
+</Project>

--- a/playground/Lambda/DynamoDBProcessorFunction/Function.cs
+++ b/playground/Lambda/DynamoDBProcessorFunction/Function.cs
@@ -1,6 +1,5 @@
 using Amazon.Lambda.Core;
 using Amazon.Lambda.DynamoDBEvents;
-using Amazon.Lambda.SQSEvents;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpenTelemetry.Instrumentation.AWSLambda;

--- a/playground/Lambda/DynamoDBProcessorFunction/Function.cs
+++ b/playground/Lambda/DynamoDBProcessorFunction/Function.cs
@@ -15,6 +15,7 @@ public class Function
 {
     IHost _host;
     TracerProvider _traceProvider;
+    long _processedRecords = 0;
 
     public Function()
     {
@@ -33,13 +34,15 @@ public class Function
 
         foreach (var record in dynamoEvent.Records)
         {
+            _processedRecords++;
+
             context.Logger.LogInformation($"Event ID: {record.EventID}");
             context.Logger.LogInformation($"Event Name: {record.EventName}");
 
             // TODO: Add business logic processing the record.Dynamodb object.
         }
 
-        context.Logger.LogInformation("Stream processing complete.");
+        context.Logger.LogInformation("Stream processing complete. Total events processed {ProcessCount}", _processedRecords);
 
         return Task.CompletedTask;
     }, dynamoEvent, context);

--- a/playground/Lambda/DynamoDBProcessorFunction/Function.cs
+++ b/playground/Lambda/DynamoDBProcessorFunction/Function.cs
@@ -1,0 +1,46 @@
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DynamoDBEvents;
+using Amazon.Lambda.SQSEvents;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Instrumentation.AWSLambda;
+using OpenTelemetry.Trace;
+
+// Assembly attribute to enable the Lambda function's JSON input to be converted into a .NET class.
+[assembly: LambdaSerializer(typeof(Amazon.Lambda.Serialization.SystemTextJson.DefaultLambdaJsonSerializer))]
+
+namespace DynamoDBProcessorFunction;
+
+public class Function
+{
+    IHost _host;
+    TracerProvider _traceProvider;
+
+    public Function()
+    {
+        var builder = new HostApplicationBuilder();
+
+        builder.AddServiceDefaults();
+        _host = builder.Build();
+
+        _traceProvider = _host.Services.GetRequiredService<TracerProvider>();
+    }
+
+    public Task FunctionHandler(DynamoDBEvent dynamoEvent, ILambdaContext context)
+        => AWSLambdaWrapper.TraceAsync(_traceProvider, async (dynamoEvent, context) =>
+    {
+        context.Logger.LogInformation($"Beginning to process {dynamoEvent.Records.Count} records...");
+
+        foreach (var record in dynamoEvent.Records)
+        {
+            context.Logger.LogInformation($"Event ID: {record.EventID}");
+            context.Logger.LogInformation($"Event Name: {record.EventName}");
+
+            // TODO: Add business logic processing the record.Dynamodb object.
+        }
+
+        context.Logger.LogInformation("Stream processing complete.");
+
+        return Task.CompletedTask;
+    }, dynamoEvent, context);
+}

--- a/playground/Lambda/DynamoDBProcessorFunction/aws-lambda-tools-defaults.json
+++ b/playground/Lambda/DynamoDBProcessorFunction/aws-lambda-tools-defaults.json
@@ -1,0 +1,15 @@
+{
+  "Information": [
+    "This file provides default values for the deployment wizard inside Visual Studio and the AWS Lambda commands added to the .NET Core CLI.",
+    "To learn more about the Lambda commands with the .NET Core CLI execute the following command at the command line in the project root directory.",
+    "dotnet lambda help",
+    "All the command line options for the Lambda command can be specified in this file."
+  ],
+  "profile": "default",
+  "region": "us-west-2",
+  "configuration": "Release",
+  "function-runtime": "dotnet8",
+  "function-memory-size": 512,
+  "function-timeout": 30,
+  "function-handler": "DynamoDBProcessorFunction::DynamoDBProcessorFunction.Function::FunctionHandler"
+}

--- a/playground/Lambda/Lambda.AppHost/Lambda.AppHost.csproj
+++ b/playground/Lambda/Lambda.AppHost/Lambda.AppHost.csproj
@@ -13,6 +13,7 @@
 		<PackageReference Include="AWSSDK.SQS" />
 		<ProjectReference Include="..\..\..\src\Aspire.Hosting.AWS\Aspire.Hosting.AWS.csproj" IsAspireProjectResource="false" />
 		<PackageReference Include="Aspire.Hosting.AppHost" />
+		<ProjectReference Include="..\DynamoDBProcessorFunction\DynamoDBProcessorFunction.csproj" />
 		<ProjectReference Include="..\SQSProcessorFunction\SQSProcessorFunction.csproj" />
 		<ProjectReference Include="..\ToUpperLambdaFunctionExecutable\ToUpperLambdaFunctionExecutable.csproj" />
 		<ProjectReference Include="..\WebAWSCallsLambdaFunction\WebAWSCallsLambdaFunction.csproj" />

--- a/playground/Lambda/Lambda.AppHost/Program.cs
+++ b/playground/Lambda/Lambda.AppHost/Program.cs
@@ -1,8 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+using Amazon.CDK.AWS.DynamoDB;
 using Amazon.Lambda;
 using Aspire.Hosting.AWS.Lambda;
 
 var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddAWSLambdaServiceEmulator(new LambdaEmulatorOptions
+{
+    DisableAutoInstall = true
+});
 
 var awsSdkConfig = builder.AddAWSSDKConfig().WithRegion(Amazon.RegionEndpoint.USWest2);
 
@@ -11,6 +17,13 @@ cdkStackResource.WithTag("aws-repo", "integrations-on-dotnet-aspire-for-aws");
 
 var sqsDemoQueue1 = cdkStackResource.AddSQSQueue("DemoQueue1");
 var sqsDemoQueue2 = cdkStackResource.AddSQSQueue("DemoQueue2");
+
+var table = cdkStackResource.AddDynamoDBTable("DemoTable", new TableProps
+{
+    PartitionKey = new Amazon.CDK.AWS.DynamoDB.Attribute { Name = "Id", Type = AttributeType.STRING },
+    Stream = StreamViewType.NEW_AND_OLD_IMAGES,
+    BillingMode = BillingMode.PAY_PER_REQUEST
+});
 
 builder.AddAWSLambdaFunction<Projects.ToUpperLambdaFunctionExecutable>("ToUpperFunction", lambdaHandler: "ToUpperLambdaFunctionExecutable", new LambdaFunctionOptions { ApplicationLogLevel = ApplicationLogLevel.DEBUG, LogFormat = LogFormat.JSON });
 
@@ -40,6 +53,14 @@ builder.AddAWSLambdaFunction<Projects.SQSProcessorFunction>("SQSProcessorFunctio
         // CDK output parameters are not attempted to be added.
         .WithReference(sqsDemoQueue1)
         .WithReference(sqsDemoQueue2);
+
+
+builder.AddAWSLambdaFunction<Projects.DynamoDBProcessorFunction>("DynamoDBProcessorFunction", "DynamoDBProcessorFunction::DynamoDBProcessorFunction.Function::FunctionHandler")
+        .WithDynamoDBStreamsEventSource(table, new DynamoDBStreamsEventSourceOptions
+        {
+            BatchSize = 5
+        })
+        .WithDynamoDBStreamsEventSource("StreamingTest");
 
 
 builder.Build().Run();

--- a/playground/Lambda/Lambda.AppHost/Program.cs
+++ b/playground/Lambda/Lambda.AppHost/Program.cs
@@ -55,8 +55,7 @@ builder.AddAWSLambdaFunction<Projects.DynamoDBProcessorFunction>("DynamoDBProces
         .WithDynamoDBStreamsEventSource(table, new DynamoDBStreamsEventSourceOptions
         {
             BatchSize = 5
-        })
-        .WithDynamoDBStreamsEventSource("StreamingTest");
+        });
 
 
 builder.Build().Run();

--- a/playground/Publishing/Publishing.AppHost/aspire.config.json
+++ b/playground/Publishing/Publishing.AppHost/aspire.config.json
@@ -1,0 +1,8 @@
+{
+  "appHost": {
+    "path": "Publishing.AppHost.csproj"
+  },
+  "features": {
+    "execCommandEnabled": true
+  }
+}

--- a/src/Aspire.Hosting.AWS/Constants.cs
+++ b/src/Aspire.Hosting.AWS/Constants.cs
@@ -39,12 +39,12 @@ internal static class Constants
     /// <summary>
     /// The version of RuntimeSupport used in the executable wrapper project
     /// </summary>
-    internal const string RuntimeSupportPackageVersion = "1.14.2";
+    internal const string RuntimeSupportPackageVersion = "2.0.0";
     
     /// <summary>
     /// The default version of Amazon.Lambda.TestTool that will be automatically installed
     /// </summary>
-    internal const string DefaultLambdaTestToolVersion = "0.13.0";
+    internal const string DefaultLambdaTestToolVersion = "0.14.0";
 
     /// <summary>
     /// The default directory the Lambda Test Tool will be configured for storing configuration information like saved requests.

--- a/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.AWS/DynamoDB/DynamoDBLocalResourceBuilderExtensions.cs
@@ -2,6 +2,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.AWS.DynamoDB;
+using Aspire.Hosting.AWS.Lambda;
 
 namespace Aspire.Hosting;
 
@@ -71,6 +72,12 @@ public static class DynamoDBLocalResourceBuilderExtensions
         if (builder is IResourceBuilder<IResourceWithWaitSupport> waitSupport)
         {
             waitSupport.WaitFor(dynamoDBLocalResourceBuilder);
+        }
+
+        if (builder is IResourceBuilder<LambdaProjectResource> lambdaFunction)
+        {
+            // Store a reference to the DDB local in case the Lambda function is using the DynamoDB stream emulator and needs to configure the stream polling to connect to the DDB local instance.
+            lambdaFunction.Resource.DynamoDBLocalInstance = dynamoDBLocalResourceBuilder;
         }
 
         builder.WithEnvironment(context =>

--- a/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceExtensions.cs
@@ -120,6 +120,15 @@ public static class DynamoDBStreamsEventSourceExtensions
 
             var dynamoDBStreamsEventConfig = DynamoDBStreamsEventSourceResource.CreateDynamoDBStreamsEventConfig(resolvedTableName, lambdaFunction.Resource.Name, lambdaEmulatorAnnotation.LambdaRuntimeEndpoint.Url, options, awsSdkConfig);
             context.EnvironmentVariables[DynamoDBStreamsEventSourceResource.DYNAMODB_STREAMS_EVENT_CONFIG_ENV_VAR] = dynamoDBStreamsEventConfig;
+
+            if (lambdaFunction.Resource.DynamoDBLocalInstance != null)
+            {
+                // If the Lambda function has a reference to a DynamoDB local instance, then set the AWS_ENDPOINT_URL_DYNAMODB_STREAMS and AWS_ENDPOINT_URL_DYNAMODB_STREAMS environment variables to the endpoint of the DynamoDB local container.
+                // This will allow the DynamoDB Streams event source to connect to the DynamoDB local instance when polling for stream records.
+                var dynamoDBLocalEndpoint = lambdaFunction.Resource.DynamoDBLocalInstance.GetEndpoint("http");
+                context.EnvironmentVariables["AWS_ENDPOINT_URL_DYNAMODB"] = dynamoDBLocalEndpoint;
+                context.EnvironmentVariables["AWS_ENDPOINT_URL_DYNAMODB_STREAMS"] = dynamoDBLocalEndpoint;
+            }
         });
 
         return lambdaFunction;

--- a/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceExtensions.cs
@@ -1,0 +1,103 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.AWS;
+using Aspire.Hosting.AWS.CDK;
+using Aspire.Hosting.AWS.CloudFormation;
+using Aspire.Hosting.AWS.Lambda;
+
+#pragma warning disable IDE0130
+namespace Aspire.Hosting;
+
+/// <summary>
+/// Extension methods adding DynamoDB Streams event source for Lambda functions.
+/// </summary>
+public static class DynamoDBStreamsEventSourceExtensions
+{
+    /// <summary>
+    /// Add a DynamoDB Streams event source to a Lambda function. This feature emulates adding a DynamoDB Streams event source to a Lambda function when deployed to AWS.
+    /// A separate sub resource will be added to the .NET Aspire application that polls the DynamoDB stream. As records
+    /// are received from the stream the Lambda function will be invoked with the records.
+    /// </summary>
+    /// <param name="lambdaFunction">The Lambda function to add the event source to.</param>
+    /// <param name="tableName">The name of the DynamoDB table to read stream records from.</param>
+    /// <param name="options">Optional configuration for the event source.</param>
+    /// <returns></returns>
+    public static IResourceBuilder<LambdaProjectResource> WithDynamoDBStreamsEventSource(this IResourceBuilder<LambdaProjectResource> lambdaFunction, string tableName, DynamoDBStreamsEventSourceOptions? options = null)
+    {
+        return WithDynamoDBStreamsEventSource(lambdaFunction, () => ValueTask.FromResult(tableName), options);
+    }
+
+    /// <summary>
+    /// Add a DynamoDB Streams event source to a Lambda function. This feature emulates adding a DynamoDB Streams event source to a Lambda function when deployed to AWS.
+    /// A separate sub resource will be added to the .NET Aspire application that polls the DynamoDB stream. As records
+    /// are received from the stream the Lambda function will be invoked with the records.
+    /// </summary>
+    /// <param name="lambdaFunction">The Lambda function to add the event source to.</param>
+    /// <param name="table">CDK DynamoDB Table construct to read stream records from.</param>
+    /// <param name="options">Optional configuration for the event source.</param>
+    /// <returns></returns>
+    public static IResourceBuilder<LambdaProjectResource> WithDynamoDBStreamsEventSource(this IResourceBuilder<LambdaProjectResource> lambdaFunction, IResourceBuilder<IConstructResource<Amazon.CDK.AWS.DynamoDB.Table>> table, DynamoDBStreamsEventSourceOptions? options = null)
+    {
+        var tableNameOutputReference = table.GetOutput("TableName", table => table.TableName);
+        return WithDynamoDBStreamsEventSource(lambdaFunction, tableNameOutputReference, options);
+    }
+
+    /// <summary>
+    /// Add a DynamoDB Streams event source to a Lambda function. This feature emulates adding a DynamoDB Streams event source to a Lambda function when deployed to AWS.
+    /// A separate sub resource will be added to the .NET Aspire application that polls the DynamoDB stream. As records
+    /// are received from the stream the Lambda function will be invoked with the records.
+    /// </summary>
+    /// <param name="lambdaFunction">The Lambda function to add the event source to.</param>
+    /// <param name="tableNameCfnOutputReference">CloudFormation StackOutputReference that should point to a DynamoDB table name output parameter in the CloudFormation stack.</param>
+    /// <param name="options">Optional configuration for the event source.</param>
+    /// <returns></returns>
+    public static IResourceBuilder<LambdaProjectResource> WithDynamoDBStreamsEventSource(this IResourceBuilder<LambdaProjectResource> lambdaFunction, StackOutputReference tableNameCfnOutputReference, DynamoDBStreamsEventSourceOptions? options = null)
+    {
+        Func<ValueTask<string>> resolver = async () =>
+        {
+            var tableName = await tableNameCfnOutputReference.GetValueAsync();
+            if (string.IsNullOrEmpty(tableName))
+            {
+                throw new InvalidOperationException("Output parameter for table name failed to resolve");
+            }
+
+            return tableName;
+        };
+
+        return WithDynamoDBStreamsEventSource(lambdaFunction, resolver, options);
+    }
+
+    private static IResourceBuilder<LambdaProjectResource> WithDynamoDBStreamsEventSource(IResourceBuilder<LambdaProjectResource> lambdaFunction, Func<ValueTask<string>> tableNameResolver, DynamoDBStreamsEventSourceOptions? options = null)
+    {
+        var dynamoDBStreamsEventSourceResource = lambdaFunction.ApplicationBuilder.AddResource(new DynamoDBStreamsEventSourceResource($"DDBStreamsEventSource-{lambdaFunction.Resource.Name}"))
+                                    .WithParentRelationship(lambdaFunction)
+                                    .ExcludeFromManifest();
+
+        dynamoDBStreamsEventSourceResource.WithArgs(context =>
+        {
+            dynamoDBStreamsEventSourceResource.Resource.AddCommandLineArguments(context.Args);
+        });
+
+        dynamoDBStreamsEventSourceResource.WithEnvironment(async (context) =>
+        {
+            LambdaEmulatorAnnotation? lambdaEmulatorAnnotation = null;
+            if (lambdaFunction.ApplicationBuilder.Resources.FirstOrDefault(x => x.TryGetLastAnnotation<LambdaEmulatorAnnotation>(out lambdaEmulatorAnnotation)) == null ||
+                    lambdaEmulatorAnnotation == null)
+            {
+                throw new InvalidOperationException("Lambda function is missing required annotations for Lambda emulator");
+            }
+
+            var tableName = await tableNameResolver();
+
+            // Look to see if the Lambda function has been configured with an AWS SDK config. If so then
+            // configure the DynamoDB Streams event source with the same config to access the DynamoDB stream.
+            var awsSdkConfig = lambdaFunction.Resource.Annotations.OfType<SDKResourceAnnotation>().FirstOrDefault()?.SdkConfig;
+
+            var dynamoDBStreamsEventConfig = DynamoDBStreamsEventSourceResource.CreateDynamoDBStreamsEventConfig(tableName, lambdaFunction.Resource.Name, lambdaEmulatorAnnotation.LambdaRuntimeEndpoint.Url, options, awsSdkConfig);
+            context.EnvironmentVariables[DynamoDBStreamsEventSourceResource.DYNAMODB_STREAMS_EVENT_CONFIG_ENV_VAR] = dynamoDBStreamsEventConfig;
+        });
+
+        return lambdaFunction;
+    }
+}

--- a/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceExtensions.cs
@@ -5,6 +5,8 @@ using Aspire.Hosting.AWS;
 using Aspire.Hosting.AWS.CDK;
 using Aspire.Hosting.AWS.CloudFormation;
 using Aspire.Hosting.AWS.Lambda;
+using System.Security.Cryptography;
+using System.Text;
 
 #pragma warning disable IDE0130
 namespace Aspire.Hosting;
@@ -14,6 +16,8 @@ namespace Aspire.Hosting;
 /// </summary>
 public static class DynamoDBStreamsEventSourceExtensions
 {
+    private const int MaxResourceNameLength = 64;
+
     /// <summary>
     /// Add a DynamoDB Streams event source to a Lambda function. This feature emulates adding a DynamoDB Streams event source to a Lambda function when deployed to AWS.
     /// A separate sub resource will be added to the .NET Aspire application that polls the DynamoDB stream. As records
@@ -25,7 +29,7 @@ public static class DynamoDBStreamsEventSourceExtensions
     /// <returns></returns>
     public static IResourceBuilder<LambdaProjectResource> WithDynamoDBStreamsEventSource(this IResourceBuilder<LambdaProjectResource> lambdaFunction, string tableName, DynamoDBStreamsEventSourceOptions? options = null)
     {
-        return WithDynamoDBStreamsEventSource(lambdaFunction, () => ValueTask.FromResult(tableName), options);
+        return WithDynamoDBStreamsEventSource(lambdaFunction, () => ValueTask.FromResult(tableName), options, tableName: tableName);
     }
 
     /// <summary>
@@ -39,8 +43,19 @@ public static class DynamoDBStreamsEventSourceExtensions
     /// <returns></returns>
     public static IResourceBuilder<LambdaProjectResource> WithDynamoDBStreamsEventSource(this IResourceBuilder<LambdaProjectResource> lambdaFunction, IResourceBuilder<IConstructResource<Amazon.CDK.AWS.DynamoDB.Table>> table, DynamoDBStreamsEventSourceOptions? options = null)
     {
-        var tableNameOutputReference = table.GetOutput("TableName", table => table.TableName);
-        return WithDynamoDBStreamsEventSource(lambdaFunction, tableNameOutputReference, options);
+        var tableNameOutputReference = table.GetOutput("TableName", t => t.TableName);
+        var tableName = table.Resource.Name;
+        Func<ValueTask<string>> resolver = async () =>
+        {
+            var resolvedTableName = await tableNameOutputReference.GetValueAsync();
+            if (string.IsNullOrEmpty(resolvedTableName))
+            {
+                throw new InvalidOperationException("Output parameter for table name failed to resolve");
+            }
+
+            return resolvedTableName;
+        };
+        return WithDynamoDBStreamsEventSource(lambdaFunction, resolver, options, tableName);
     }
 
     /// <summary>
@@ -65,12 +80,21 @@ public static class DynamoDBStreamsEventSourceExtensions
             return tableName;
         };
 
-        return WithDynamoDBStreamsEventSource(lambdaFunction, resolver, options);
+        return WithDynamoDBStreamsEventSource(lambdaFunction, resolver, options, tableNameCfnOutputReference.Name);
     }
 
-    private static IResourceBuilder<LambdaProjectResource> WithDynamoDBStreamsEventSource(IResourceBuilder<LambdaProjectResource> lambdaFunction, Func<ValueTask<string>> tableNameResolver, DynamoDBStreamsEventSourceOptions? options = null)
+    private static IResourceBuilder<LambdaProjectResource> WithDynamoDBStreamsEventSource(IResourceBuilder<LambdaProjectResource> lambdaFunction, Func<ValueTask<string>> tableNameResolver, DynamoDBStreamsEventSourceOptions? options = null, string? tableName = null)
     {
-        var dynamoDBStreamsEventSourceResource = lambdaFunction.ApplicationBuilder.AddResource(new DynamoDBStreamsEventSourceResource($"DDBStreamsEventSource-{lambdaFunction.Resource.Name}"))
+        var lambdaName = lambdaFunction.Resource.Name;
+        var resourceName = !string.IsNullOrEmpty(options?.ResourceName)
+            ? options.ResourceName
+            : !string.IsNullOrEmpty(tableName)
+                ? $"DDBStreamsEventSource-{lambdaName}-{tableName}"
+                : $"DDBStreamsEventSource-{lambdaName}";
+
+        resourceName = EnsureResourceNameLength(resourceName, lambdaName, tableName);
+
+        var dynamoDBStreamsEventSourceResource = lambdaFunction.ApplicationBuilder.AddResource(new DynamoDBStreamsEventSourceResource(resourceName))
                                     .WithParentRelationship(lambdaFunction)
                                     .ExcludeFromManifest();
 
@@ -88,16 +112,48 @@ public static class DynamoDBStreamsEventSourceExtensions
                 throw new InvalidOperationException("Lambda function is missing required annotations for Lambda emulator");
             }
 
-            var tableName = await tableNameResolver();
+            var resolvedTableName = await tableNameResolver();
 
             // Look to see if the Lambda function has been configured with an AWS SDK config. If so then
             // configure the DynamoDB Streams event source with the same config to access the DynamoDB stream.
             var awsSdkConfig = lambdaFunction.Resource.Annotations.OfType<SDKResourceAnnotation>().FirstOrDefault()?.SdkConfig;
 
-            var dynamoDBStreamsEventConfig = DynamoDBStreamsEventSourceResource.CreateDynamoDBStreamsEventConfig(tableName, lambdaFunction.Resource.Name, lambdaEmulatorAnnotation.LambdaRuntimeEndpoint.Url, options, awsSdkConfig);
+            var dynamoDBStreamsEventConfig = DynamoDBStreamsEventSourceResource.CreateDynamoDBStreamsEventConfig(resolvedTableName, lambdaFunction.Resource.Name, lambdaEmulatorAnnotation.LambdaRuntimeEndpoint.Url, options, awsSdkConfig);
             context.EnvironmentVariables[DynamoDBStreamsEventSourceResource.DYNAMODB_STREAMS_EVENT_CONFIG_ENV_VAR] = dynamoDBStreamsEventConfig;
         });
 
         return lambdaFunction;
+    }
+
+    /// <summary>
+    /// Ensures the resource name does not exceed Aspire's 64-character limit.
+    /// When truncation is needed, uses a short hash of the table name to preserve uniqueness.
+    /// </summary>
+    private static string EnsureResourceNameLength(string resourceName, string lambdaName, string? tableName)
+    {
+        if (resourceName.Length <= MaxResourceNameLength)
+            return resourceName;
+
+        if (!string.IsNullOrEmpty(tableName))
+        {
+            var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(tableName)))[..8].ToLowerInvariant();
+
+            if (MaxResourceNameLength <= hash.Length)
+            {
+                return hash[..MaxResourceNameLength];
+            }
+
+            var prefix = $"DDBStreamsEventSource-{lambdaName}-";
+            var maxPrefixLength = MaxResourceNameLength - hash.Length;
+
+            if (prefix.Length > maxPrefixLength)
+            {
+                prefix = prefix[..maxPrefixLength];
+            }
+
+            return prefix + hash;
+        }
+
+        return resourceName[..MaxResourceNameLength];
     }
 }

--- a/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceExtensions.cs
@@ -123,7 +123,7 @@ public static class DynamoDBStreamsEventSourceExtensions
 
             if (lambdaFunction.Resource.DynamoDBLocalInstance != null)
             {
-                // If the Lambda function has a reference to a DynamoDB local instance, then set the AWS_ENDPOINT_URL_DYNAMODB_STREAMS and AWS_ENDPOINT_URL_DYNAMODB_STREAMS environment variables to the endpoint of the DynamoDB local container.
+                // If the Lambda function has a reference to a DynamoDB local instance, then set the AWS_ENDPOINT_URL_DYNAMODB and AWS_ENDPOINT_URL_DYNAMODB_STREAMS environment variables to the endpoint of the DynamoDB local container.
                 // This will allow the DynamoDB Streams event source to connect to the DynamoDB local instance when polling for stream records.
                 var dynamoDBLocalEndpoint = lambdaFunction.Resource.DynamoDBLocalInstance.GetEndpoint("http");
                 context.EnvironmentVariables["AWS_ENDPOINT_URL_DYNAMODB"] = dynamoDBLocalEndpoint;
@@ -145,7 +145,7 @@ public static class DynamoDBStreamsEventSourceExtensions
 
         if (!string.IsNullOrEmpty(tableName))
         {
-            var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(tableName)))[..8].ToLowerInvariant();
+            var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(lambdaName + ":" + tableName)))[..8].ToLowerInvariant();
 
             if (MaxResourceNameLength <= hash.Length)
             {

--- a/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceOptions.cs
@@ -17,4 +17,16 @@ public class DynamoDBStreamsEventSourceOptions
     /// The batch size to read from the DynamoDB stream and send to the Lambda function.
     /// </summary>
     public int? BatchSize { get; set; }
+
+    /// <summary>
+    /// The shard iterator type to use when reading from the stream.
+    /// Valid values: LATEST, TRIM_HORIZON. Default is LATEST.
+    /// </summary>
+    public string? ShardIteratorType { get; set; }
+
+    /// <summary>
+    /// The polling interval in milliseconds between stream reads when no records are found.
+    /// Default is 1000.
+    /// </summary>
+    public int? PollingIntervalMs { get; set; }
 }

--- a/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceOptions.cs
@@ -8,6 +8,12 @@ namespace Aspire.Hosting.AWS.Lambda;
 public class DynamoDBStreamsEventSourceOptions
 {
     /// <summary>
+    /// Optional unique resource name for the DynamoDBStreamsEventSourceResource. When adding multiple DynamoDB tables to the same Lambda,
+    /// set this to avoid duplicate resource name errors. If not set, the default pattern uses the Lambda and table names.
+    /// </summary>
+    public string? ResourceName { get; set; }
+
+    /// <summary>
     /// The batch size to read from the DynamoDB stream and send to the Lambda function.
     /// </summary>
     public int? BatchSize { get; set; }

--- a/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceOptions.cs
@@ -3,6 +3,22 @@
 namespace Aspire.Hosting.AWS.Lambda;
 
 /// <summary>
+/// The position in the stream where reading begins.
+/// </summary>
+public enum DynamoDBStreamsIteratorType
+{
+    /// <summary>
+    /// Start reading just after the most recent stream record, so you only process new records.
+    /// </summary>
+    Latest,
+
+    /// <summary>
+    /// Start reading at the last untrimmed record in the shard, processing all available records.
+    /// </summary>
+    TrimHorizon
+}
+
+/// <summary>
 /// Optional settings for configuring a DynamoDB Streams event source for a Lambda function.
 /// </summary>
 public class DynamoDBStreamsEventSourceOptions
@@ -19,10 +35,9 @@ public class DynamoDBStreamsEventSourceOptions
     public int? BatchSize { get; set; }
 
     /// <summary>
-    /// The shard iterator type to use when reading from the stream.
-    /// Valid values: LATEST, TRIM_HORIZON. Default is LATEST.
+    /// The position in the stream where reading begins. Default is <see cref="DynamoDBStreamsIteratorType.Latest"/>.
     /// </summary>
-    public string? ShardIteratorType { get; set; }
+    public DynamoDBStreamsIteratorType? ShardIteratorType { get; set; }
 
     /// <summary>
     /// The polling interval in milliseconds between stream reads when no records are found.

--- a/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceOptions.cs
@@ -3,22 +3,6 @@
 namespace Aspire.Hosting.AWS.Lambda;
 
 /// <summary>
-/// The position in the stream where reading begins.
-/// </summary>
-public enum DynamoDBStreamsIteratorType
-{
-    /// <summary>
-    /// Start reading just after the most recent stream record, so you only process new records.
-    /// </summary>
-    Latest,
-
-    /// <summary>
-    /// Start reading at the last untrimmed record in the shard, processing all available records.
-    /// </summary>
-    TrimHorizon
-}
-
-/// <summary>
 /// Optional settings for configuring a DynamoDB Streams event source for a Lambda function.
 /// </summary>
 public class DynamoDBStreamsEventSourceOptions
@@ -33,11 +17,6 @@ public class DynamoDBStreamsEventSourceOptions
     /// The batch size to read from the DynamoDB stream and send to the Lambda function.
     /// </summary>
     public int? BatchSize { get; set; }
-
-    /// <summary>
-    /// The position in the stream where reading begins. Default is <see cref="DynamoDBStreamsIteratorType.Latest"/>.
-    /// </summary>
-    public DynamoDBStreamsIteratorType? ShardIteratorType { get; set; }
 
     /// <summary>
     /// The polling interval in milliseconds between stream reads when no records are found.

--- a/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceOptions.cs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+namespace Aspire.Hosting.AWS.Lambda;
+
+/// <summary>
+/// Optional settings for configuring a DynamoDB Streams event source for a Lambda function.
+/// </summary>
+public class DynamoDBStreamsEventSourceOptions
+{
+    /// <summary>
+    /// The batch size to read from the DynamoDB stream and send to the Lambda function.
+    /// </summary>
+    public int? BatchSize { get; set; }
+}

--- a/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceOptions.cs
@@ -20,7 +20,7 @@ public class DynamoDBStreamsEventSourceOptions
 
     /// <summary>
     /// The polling interval in milliseconds between stream reads when no records are found.
-    /// Default is 1000.
+    /// If not set, uses the Lambda test tool default (currently 1000ms).
     /// </summary>
     public int? PollingIntervalMs { get; set; }
 }

--- a/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceResource.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceResource.cs
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+using Aspire.Hosting.ApplicationModel;
+using System.Text;
+
+namespace Aspire.Hosting.AWS.Lambda;
+
+internal class DynamoDBStreamsEventSourceResource(string name) : ExecutableResource(name,
+        "dotnet",
+        Environment.CurrentDirectory
+        )
+{
+    internal const string DYNAMODB_STREAMS_EVENT_CONFIG_ENV_VAR = "DYNAMODB_STREAMS_EVENTSOURCE_CONFIG";
+    internal void AddCommandLineArguments(IList<object> arguments)
+    {
+        arguments.Add("lambda-test-tool");
+        arguments.Add("start");
+        arguments.Add("--no-launch-window");
+
+        arguments.Add("--dynamodbstreams-eventsource-config");
+
+        // The TestTool will look for the config in the environment variable. The environment variable
+        // is used because the config contains information like port numbers and table names from CloudFormation
+        // stacks that haven't been resolved at the time of setting up the command line arguments.
+        arguments.Add($"env:{DYNAMODB_STREAMS_EVENT_CONFIG_ENV_VAR}");
+    }
+
+    internal static string CreateDynamoDBStreamsEventConfig(string tableName, string lambdaFunctionName, string lambdaEmulatorUrl, DynamoDBStreamsEventSourceOptions? options, IAWSSDKConfig? awsSdkConfig)
+    {
+        var configBuilder = new StringBuilder();
+        configBuilder.Append($"TableName={tableName},FunctionName={lambdaFunctionName},LambdaRuntimeApi={lambdaEmulatorUrl}");
+
+        if (options?.BatchSize.HasValue == true)
+        {
+            configBuilder.Append($",BatchSize={options.BatchSize.Value}");
+        }
+
+        if (awsSdkConfig != null)
+        {
+            if (!string.IsNullOrEmpty(awsSdkConfig.Profile))
+            {
+                configBuilder.Append($",Profile={awsSdkConfig.Profile}");
+            }
+            if (awsSdkConfig.Region != null)
+            {
+                configBuilder.Append($",Region={awsSdkConfig.Region.SystemName}");
+            }
+        }
+
+        return configBuilder.ToString();
+    }
+}

--- a/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceResource.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceResource.cs
@@ -35,16 +35,6 @@ internal class DynamoDBStreamsEventSourceResource(string name) : ExecutableResou
             configBuilder.Append($",BatchSize={options.BatchSize.Value}");
         }
 
-        if (options?.ShardIteratorType.HasValue == true)
-        {
-            var iteratorTypeValue = options.ShardIteratorType.Value switch
-            {
-                DynamoDBStreamsIteratorType.TrimHorizon => "TRIM_HORIZON",
-                _ => "LATEST"
-            };
-            configBuilder.Append($",ShardIteratorType={iteratorTypeValue}");
-        }
-
         if (options?.PollingIntervalMs.HasValue == true)
         {
             configBuilder.Append($",PollingIntervalMs={options.PollingIntervalMs.Value}");

--- a/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceResource.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceResource.cs
@@ -35,6 +35,16 @@ internal class DynamoDBStreamsEventSourceResource(string name) : ExecutableResou
             configBuilder.Append($",BatchSize={options.BatchSize.Value}");
         }
 
+        if (!string.IsNullOrEmpty(options?.ShardIteratorType))
+        {
+            configBuilder.Append($",ShardIteratorType={options.ShardIteratorType}");
+        }
+
+        if (options?.PollingIntervalMs.HasValue == true)
+        {
+            configBuilder.Append($",PollingIntervalMs={options.PollingIntervalMs.Value}");
+        }
+
         if (awsSdkConfig != null)
         {
             if (!string.IsNullOrEmpty(awsSdkConfig.Profile))

--- a/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceResource.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceResource.cs
@@ -35,9 +35,14 @@ internal class DynamoDBStreamsEventSourceResource(string name) : ExecutableResou
             configBuilder.Append($",BatchSize={options.BatchSize.Value}");
         }
 
-        if (!string.IsNullOrEmpty(options?.ShardIteratorType))
+        if (options?.ShardIteratorType.HasValue == true)
         {
-            configBuilder.Append($",ShardIteratorType={options.ShardIteratorType}");
+            var iteratorTypeValue = options.ShardIteratorType.Value switch
+            {
+                DynamoDBStreamsIteratorType.TrimHorizon => "TRIM_HORIZON",
+                _ => "LATEST"
+            };
+            configBuilder.Append($",ShardIteratorType={iteratorTypeValue}");
         }
 
         if (options?.PollingIntervalMs.HasValue == true)

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaProjectResource.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaProjectResource.cs
@@ -51,7 +51,7 @@ public class LambdaProjectResource : ProjectResource
     }
 
     /// <summary>
-    /// A reference to an instance of DynamoDB local that the Lambda function can use. This is set when the WithAWSDynamoDBLocal extension method is used on the project.
+    /// A reference to an instance of DynamoDB local that the Lambda function can use. This is set when the WithReference extension method is used on the project.
     /// </summary>
     internal IResourceBuilder<DynamoDBLocalResource>? DynamoDBLocalInstance { get; set; }
 

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaProjectResource.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaProjectResource.cs
@@ -2,6 +2,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.AWS.Deployment.Services;
+using Aspire.Hosting.AWS.DynamoDB;
 using Aspire.Hosting.Pipelines;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -48,6 +49,11 @@ public class LambdaProjectResource : ProjectResource
         }));
 
     }
+
+    /// <summary>
+    /// A reference to an instance of DynamoDB local that the Lambda function can use. This is set when the WithAWSDynamoDBLocal extension method is used on the project.
+    /// </summary>
+    internal IResourceBuilder<DynamoDBLocalResource>? DynamoDBLocalInstance { get; set; }
 
     private async Task BuildLambdaDeploymentBundle(PipelineStepContext ctx)
     {

--- a/tests/Aspire.Hosting.AWS.UnitTests/DynamoDBStreamsEventSourceConfigTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/DynamoDBStreamsEventSourceConfigTests.cs
@@ -1,0 +1,35 @@
+using Aspire.Hosting.AWS.Lambda;
+using Xunit;
+
+namespace Aspire.Hosting.AWS.UnitTests;
+
+public class DynamoDBStreamsEventSourceConfigTests
+{
+    [Fact]
+    public void Minimal()
+    {
+        var config = DynamoDBStreamsEventSourceResource.CreateDynamoDBStreamsEventConfig("theTable", "theFunction", "theEmulatorUrl", null, null);
+        Assert.Equal("TableName=theTable,FunctionName=theFunction,LambdaRuntimeApi=theEmulatorUrl", config);
+    }
+
+    [Fact]
+    public void WithOptions()
+    {
+        var config = DynamoDBStreamsEventSourceResource.CreateDynamoDBStreamsEventConfig("theTable", "theFunction", "theEmulatorUrl", new DynamoDBStreamsEventSourceOptions { BatchSize = 10 }, null);
+        Assert.Equal("TableName=theTable,FunctionName=theFunction,LambdaRuntimeApi=theEmulatorUrl,BatchSize=10", config);
+    }
+
+    [Fact]
+    public void WithSDKProfile()
+    {
+        var config = DynamoDBStreamsEventSourceResource.CreateDynamoDBStreamsEventConfig("theTable", "theFunction", "theEmulatorUrl", null, new AWSSDKConfig { Profile = "beta", Region = Amazon.RegionEndpoint.USWest2 });
+        Assert.Equal("TableName=theTable,FunctionName=theFunction,LambdaRuntimeApi=theEmulatorUrl,Profile=beta,Region=us-west-2", config);
+    }
+
+    [Fact]
+    public void WithOptionsAndProfile()
+    {
+        var config = DynamoDBStreamsEventSourceResource.CreateDynamoDBStreamsEventConfig("theTable", "theFunction", "theEmulatorUrl", new DynamoDBStreamsEventSourceOptions { BatchSize = 10 }, new AWSSDKConfig { Profile = "beta" });
+        Assert.Equal("TableName=theTable,FunctionName=theFunction,LambdaRuntimeApi=theEmulatorUrl,BatchSize=10,Profile=beta", config);
+    }
+}


### PR DESCRIPTION
## Summary

Adds DynamoDB Streams event source emulation and DynamoDB Local container support to the .NET Aspire hosting layer for AWS, enabling local testing of Lambda functions triggered by DynamoDB Streams without deploying to AWS.

PR is ready for review but kept in draft mode till [PR](https://github.com/aws/aws-lambda-dotnet/pull/2356) for the Lambda test tool is released.

## Features

### 1. DynamoDB Streams Event Source

Extension methods on `IResourceBuilder<LambdaProjectResource>` to wire up DynamoDB Streams as a Lambda trigger:

```csharp
builder.AddAWSLambdaFunction<Projects.DynamoDBProcessorFunction>("DynamoDBProcessorFunction", "...")
    .WithDynamoDBStreamsEventSource(table, new DynamoDBStreamsEventSourceOptions { BatchSize = 5 });
```

**Three input overloads:**
- `string tableName` — raw table name or stream ARN
- `IResourceBuilder<IConstructResource<Table>>` — CDK Table construct (resolves table name from CDK output)
- `StackOutputReference` — CloudFormation stack output reference

**Configuration options (`DynamoDBStreamsEventSourceOptions`):**
| Property | Default | Description |
|----------|---------|-------------|
| `ResourceName` | auto-generated | Custom resource name to avoid collisions |
| `BatchSize` | null (uses test tool default of 100) | Records per Lambda invocation |
| `PollingIntervalMs` | null (uses test tool default of 1000) | Delay between polls when idle |

**How it works:**
- Creates a `DynamoDBStreamsEventSourceResource` (executable resource) as a child of the Lambda function
- Launches `dotnet lambda-test-tool start --no-launch-window --dynamodbstreams-eventsource-config env:DYNAMODB_STREAMS_EVENTSOURCE_CONFIG`
- Serializes config into a comma-separated key=value string passed via environment variable
- Inherits AWS credentials from `.WithReference(awsSdkConfig)` (Profile/Region)

**Unique resource naming (bug fix):**
- Pattern: `DDBStreamsEventSource-{lambdaName}-{tableName}`
- SHA256 hash truncation when name exceeds Aspire's 64-char limit
- Explicit `ResourceName` override available for full control
- Fixes duplicate resource name exception when multiple tables target the same Lambda function

### 2. DynamoDB Local Container Support

Extension methods to run DynamoDB Local as a container resource in the Aspire app model:

```csharp
var dynamoDbLocal = builder.AddAWSDynamoDBLocal("DynamoDBLocal");
builder.AddAWSLambdaFunction<Projects.MyFunction>("MyFunction", "...")
    .WithReference(dynamoDbLocal);
```

**`AddAWSDynamoDBLocal()`** registers the DynamoDB Local container (ECR public image) with configurable options:
| Option | Description |
|--------|-------------|
| `SharedDb` | Use a single database file for all credentials/regions |
| `InMemory` | Run entirely in memory (no persistence) |
| `LocalStorageDirectory` | Mount path for persistent storage |
| `DisableDynamoDBLocalTelemetry` | Disable telemetry |
| `DelayTransientStatuses` | Simulate real DynamoDB transient states |
| `Port` | Container port |

**`WithReference()` for DynamoDB Local:**
- Sets `AWS_ENDPOINT_URL_DYNAMODB` environment variable on the target project/Lambda
- For `LambdaProjectResource`, stores the DynamoDB Local reference on the resource so the DynamoDB Streams event source poller can discover it and also set `AWS_ENDPOINT_URL_DYNAMODB_STREAMS`

### 3. DynamoDB Streams + DynamoDB Local Integration

When a Lambda function has both a DynamoDB Local reference and a DynamoDB Streams event source, the streams poller automatically receives the DynamoDB Local endpoint URLs (`AWS_ENDPOINT_URL_DYNAMODB` and `AWS_ENDPOINT_URL_DYNAMODB_STREAMS`), enabling fully local stream processing without any AWS connectivity.

## Playground Example

`playground/Lambda/` includes a complete working example:
- `DynamoDBProcessorFunction` — Lambda function that processes `DynamoDBEvent` records with OpenTelemetry tracing
- `Lambda.AppHost/Program.cs` — Wires up a CDK DynamoDB table with streams enabled and connects it to the processor function

## Dependencies

- Requires [aws-lambda-dotnet PR #2356](https://github.com/aws/aws-lambda-dotnet/pull/2356) for the test tool DynamoDB Streams poller

## Testing

5 unit tests across 2 test files:

### DynamoDB Streams Config Tests (`DynamoDBStreamsEventSourceConfigTests.cs`)
- `Minimal` — Config string with only required params (table, function, emulator URL)
- `WithOptions` — Config string includes BatchSize from options
- `WithSDKProfile` — Config string includes Profile and Region from AWSSDKConfig
- `WithOptionsAndProfile` — Config string includes both BatchSize and Profile

### DynamoDB Local Tests (`DynamoDBLocalCommandLineArgumentTests.cs`)
- `CommandLineArgumentTests` — Verifies DynamoDBLocalOptions properties are correctly converted to container command-line arguments
