### PR TITLE
Add support for custom container runtime (e.g. podman) in CDK publish

### DIFF
--- a/.autover/changes/768887e7-e141-465b-b633-430c1d9e5343.json
+++ b/.autover/changes/768887e7-e141-465b-b633-430c1d9e5343.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Add support for custom container runtime (e.g. podman) in CDK publish"
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishingStep.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishingStep.cs
@@ -225,8 +225,8 @@ internal class CDKPublishingStep(IServiceProvider serviceProvider, ILogger<CDKPu
 
                         if (imageObject["source"]?["executable"] is JsonArray)
                         {
-                            // Replace the executable array
-                            imageObject["source"]!["executable"] = new JsonArray("powershell", "-Command", $"docker load -i asset.{image.Key}.tar | ForEach-Object {{ ($_ -replace '^Loaded image: ', '') }}");
+                            var runtime = Environment.GetEnvironmentVariable("ASPIRE_CONTAINER_RUNTIME") ?? "docker";
+                            imageObject["source"]!["executable"] = new JsonArray("powershell", "-Command", $"{runtime} load -i asset.{image.Key}.tar | ForEach-Object {{ ($_ -replace '^Loaded image: ', '') }}");
                             changed = true;
                         }
                     }

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishingStep.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishingStep.cs
@@ -45,7 +45,8 @@ internal class CDKPublishingStep(IServiceProvider serviceProvider, ILogger<CDKPu
 
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && !environment.Config.DisablePlatformCorrection)
             {
-                FixCDKAssetsFileForWindows(outputPath);
+                var containerRuntime = await serviceProvider.GetRequiredService<IContainerRuntimeResolver>().ResolveAsync(cancellationToken);
+                FixCDKAssetsFileForWindows(outputPath, containerRuntime.Name);
             }
 
             await step.SucceedAsync(cancellationToken: cancellationToken);
@@ -205,7 +206,7 @@ internal class CDKPublishingStep(IServiceProvider serviceProvider, ILogger<CDKPu
         }
     }
 
-    private void FixCDKAssetsFileForWindows(string outputPath)
+    private void FixCDKAssetsFileForWindows(string outputPath, string runtimeName)
     {
         foreach (var file in Directory.EnumerateFiles(outputPath, "*.assets.json", SearchOption.AllDirectories))
         {
@@ -217,14 +218,13 @@ internal class CDKPublishingStep(IServiceProvider serviceProvider, ILogger<CDKPu
 
                 if (root["dockerImages"] is JsonObject dockerImages)
                 {
-                    var runtime = serviceProvider.GetRequiredService<IContainerRuntime>().Name;
                     foreach (var image in dockerImages)
                     {
                         JsonObject imageObject = image.Value!.AsObject();
 
                         if (imageObject["source"]?["executable"] is JsonArray)
                         {
-                            imageObject["source"]!["executable"] = new JsonArray("powershell", "-Command", $"& '{runtime}' load -i asset.{image.Key}.tar | ForEach-Object {{ ($_ -replace '^Loaded image: ', '') }}");
+                            imageObject["source"]!["executable"] = new JsonArray("powershell", "-Command", $"& '{runtimeName}' load -i asset.{image.Key}.tar | ForEach-Object {{ ($_ -replace '^Loaded image: ', '') }}");
                             changed = true;
                         }
                     }

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishingStep.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishingStep.cs
@@ -1,13 +1,11 @@
 ﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-#pragma warning disable ASPIREPUBLISHERS001
-#pragma warning disable ASPIREAWSPUBLISHERS001
-
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.AWS.CDK;
 using Aspire.Hosting.AWS.Deployment.CDKPublishTargets;
 using Aspire.Hosting.AWS.Utils.Internal;
 using Aspire.Hosting.Pipelines;
+using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System.Collections.ObjectModel;
@@ -219,14 +217,14 @@ internal class CDKPublishingStep(IServiceProvider serviceProvider, ILogger<CDKPu
 
                 if (root["dockerImages"] is JsonObject dockerImages)
                 {
+                    var runtime = serviceProvider.GetRequiredService<IContainerRuntime>().Name;
                     foreach (var image in dockerImages)
                     {
                         JsonObject imageObject = image.Value!.AsObject();
 
                         if (imageObject["source"]?["executable"] is JsonArray)
                         {
-                            var runtime = Environment.GetEnvironmentVariable("ASPIRE_CONTAINER_RUNTIME") ?? "docker";
-                            imageObject["source"]!["executable"] = new JsonArray("powershell", "-Command", $"{runtime} load -i asset.{image.Key}.tar | ForEach-Object {{ ($_ -replace '^Loaded image: ', '') }}");
+                            imageObject["source"]!["executable"] = new JsonArray("powershell", "-Command", $"& '{runtime}' load -i asset.{image.Key}.tar | ForEach-Object {{ ($_ -replace '^Loaded image: ', '') }}");
                             changed = true;
                         }
                     }

--- a/src/Aspire.Hosting.AWS/Deployment/Services/DefaultTarballContainerImageBuilder.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/Services/DefaultTarballContainerImageBuilder.cs
@@ -1,41 +1,27 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-using System.Runtime.InteropServices;
+#pragma warning disable ASPIRECONTAINERRUNTIME001
+
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.AWS.Utils.Internal;
+using Aspire.Hosting.Publishing;
 using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.AWS.Deployment.Services;
 
-internal class DefaultTarballContainerImageBuilder(ILogger<DefaultTarballContainerImageBuilder> logger, IProcessCommandService processCommandService) : ITarballContainerImageBuilder
+internal class DefaultTarballContainerImageBuilder(ILogger<DefaultTarballContainerImageBuilder> logger, IProcessCommandService processCommandService, IContainerRuntime containerRuntime) : ITarballContainerImageBuilder
 {
     public async Task<string> CreateTarballImageAsync(ProjectResource resource, CancellationToken cancellationToken)
     {
         var tarballFilePath = Path.GetTempFileName() + ".tar";
 
         var imageTag = resource.Name.ToLower() + ":latest";
-        var runtime = Environment.GetEnvironmentVariable("ASPIRE_CONTAINER_RUNTIME") ?? "docker";
-        var dockerSaveCommand = $"{runtime} save -o {tarballFilePath} {imageTag}";
-        string shellCommand;
-        string arguments;
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            shellCommand = "cmd";
-            arguments = $"/c \"{dockerSaveCommand}\"";
-        }
-        else
-        {
-            shellCommand = "sh";
-            arguments = $"-c \"{dockerSaveCommand}\"";
-        }
-
-        var results = await processCommandService.RunProcessAndCaptureOutputAsync(logger, shellCommand, arguments, Environment.CurrentDirectory, cancellationToken);
+        var results = await processCommandService.RunProcessAndCaptureOutputAsync(logger, containerRuntime.Name, $"save -o {tarballFilePath} {imageTag}", Environment.CurrentDirectory, cancellationToken);
         if (results.ExitCode != 0)
         {
             logger.LogError("Failed to save container image {ImageTag} as tarball for publish assets. Exit Code: {ExitCode}, Output: {Output}", imageTag, results.ExitCode, results.Output);
             throw new InvalidOperationException($"Failed to save container image {resource.Name} as tarball for publish assets.");
         }
-        
 
         return tarballFilePath;
     }

--- a/src/Aspire.Hosting.AWS/Deployment/Services/DefaultTarballContainerImageBuilder.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/Services/DefaultTarballContainerImageBuilder.cs
@@ -9,13 +9,14 @@ using Microsoft.Extensions.Logging;
 
 namespace Aspire.Hosting.AWS.Deployment.Services;
 
-internal class DefaultTarballContainerImageBuilder(ILogger<DefaultTarballContainerImageBuilder> logger, IProcessCommandService processCommandService, IContainerRuntime containerRuntime) : ITarballContainerImageBuilder
+internal class DefaultTarballContainerImageBuilder(ILogger<DefaultTarballContainerImageBuilder> logger, IProcessCommandService processCommandService, IContainerRuntimeResolver containerRuntimeResolver) : ITarballContainerImageBuilder
 {
     public async Task<string> CreateTarballImageAsync(ProjectResource resource, CancellationToken cancellationToken)
     {
         var tarballFilePath = Path.GetTempFileName() + ".tar";
 
         var imageTag = resource.Name.ToLower() + ":latest";
+        var containerRuntime = await containerRuntimeResolver.ResolveAsync(cancellationToken);
         var results = await processCommandService.RunProcessAndCaptureOutputAsync(logger, containerRuntime.Name, $"save -o {tarballFilePath} {imageTag}", Environment.CurrentDirectory, cancellationToken);
         if (results.ExitCode != 0)
         {

--- a/src/Aspire.Hosting.AWS/Deployment/Services/DefaultTarballContainerImageBuilder.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/Services/DefaultTarballContainerImageBuilder.cs
@@ -14,7 +14,8 @@ internal class DefaultTarballContainerImageBuilder(ILogger<DefaultTarballContain
         var tarballFilePath = Path.GetTempFileName() + ".tar";
 
         var imageTag = resource.Name.ToLower() + ":latest";
-        var dockerSaveCommand = $"docker save -o {tarballFilePath} {imageTag}";
+        var runtime = Environment.GetEnvironmentVariable("ASPIRE_CONTAINER_RUNTIME") ?? "docker";
+        var dockerSaveCommand = $"{runtime} save -o {tarballFilePath} {imageTag}";
         string shellCommand;
         string arguments;
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))


### PR DESCRIPTION
# Support Podman (and other OCI runtimes) in CDK publishing steps

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Read `ASPIRE_CONTAINER_RUNTIME` from the environment (defaulting to `docker`) wherever the CDK publish pipeline previously hardcoded the `docker` binary:

- `DefaultTarballContainerImageBuilder`: uses the runtime when building the `save` command
- `CDKPublishingStep.FixCDKAssetsFileForWindows`: uses the runtime when building the PowerShell `load` command

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here -->

Users running Podman instead of Docker could not publish without symlinking `podman` to `docker`, because both publish paths hardcoded the `docker` binary name. The workaround is unsupported and breaks in environments where both runtimes coexist or where the user cannot write to system directories.

`ASPIRE_CONTAINER_RUNTIME` is already used by the core Aspire CLI to select between Docker and Podman for local run scenarios. Using the same variable keeps behaviour consistent across the Aspire ecosystem and requires no new user-facing API.

Usage with Podman:

```bash
ASPIRE_CONTAINER_RUNTIME=podman aspire publish -o ./publish
```

When the env var is unset the behaviour is identical to before (`docker`).

## Testing

<!--- Please describe in detail how you tested your changes -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Verified the project builds without errors or warnings
- Manually tested `aspire publish` with `ASPIRE_CONTAINER_RUNTIME=podman` on macOS with Podman installed
- Manually tested `aspire publish` without the env var set to confirm the default `docker` path is unchanged

## Breaking Changes Assessment

No breaking changes. When `ASPIRE_CONTAINER_RUNTIME` is unset the pipeline behaves exactly as before.

## Screenshots (if appropriate)

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have read the **README** document
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed

## License

- [x] I confirm that this pull request can be released under the [Apache 2 license](http://aws.amazon.com/apache2.0/)
