### PR TITLE
Update to Aspire 13.3 and add support for "aspire destroy"

### DIFF
--- a/.autover/changes/a5700e1c-75bb-4899-b370-6d8d250c36d0.json
+++ b/.autover/changes/a5700e1c-75bb-4899-b370-6d8d250c36d0.json
@@ -1,0 +1,12 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Update to Aspire 13.3",
+        "Add support for deleting the CloudFormation stack as part of the 'aspire destroy' command"
+      ]
+    }
+  ]
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,23 +2,23 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <AspireSdkVersion>13.1.0</AspireSdkVersion>
+    <AspireSdkVersion>13.3.0</AspireSdkVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting" Version="13.1.0" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.1.0" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.1.0" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.1.0" />
-    <PackageVersion Include="Aspire.Hosting.Valkey" Version="13.1.0" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.1.0" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.1.0" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Dns" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.0" />	  
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />
+    <PackageVersion Include="Aspire.Hosting" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Hosting.Valkey" Version="13.3.0" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.3.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.3.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.3.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Dns" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.7" />	  
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <!-- AWS SDK for .NET dependencies -->
     <PackageVersion Include="AWSSDK.CloudFormation" Version="4.0.8.8" />
@@ -42,12 +42,12 @@
     <PackageVersion Include="Amazon.CDK.Lib" Version="2.236.0" />
     <!-- Open Telemetry -->
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AWS" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AWSLambda" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
     <!-- Test dependencies -->
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/src/Aspire.Hosting.AWS/Deployment/AWSCDKEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/AWSCDKEnvironmentExtensions.cs
@@ -27,6 +27,7 @@ public static class AWSCDKEnvironmentExtensions
         builder.Services.TryAddSingleton<IAWSEnvironmentService, DefaultAWSEnvironmentService>();
         builder.Services.TryAddSingleton<CDKPublishingStep, CDKPublishingStep>();
         builder.Services.TryAddSingleton<CDKDeployStep, CDKDeployStep>();
+        builder.Services.TryAddSingleton<CDKDestroyStep, CDKDestroyStep>();
         builder.Services.TryAddSingleton<ITarballContainerImageBuilder, DefaultTarballContainerImageBuilder>();
         builder.Services.TryAddSingleton<IProcessCommandService, ProcessCommandService>();
         builder.Services.TryAddSingleton<ILambdaDeploymentPackager, DefaultLambdaDeploymentPackager>();

--- a/src/Aspire.Hosting.AWS/Deployment/AWSCDKEnvironmentResource.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/AWSCDKEnvironmentResource.cs
@@ -69,6 +69,7 @@ public abstract class AWSCDKEnvironmentResource : Resource, IComputeEnvironmentR
 
         Annotations.Add(new PipelineStepAnnotation(ConfigurePublishPipelineStep));
         Annotations.Add(new PipelineStepAnnotation(ConfigureDeployPipelineStep));
+        Annotations.Add(new PipelineStepAnnotation(ConfigureDestroyPipelineStep));
     }
 
     private App? _cdkApp;
@@ -158,6 +159,25 @@ public abstract class AWSCDKEnvironmentResource : Resource, IComputeEnvironmentR
 
         return deployStep;
     }
+    
+    private PipelineStep ConfigureDestroyPipelineStep(PipelineStepFactoryContext factoryContext)
+    {
+        var model = factoryContext.PipelineContext.Model;
+
+        var step = new PipelineStep
+        {
+            Name = $"destroy-{Name}",
+            Action = async (context) =>
+            {
+                var cdkCtx = context.Services.GetRequiredService<CDKDestroyStep>();
+                await cdkCtx.ExecuteCDKDestroyAsync(context, model, this);
+            },
+            RequiredBySteps = [WellKnownPipelineSteps.Destroy],
+            DependsOnSteps = [WellKnownPipelineSteps.DestroyPrereq]
+        };
+
+        return step;
+    }    
 
     protected IEnvironment GetCDKEnvironment()
     {

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDestroyStep.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDestroyStep.cs
@@ -1,19 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.InteropServices;
 using Amazon.CloudFormation;
 using Amazon.CloudFormation.Model;
 using Aspire.Hosting.ApplicationModel;
-using Aspire.Hosting.AWS.Utils;
-using Aspire.Hosting.AWS.Utils.Internal;
 using Aspire.Hosting.Pipelines;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.AWS.Deployment;
 
 [Experimental(Constants.ASPIREAWSPUBLISHERS001)]
-internal class CDKDestroyStep(ILogger<CDKDeployStep> logger)
+internal class CDKDestroyStep(ILogger<CDKDestroyStep> logger)
 {
     // CloudFormation statuses for when the stack is in transition all end with IN_PROGRESS
     const string IN_PROGRESS_SUFFIX = "IN_PROGRESS";
@@ -75,7 +72,7 @@ internal class CDKDestroyStep(ILogger<CDKDeployStep> logger)
         Stack? stack;
         do
         {
-            await Task.Delay(StackPollingDelay);
+            await Task.Delay(StackPollingDelay, cancellationToken);
             stack = await GetExistingStackAsync(cfClient, stackName, cancellationToken);
             
             var events = await GetLatestEventsAsync(cfClient, stackName, mintimeStampForEvents, mostRecentEventId, cancellationToken);

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDestroyStep.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDestroyStep.cs
@@ -1,0 +1,160 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+using Amazon.CloudFormation;
+using Amazon.CloudFormation.Model;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.AWS.Utils;
+using Aspire.Hosting.AWS.Utils.Internal;
+using Aspire.Hosting.Pipelines;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.AWS.Deployment;
+
+[Experimental(Constants.ASPIREAWSPUBLISHERS001)]
+internal class CDKDestroyStep(ILogger<CDKDeployStep> logger)
+{
+    // CloudFormation statuses for when the stack is in transition all end with IN_PROGRESS
+    const string IN_PROGRESS_SUFFIX = "IN_PROGRESS";
+    static readonly TimeSpan StackPollingDelay = TimeSpan.FromSeconds(3);
+    
+    public async Task ExecuteCDKDestroyAsync(PipelineStepContext context, DistributedApplicationModel model, AWSCDKEnvironmentResource environment, CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Executing aws destroy");
+        
+        environment.InitializeCDKApp(logger, Path.GetTempPath());
+
+        using var cfClient = environment.GetCloudFormationClient();
+
+        await ExecuteCDKDestroyCLIAsync(cfClient, context, environment, cancellationToken);
+    }
+    
+    private async Task ExecuteCDKDestroyCLIAsync(AmazonCloudFormationClient cfClient, PipelineStepContext context, AWSCDKEnvironmentResource environment, CancellationToken cancellationToken)
+    {
+        var step = await context.ReportingStep.CreateTaskAsync($"Initiating CloudFormation Stack deletion: {environment.CDKStack.StackName}", cancellationToken);
+        try
+        {
+            var deleteRequest = new DeleteStackRequest
+            {
+                StackName = environment.CDKStack.StackName
+            };
+
+            var mintimeStampForEvents = DateTime.UtcNow;
+            await cfClient.DeleteStackAsync(deleteRequest, cancellationToken);
+
+            await WaitStackToCompleteAsync(cfClient, environment.CDKStack.StackName, mintimeStampForEvents, cancellationToken);
+
+            await step.SucceedAsync(cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Failed to delete CloudFormation Stack");
+            await step.FailAsync($"Failed to delete CloudFormation Stack: {ex}", cancellationToken);
+        }
+    }   
+    
+    private async Task<Stack?> WaitStackToCompleteAsync(AmazonCloudFormationClient cfClient, string stackName, DateTime mintimeStampForEvents, CancellationToken cancellationToken)
+    {
+        const int TIMESTAMP_WIDTH = 20;
+        const int LOGICAL_RESOURCE_WIDTH = 40;
+        const int RESOURCE_STATUS = 40;
+        string mostRecentEventId = "";
+        
+        // Write header for the status table.
+        logger.LogInformation("   ");
+        logger.LogInformation(
+            "Timestamp".PadRight(TIMESTAMP_WIDTH) + " " +
+            "Logical Resource Id".PadRight(LOGICAL_RESOURCE_WIDTH) + " " +
+            "Status".PadRight(RESOURCE_STATUS) + " ");
+        logger.LogInformation(
+            new string('-', TIMESTAMP_WIDTH) + " " +
+            new string('-', LOGICAL_RESOURCE_WIDTH) + " " +
+            new string('-', RESOURCE_STATUS) + " ");
+
+        Stack? stack;
+        do
+        {
+            await Task.Delay(StackPollingDelay);
+            stack = await GetExistingStackAsync(cfClient, stackName, cancellationToken);
+            
+            var events = await GetLatestEventsAsync(cfClient, stackName, mintimeStampForEvents, mostRecentEventId, cancellationToken);
+            if (events.Count > 0)
+                mostRecentEventId = events[0].EventId;
+
+            for (int i = events.Count - 1; i >= 0; i--)
+            {
+                string line =
+                    events[i].Timestamp.GetValueOrDefault().ToLocalTime().ToString("g").PadRight(TIMESTAMP_WIDTH) + " " +
+                    events[i].LogicalResourceId.PadRight(LOGICAL_RESOURCE_WIDTH) + " " +
+                    events[i].ResourceStatus.ToString().PadRight(RESOURCE_STATUS);
+
+                // To save screen space only show error messages.
+                if (!events[i].ResourceStatus.ToString().EndsWith(IN_PROGRESS_SUFFIX) && !string.IsNullOrEmpty(events[i].ResourceStatusReason))
+                    line += " " + events[i].ResourceStatusReason;
+
+                logger.LogInformation(line);
+            }
+
+        } while (stack != null && stack.StackStatus.ToString().EndsWith(IN_PROGRESS_SUFFIX));
+
+        return stack;
+    }
+
+    private async Task<List<StackEvent>> GetLatestEventsAsync(AmazonCloudFormationClient cfClient, string stackName, DateTime mintimeStampForEvents, string mostRecentEventId, CancellationToken cancellationToken)
+    {
+        bool noNewEvents = false;
+        List<StackEvent> events = new List<StackEvent>();
+        DescribeStackEventsResponse? response = null;
+        do
+        {
+            var request = new DescribeStackEventsRequest() { StackName = stackName };
+            if (response != null)
+                request.NextToken = response.NextToken;
+
+            try
+            {
+                response = await cfClient.DescribeStackEventsAsync(request, cancellationToken);
+            }
+            catch (AmazonCloudFormationException e) when 
+                (e.StatusCode == System.Net.HttpStatusCode.BadRequest && string.Equals(e.ErrorCode, "ValidationError", StringComparison.InvariantCultureIgnoreCase))
+            {
+                // This will happen once the stack is completely deleted.
+                break;
+            }
+            catch (Exception e)
+            {
+                throw new ApplicationException($"Error getting events for stack: {e.Message}", e);
+            }
+            foreach (var evnt in response.StackEvents ?? new List<StackEvent>())
+            {
+                if (string.Equals(evnt.EventId, mostRecentEventId) || evnt.Timestamp < mintimeStampForEvents)
+                {
+                    noNewEvents = true;
+                    break;
+                }
+
+                events.Add(evnt);
+            }
+
+        } while (!noNewEvents && !string.IsNullOrEmpty(response.NextToken));
+
+        return events;
+    }
+    
+    public async Task<Stack?> GetExistingStackAsync(AmazonCloudFormationClient cfClient, string stackName, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await cfClient.DescribeStacksAsync(new DescribeStacksRequest { StackName = stackName }, cancellationToken);
+            if (response.Stacks == null || response.Stacks.Count != 1)
+                return null;
+
+            return response.Stacks[0];
+        }
+        catch (AmazonCloudFormationException)
+        {
+            return null;
+        }
+    }        
+}

--- a/tests/Aspire.Hosting.AWS.UnitTests/Deployment/CDKDestroyStepTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/Deployment/CDKDestroyStepTests.cs
@@ -1,0 +1,135 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#pragma warning disable ASPIREAWSPUBLISHERS001
+#pragma warning disable ASPIRECOMPUTE001
+#pragma warning disable ASPIREINTERACTION001
+#pragma warning disable ASPIREPIPELINES001
+
+using Amazon.CDK;
+using Aspire.Hosting.AWS.Deployment;
+using Aspire.Hosting.AWS.Deployment.CDKDefaults;
+using Aspire.Hosting.Pipelines;
+using Constructs;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Aspire.Hosting.AWS.UnitTests.Deployment;
+
+[Collection("CDKDeploymentTests")]
+public class CDKDestroyStepTests
+{
+
+
+    [Fact]
+    public void CDKDestroyStep_IsRegistered_InServiceCollection()
+    {
+        // Arrange
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            Args = ["--operation", "publish", "--step", "publish"]
+        });
+
+        // Act
+        builder.AddAWSCDKEnvironment("TestEnv", CDKDefaultsProviderFactory.Preview_V1);
+        var services = builder.Services.BuildServiceProvider();
+
+        // Assert
+        var destroyStep = services.GetService<CDKDestroyStep>();
+        Assert.NotNull(destroyStep);
+    }
+
+    [Fact]
+    public void CDKDestroyStep_IsRegistered_AsSingleton()
+    {
+        // Arrange
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            Args = ["--operation", "publish", "--step", "publish"]
+        });
+        builder.AddAWSCDKEnvironment("TestEnv", CDKDefaultsProviderFactory.Preview_V1);
+        var services = builder.Services.BuildServiceProvider();
+
+        // Act
+        var instance1 = services.GetService<CDKDestroyStep>();
+        var instance2 = services.GetService<CDKDestroyStep>();
+
+        // Assert
+        Assert.Same(instance1, instance2);
+    }
+
+    [Fact]
+    public void MultipleEnvironments_EachHave_DestroyAnnotation()
+    {
+        // Arrange
+        var app1 = new App();
+        var stack1 = new TestStack(app1, "Stack1", null);
+        var env1 = new AWSCDKEnvironmentResource<Stack>(
+            "env1",
+            isPublishMode: true,
+            CDKDefaultsProviderFactory.Preview_V1,
+            (a, props) => stack1,
+            null);
+
+        var app2 = new App();
+        var stack2 = new TestStack(app2, "Stack2", null);
+        var env2 = new AWSCDKEnvironmentResource<Stack>(
+            "env2",
+            isPublishMode: true,
+            CDKDefaultsProviderFactory.Preview_V1,
+            (a, props) => stack2,
+            null);
+
+        // Act
+        var annotations1 = env1.Annotations.OfType<PipelineStepAnnotation>().ToList();
+        var annotations2 = env2.Annotations.OfType<PipelineStepAnnotation>().ToList();
+
+        // Assert - each environment should have its own set of 3 pipeline annotations
+        Assert.Equal(3, annotations1.Count);
+        Assert.Equal(3, annotations2.Count);
+    }
+
+    [Fact]
+    public void DestroyAnnotation_IsDistinct_FromPublishAndDeployAnnotations()
+    {
+        // Arrange
+        var app = new App();
+        var stack = new TestStack(app, "TestStack", null);
+        var environment = new AWSCDKEnvironmentResource<Stack>(
+            "test-env",
+            isPublishMode: true,
+            CDKDefaultsProviderFactory.Preview_V1,
+            (a, props) => stack,
+            null);
+
+        // Act
+        var pipelineAnnotations = environment.Annotations
+            .OfType<PipelineStepAnnotation>()
+            .ToList();
+
+        // Assert - all three annotations should be distinct instances
+        Assert.Equal(3, pipelineAnnotations.Distinct().Count());
+    }
+
+    [Fact]
+    public void CDKDestroyStep_CanBeResolved_WithDependencies()
+    {
+        // Arrange
+        var builder = DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            Args = ["--operation", "publish", "--step", "publish"]
+        });
+        builder.AddAWSCDKEnvironment("TestEnv", CDKDefaultsProviderFactory.Preview_V1);
+        var services = builder.Services.BuildServiceProvider();
+
+        // Act & Assert - CDKDestroyStep should resolve without throwing
+        var destroyStep = services.GetRequiredService<CDKDestroyStep>();
+        Assert.NotNull(destroyStep);
+    }
+
+    private class TestStack : Stack
+    {
+        public TestStack(Construct scope, string id, IStackProps? props = null) : base(scope, id, props)
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Description
Update the dependencies to version Aspire 13.3. There is a new "aspire destroy" feature in 13.3 that is used for providers to connect into destroy the deployed application. This PR connects our provider to that and then deletes the CloudFormation stack.