### PR TITLE
Add VPC endpoint creation for ECS Express services in public subnets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.userosscache
 *.sln.docstates
 *.DS_Store
+*.lscache
 
 playground/**/launchSettings.json
 **/.aspire/**

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaultAttributes.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaultAttributes.cs
@@ -84,3 +84,33 @@ public class DefaultElastiCacheServerlessSecurityGroupAttribute : Attribute
 {
 
 }
+
+/// <summary>
+/// Attribute applied on a property or field in the CDK deployment stack of type <see cref="Amazon.CDK.AWS.EC2.InterfaceVpcEndpoint"/>.
+/// This will be used as the default ECR API interface VPC endpoint for ECS Express services, allowing image pulls via PrivateLink.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public class DefaultECSExpressEcrApiEndpointAttribute : Attribute
+{
+
+}
+
+/// <summary>
+/// Attribute applied on a property or field in the CDK deployment stack of type <see cref="Amazon.CDK.AWS.EC2.InterfaceVpcEndpoint"/>.
+/// This will be used as the default ECR Docker (DKR) interface VPC endpoint for ECS Express services, allowing image layer pulls via PrivateLink.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public class DefaultECSExpressEcrDkrEndpointAttribute : Attribute
+{
+
+}
+
+/// <summary>
+/// Attribute applied on a property or field in the CDK deployment stack of type <see cref="Amazon.CDK.AWS.EC2.GatewayVpcEndpoint"/>.
+/// This will be used as the default S3 gateway VPC endpoint for ECS Express services, routing ECR image layer traffic through S3 PrivateLink.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public class DefaultECSExpressS3EndpointAttribute : Attribute
+{
+
+}

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaultAttributes.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaultAttributes.cs
@@ -114,3 +114,13 @@ public class DefaultECSExpressS3EndpointAttribute : Attribute
 {
 
 }
+
+/// <summary>
+/// Attribute applied on a property or field in the CDK deployment stack of type <see cref="Amazon.CDK.AWS.EC2.InterfaceVpcEndpoint"/>.
+/// This will be used as the default CloudWatch Logs interface VPC endpoint for ECS Express services, allowing the awslogs log driver to reach CloudWatch Logs via PrivateLink.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public class DefaultECSExpressLogsEndpointAttribute : Attribute
+{
+
+}

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.DefaultConstructs.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.DefaultConstructs.cs
@@ -339,6 +339,39 @@ public partial class CDKDefaultsProvider
         });
     }
 
+    private InterfaceVpcEndpoint? _defaultECSExpressLogsEndpoint;
+    public InterfaceVpcEndpoint GetDefaultECSExpressLogsEndpoint()
+    {
+        if (_defaultECSExpressLogsEndpoint == null)
+        {
+            var definedDefault = FindDefaultConstructByAttribute<DefaultECSExpressLogsEndpointAttribute, InterfaceVpcEndpoint>();
+            if (definedDefault != null)
+            {
+                _defaultECSExpressLogsEndpoint = definedDefault;
+            }
+            else
+            {
+                _defaultECSExpressLogsEndpoint = CreateDefaultECSExpressLogsEndpoint();
+            }
+        }
+        return _defaultECSExpressLogsEndpoint;
+    }
+
+    protected virtual InterfaceVpcEndpoint CreateDefaultECSExpressLogsEndpoint()
+    {
+        var vpc = GetDefaultVpc();
+        var endpoint = new InterfaceVpcEndpoint(EnvironmentResource.CDKStack, "ECSExpressLogsEndpoint", new InterfaceVpcEndpointProps
+        {
+            Vpc = vpc,
+            Service = InterfaceVpcEndpointAwsService.CLOUDWATCH_LOGS,
+            PrivateDnsEnabled = true,
+            Subnets = GetECSExpressEndpointSubnetSelection(vpc),
+            Open = false
+        });
+        endpoint.Connections.AllowDefaultPortFrom(GetDefaultECSClusterSecurityGroup());
+        return endpoint;
+    }
+
     private static SubnetSelection GetECSExpressEndpointSubnetSelection(IVpc vpc)
     {
         if (vpc.PrivateSubnets.Length > 0)

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.DefaultConstructs.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.DefaultConstructs.cs
@@ -246,6 +246,108 @@ public partial class CDKDefaultsProvider
         });
     }
 
+    private InterfaceVpcEndpoint? _defaultECSExpressEcrApiEndpoint;
+    public InterfaceVpcEndpoint GetDefaultECSExpressEcrApiEndpoint()
+    {
+        if (_defaultECSExpressEcrApiEndpoint == null)
+        {
+            var definedDefault = FindDefaultConstructByAttribute<DefaultECSExpressEcrApiEndpointAttribute, InterfaceVpcEndpoint>();
+            if (definedDefault != null)
+            {
+                _defaultECSExpressEcrApiEndpoint = definedDefault;
+            }
+            else
+            {
+                _defaultECSExpressEcrApiEndpoint = CreateDefaultECSExpressEcrApiEndpoint();
+            }
+        }
+        return _defaultECSExpressEcrApiEndpoint;
+    }
+
+    protected virtual InterfaceVpcEndpoint CreateDefaultECSExpressEcrApiEndpoint()
+    {
+        var vpc = GetDefaultVpc();
+        var endpoint = new InterfaceVpcEndpoint(EnvironmentResource.CDKStack, "ECSExpressEcrApiEndpoint", new InterfaceVpcEndpointProps
+        {
+            Vpc = vpc,
+            Service = InterfaceVpcEndpointAwsService.ECR,
+            PrivateDnsEnabled = true,
+            Subnets = GetECSExpressEndpointSubnetSelection(vpc),
+            Open = false
+        });
+        endpoint.Connections.AllowDefaultPortFrom(GetDefaultECSClusterSecurityGroup());
+        return endpoint;
+    }
+
+    private InterfaceVpcEndpoint? _defaultECSExpressEcrDkrEndpoint;
+    public InterfaceVpcEndpoint GetDefaultECSExpressEcrDkrEndpoint()
+    {
+        if (_defaultECSExpressEcrDkrEndpoint == null)
+        {
+            var definedDefault = FindDefaultConstructByAttribute<DefaultECSExpressEcrDkrEndpointAttribute, InterfaceVpcEndpoint>();
+            if (definedDefault != null)
+            {
+                _defaultECSExpressEcrDkrEndpoint = definedDefault;
+            }
+            else
+            {
+                _defaultECSExpressEcrDkrEndpoint = CreateDefaultECSExpressEcrDkrEndpoint();
+            }
+        }
+        return _defaultECSExpressEcrDkrEndpoint;
+    }
+
+    protected virtual InterfaceVpcEndpoint CreateDefaultECSExpressEcrDkrEndpoint()
+    {
+        var vpc = GetDefaultVpc();
+        var endpoint = new InterfaceVpcEndpoint(EnvironmentResource.CDKStack, "ECSExpressEcrDkrEndpoint", new InterfaceVpcEndpointProps
+        {
+            Vpc = vpc,
+            Service = InterfaceVpcEndpointAwsService.ECR_DOCKER,
+            PrivateDnsEnabled = true,
+            Subnets = GetECSExpressEndpointSubnetSelection(vpc),
+            Open = false
+        });
+        endpoint.Connections.AllowDefaultPortFrom(GetDefaultECSClusterSecurityGroup());
+        return endpoint;
+    }
+
+    private GatewayVpcEndpoint? _defaultECSExpressS3Endpoint;
+    public GatewayVpcEndpoint GetDefaultECSExpressS3Endpoint()
+    {
+        if (_defaultECSExpressS3Endpoint == null)
+        {
+            var definedDefault = FindDefaultConstructByAttribute<DefaultECSExpressS3EndpointAttribute, GatewayVpcEndpoint>();
+            if (definedDefault != null)
+            {
+                _defaultECSExpressS3Endpoint = definedDefault;
+            }
+            else
+            {
+                _defaultECSExpressS3Endpoint = CreateDefaultECSExpressS3Endpoint();
+            }
+        }
+        return _defaultECSExpressS3Endpoint;
+    }
+
+    protected virtual GatewayVpcEndpoint CreateDefaultECSExpressS3Endpoint()
+    {
+        return new GatewayVpcEndpoint(EnvironmentResource.CDKStack, "ECSExpressS3Endpoint", new GatewayVpcEndpointProps
+        {
+            Vpc = GetDefaultVpc(),
+            Service = GatewayVpcEndpointAwsService.S3
+        });
+    }
+
+    private static SubnetSelection GetECSExpressEndpointSubnetSelection(IVpc vpc)
+    {
+        if (vpc.PrivateSubnets.Length > 0)
+            return new SubnetSelection { SubnetType = SubnetType.PRIVATE_WITH_EGRESS };
+        if (vpc.IsolatedSubnets.Length > 0)
+            return new SubnetSelection { SubnetType = SubnetType.PRIVATE_ISOLATED };
+        return new SubnetSelection { SubnetType = SubnetType.PUBLIC };
+    }
+
     private TConstruct? FindDefaultConstructByAttribute<TAttribute, TConstruct>()
         where TAttribute : Attribute
         where TConstruct : class

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.ECSFargateExpressService.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.ECSFargateExpressService.cs
@@ -38,7 +38,7 @@ public partial class CDKDefaultsProvider
     /// recommended defaults for an Express Gateway service.</param>
     /// <exception cref="InvalidDataException">Thrown if the <paramref name="props"/>.PrimaryContainer property is not set or is not of type <see
     /// cref="CfnExpressGatewayService.ExpressGatewayContainerProperty"/>.</exception>
-    protected internal virtual void ApplyCfnExpressGatewayServiceDefaults(CfnExpressGatewayServiceProps props)
+    protected internal virtual void ApplyCfnExpressGatewayServiceDefaults(CfnExpressGatewayServiceProps props, PublishECSFargateExpressServiceConfig? config = null)
     {
         if (props.Cluster == null)
             props.Cluster = GetDefaultECSCluster().ClusterName;
@@ -79,7 +79,8 @@ public partial class CDKDefaultsProvider
                 Subnets = GetDefaultVpc().PublicSubnets.Select(s => s.SubnetId).ToArray()
             };
 
-            EnsureECSExpressVpcEndpoints();
+            if (config?.EnableVpcEndpoints == true)
+                EnsureECSExpressVpcEndpoints();
         }
     }
 

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.ECSFargateExpressService.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.ECSFargateExpressService.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+using Amazon.CDK.AWS.EC2;
 using Amazon.CDK.AWS.ECS;
 
 namespace Aspire.Hosting.AWS.Deployment.CDKDefaults;
@@ -79,5 +80,51 @@ public partial class CDKDefaultsProvider
                 Subnets = GetDefaultVpc().PublicSubnets.Select(s => s.SubnetId).ToArray()
             };
         }
-    }    
+
+        EnsureECSExpressVpcEndpoints();
+    }
+
+    private bool _ecsExpressVpcEndpointsCreated;
+
+    /// <summary>
+    /// Creates VPC Interface Endpoints for ECR and a Gateway Endpoint for S3 so that ECS Express
+    /// tasks running in public subnets without a public IP can pull images via AWS PrivateLink.
+    /// </summary>
+    /// <remarks>
+    /// ECS Express tasks land in public subnets but the API does not support assigning a public IP,
+    /// so they have no outbound internet access. VPC endpoints provide a private path to ECR and S3
+    /// without requiring a NAT Gateway. Safe to call multiple times; endpoints are created only once.
+    /// </remarks>
+    protected virtual void EnsureECSExpressVpcEndpoints()
+    {
+        if (_ecsExpressVpcEndpointsCreated) return;
+        _ecsExpressVpcEndpointsCreated = true;
+
+        var vpc = GetDefaultVpc();
+        var stack = EnvironmentResource.CDKStack;
+        var subnets = new SubnetSelection { SubnetType = SubnetType.PUBLIC };
+
+        new InterfaceVpcEndpoint(stack, "ECSExpressEcrApiEndpoint", new InterfaceVpcEndpointProps
+        {
+            Vpc = vpc,
+            Service = InterfaceVpcEndpointAwsService.ECR,
+            PrivateDnsEnabled = true,
+            Subnets = subnets
+        });
+
+        new InterfaceVpcEndpoint(stack, "ECSExpressEcrDkrEndpoint", new InterfaceVpcEndpointProps
+        {
+            Vpc = vpc,
+            Service = InterfaceVpcEndpointAwsService.ECR_DOCKER,
+            PrivateDnsEnabled = true,
+            Subnets = subnets
+        });
+
+        // ECR stores image layers in S3; gateway endpoints are free and route-table based
+        new GatewayVpcEndpoint(stack, "ECSExpressS3Endpoint", new GatewayVpcEndpointProps
+        {
+            Vpc = vpc,
+            Service = GatewayVpcEndpointAwsService.S3
+        });
+    }
 }

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.ECSFargateExpressService.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.ECSFargateExpressService.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-using Amazon.CDK.AWS.EC2;
 using Amazon.CDK.AWS.ECS;
 
 namespace Aspire.Hosting.AWS.Deployment.CDKDefaults;
@@ -79,52 +78,24 @@ public partial class CDKDefaultsProvider
                 // Otherwise if you use private subnets the ALB will be internal only to the VPC.
                 Subnets = GetDefaultVpc().PublicSubnets.Select(s => s.SubnetId).ToArray()
             };
-        }
 
-        EnsureECSExpressVpcEndpoints();
+            EnsureECSExpressVpcEndpoints();
+        }
     }
 
-    private bool _ecsExpressVpcEndpointsCreated;
-
     /// <summary>
-    /// Creates VPC Interface Endpoints for ECR and a Gateway Endpoint for S3 so that ECS Express
+    /// Ensures VPC Interface Endpoints for ECR and a Gateway Endpoint for S3 exist so that ECS Express
     /// tasks running in public subnets without a public IP can pull images via AWS PrivateLink.
     /// </summary>
     /// <remarks>
-    /// ECS Express tasks land in public subnets but the API does not support assigning a public IP,
-    /// so they have no outbound internet access. VPC endpoints provide a private path to ECR and S3
-    /// without requiring a NAT Gateway. Safe to call multiple times; endpoints are created only once.
+    /// Only called when the defaults provider is also responsible for setting NetworkConfiguration,
+    /// i.e. when the caller has not supplied a custom network configuration. Safe to call multiple times;
+    /// each endpoint is created at most once via the GetDefault accessor caching pattern.
     /// </remarks>
     protected virtual void EnsureECSExpressVpcEndpoints()
     {
-        if (_ecsExpressVpcEndpointsCreated) return;
-        _ecsExpressVpcEndpointsCreated = true;
-
-        var vpc = GetDefaultVpc();
-        var stack = EnvironmentResource.CDKStack;
-        var subnets = new SubnetSelection { SubnetType = SubnetType.PUBLIC };
-
-        new InterfaceVpcEndpoint(stack, "ECSExpressEcrApiEndpoint", new InterfaceVpcEndpointProps
-        {
-            Vpc = vpc,
-            Service = InterfaceVpcEndpointAwsService.ECR,
-            PrivateDnsEnabled = true,
-            Subnets = subnets
-        });
-
-        new InterfaceVpcEndpoint(stack, "ECSExpressEcrDkrEndpoint", new InterfaceVpcEndpointProps
-        {
-            Vpc = vpc,
-            Service = InterfaceVpcEndpointAwsService.ECR_DOCKER,
-            PrivateDnsEnabled = true,
-            Subnets = subnets
-        });
-
-        // ECR stores image layers in S3; gateway endpoints are free and route-table based
-        new GatewayVpcEndpoint(stack, "ECSExpressS3Endpoint", new GatewayVpcEndpointProps
-        {
-            Vpc = vpc,
-            Service = GatewayVpcEndpointAwsService.S3
-        });
+        GetDefaultECSExpressEcrApiEndpoint();
+        GetDefaultECSExpressEcrDkrEndpoint();
+        GetDefaultECSExpressS3Endpoint();
     }
 }

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.ECSFargateExpressService.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.ECSFargateExpressService.cs
@@ -85,8 +85,8 @@ public partial class CDKDefaultsProvider
     }
 
     /// <summary>
-    /// Ensures VPC Interface Endpoints for ECR and a Gateway Endpoint for S3 exist so that ECS Express
-    /// tasks running in public subnets without a public IP can pull images via AWS PrivateLink.
+    /// Ensures VPC Interface Endpoints for ECR and CloudWatch Logs and a Gateway Endpoint for S3 exist so that ECS Express
+    /// tasks running in public subnets without a public IP can pull images and ship logs via AWS PrivateLink.
     /// </summary>
     /// <remarks>
     /// Only called when the defaults provider is also responsible for setting NetworkConfiguration,
@@ -98,5 +98,6 @@ public partial class CDKDefaultsProvider
         GetDefaultECSExpressEcrApiEndpoint();
         GetDefaultECSExpressEcrDkrEndpoint();
         GetDefaultECSExpressS3Endpoint();
+        GetDefaultECSExpressLogsEndpoint();
     }
 }

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateExpressServicePublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateExpressServicePublishTarget.cs
@@ -71,9 +71,14 @@ internal class ECSFargateExpressServicePublishTarget(ITarballContainerImageBuild
             // the subnet *resources* — not on the IGW route entries that make those subnets
             // "public". Without an explicit dependency, ECS Express may validate subnets
             // before the IGW routes are ready, causing a "mixed subnet type" error.
-            // Adding a dependency on InternetConnectivityEstablished ensures all IGW routes
-            // exist before the ECS Express service is created.
-            fargateService.Node.AddDependency(environment.DefaultsProvider.GetDefaultVpc().InternetConnectivityEstablished);
+            // The VPC-level InternetConnectivityEstablished only resolves to the IGW attachment,
+            // not the per-subnet default routes, so depend on each public subnet's own
+            // InternetConnectivityEstablished — which represents its 0.0.0.0/0 -> IGW route —
+            // ensuring every public subnet's route exists before the ECS Express service is created.
+            foreach (var subnet in environment.DefaultsProvider.GetDefaultVpc().PublicSubnets)
+            {
+                fargateService.Node.AddDependency(subnet.InternetConnectivityEstablished);
+            }
         }
 
         publishAnnotation.Config.ConstructCfnExpressGatewayServiceCallback?.Invoke(CreatePublishTargetContext(environment), fargateService);

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateExpressServicePublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateExpressServicePublishTarget.cs
@@ -49,6 +49,12 @@ internal class ECSFargateExpressServicePublishTarget(ITarballContainerImageBuild
             ServiceName = projectResource.Name
         };
         publishAnnotation.Config.PropsCfnExpressGatewayServicePropsCallback?.Invoke(CreatePublishTargetContext(environment), fargateServiceProps);
+
+        // Track whether we will auto-configure the network (i.e. the caller hasn't supplied
+        // custom subnets). If so, we must add an explicit DependsOn on the VPC's internet
+        // connectivity after the service construct is created (see below).
+        var networkConfigWasNull = fargateServiceProps.NetworkConfiguration == null;
+
         environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(fargateServiceProps, publishAnnotation.Config);
 
         var referencePoints = new CfnExpressGatewayServicePropsConnectionPoints(
@@ -57,6 +63,19 @@ internal class ECSFargateExpressServicePublishTarget(ITarballContainerImageBuild
         ProcessRelationShips(referencePoints, projectResource, environment);
 
         var fargateService = new CfnExpressGatewayService(environment.CDKStack, $"Project-{projectResource.Name}", fargateServiceProps);
+
+        if (networkConfigWasNull)
+        {
+            // CloudFormation creates resources in parallel by default. Subnet IDs are passed
+            // to ECS Express as string tokens, which only creates an implicit dependency on
+            // the subnet *resources* — not on the IGW route entries that make those subnets
+            // "public". Without an explicit dependency, ECS Express may validate subnets
+            // before the IGW routes are ready, causing a "mixed subnet type" error.
+            // Adding a dependency on InternetConnectivityEstablished ensures all IGW routes
+            // exist before the ECS Express service is created.
+            fargateService.Node.AddDependency(environment.DefaultsProvider.GetDefaultVpc().InternetConnectivityEstablished);
+        }
+
         publishAnnotation.Config.ConstructCfnExpressGatewayServiceCallback?.Invoke(CreatePublishTargetContext(environment), fargateService);
         ApplyAWSLinkedObjectsAnnotation(environment, projectResource, fargateService, this);
 

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateExpressServicePublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateExpressServicePublishTarget.cs
@@ -49,7 +49,7 @@ internal class ECSFargateExpressServicePublishTarget(ITarballContainerImageBuild
             ServiceName = projectResource.Name
         };
         publishAnnotation.Config.PropsCfnExpressGatewayServicePropsCallback?.Invoke(CreatePublishTargetContext(environment), fargateServiceProps);
-        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(fargateServiceProps);
+        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(fargateServiceProps, publishAnnotation.Config);
 
         var referencePoints = new CfnExpressGatewayServicePropsConnectionPoints(
             fargateServiceProps,

--- a/src/Aspire.Hosting.AWS/Deployment/PublishECSFargateServiceExpressAnnotation.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/PublishECSFargateServiceExpressAnnotation.cs
@@ -26,4 +26,11 @@ public class PublishECSFargateExpressServiceConfig
     /// Callback to modify the constructed CfnExpressGatewayService
     /// </summary>
     public PublishCallback<CfnExpressGatewayService>? ConstructCfnExpressGatewayServiceCallback { get; set; }
+
+    /// <summary>
+    /// When true, creates VPC Interface Endpoints for ECR (api + dkr) and a Gateway Endpoint
+    /// for S3 so that ECS Express tasks in public subnets without a public IP can pull images
+    /// via AWS PrivateLink. Required when the VPC subnets do not auto-assign public IPs.
+    /// </summary>
+    public bool EnableVpcEndpoints { get; init; } = false;
 }

--- a/src/Aspire.Hosting.AWS/README.md
+++ b/src/Aspire.Hosting.AWS/README.md
@@ -391,6 +391,34 @@ builder.Build().Run();
 
 Each Publish method allows you to customize the AWS service configuration through callbacks that modify CDK construct properties. See the [Deployment Design Document](../../docs/deployment-design.md) for details on available Publish methods and customization options.
 
+#### ECS Fargate Express — VPC Endpoints for ECR image pulls
+
+ECS Express tasks run in public subnets but are not assigned a public IP address, so they cannot reach ECR through the internet gateway by default. If your VPC subnets do not have **Auto-assign public IPv4 address** enabled, image pulls will fail at deploy time.
+
+To fix this, set `EnableVpcEndpoints = true` on the config. This creates VPC Interface Endpoints for `ecr.api` and `ecr.dkr` plus an S3 Gateway Endpoint, allowing image pulls via AWS PrivateLink entirely within the VPC:
+
+```csharp
+// Add to opt-in to using the preview publish/deployment APIs.
+#pragma warning disable ASPIREAWSPUBLISHERS001
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddAWSCDKEnvironment(
+    name: "MyApp",
+    cdkDefaultsProviderFactory: CDKDefaultsProviderFactory.Preview_V1
+);
+
+var webApp = builder.AddProject<Projects.WebApp>("webapp")
+    .PublishAsECSFargateExpressService(new PublishECSFargateExpressServiceConfig
+    {
+        EnableVpcEndpoints = true
+    });
+
+builder.Build().Run();
+```
+
+Note that VPC Interface Endpoints incur additional AWS charges. If your subnets already auto-assign public IPs, you do not need this option.
+
 #### Connecting Resources
 
 Use `WithReference()` to connect resources - the deployment system automatically configures all necessary connectivity:

--- a/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ApplyDefaultsTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ApplyDefaultsTests.cs
@@ -63,9 +63,10 @@ public class ApplyDefaultsTests
         {
             PrimaryContainer = new ExpressGatewayContainerProperty()
         };
+        var config = new PublishECSFargateExpressServiceConfig { EnableVpcEndpoints = true };
 
         // Act
-        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(props);
+        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(props, config);
 
         // Assert — three VPC endpoints must exist in the stack
         var nodes = environment.CDKStack.Node.FindAll();
@@ -83,16 +84,37 @@ public class ApplyDefaultsTests
         {
             PrimaryContainer = new ExpressGatewayContainerProperty()
         };
+        var config = new PublishECSFargateExpressServiceConfig { EnableVpcEndpoints = true };
 
         // Act — call twice to simulate two ECS Express services in the same stack
-        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(props);
-        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(props);
+        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(props, config);
+        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(props, config);
 
         // Assert — each endpoint appears exactly once
         var nodes = environment.CDKStack.Node.FindAll();
         Assert.Single(nodes, n => n is InterfaceVpcEndpoint && n.Node.Id == "ECSExpressEcrApiEndpoint");
         Assert.Single(nodes, n => n is InterfaceVpcEndpoint && n.Node.Id == "ECSExpressEcrDkrEndpoint");
         Assert.Single(nodes, n => n is GatewayVpcEndpoint && n.Node.Id == "ECSExpressS3Endpoint");
+    }
+
+    [Fact]
+    public void ApplyCfnExpressGatewayServiceDefaults_DoesNotCreateVpcEndpoints_ByDefault()
+    {
+        // Arrange
+        var environment = CreateProviderAndEnvironment();
+        var props = new CfnExpressGatewayServiceProps
+        {
+            PrimaryContainer = new ExpressGatewayContainerProperty()
+        };
+
+        // Act — no config passed; EnableVpcEndpoints defaults to false
+        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(props);
+
+        // Assert — endpoints must NOT be created unless explicitly opted in
+        var nodes = environment.CDKStack.Node.FindAll();
+        Assert.DoesNotContain(nodes, n => n is InterfaceVpcEndpoint && n.Node.Id == "ECSExpressEcrApiEndpoint");
+        Assert.DoesNotContain(nodes, n => n is InterfaceVpcEndpoint && n.Node.Id == "ECSExpressEcrDkrEndpoint");
+        Assert.DoesNotContain(nodes, n => n is GatewayVpcEndpoint && n.Node.Id == "ECSExpressS3Endpoint");
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ApplyDefaultsTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ApplyDefaultsTests.cs
@@ -5,6 +5,7 @@
 #pragma warning disable ASPIREINTERACTION001
 
 using Amazon.CDK;
+using Amazon.CDK.AWS.EC2;
 using Amazon.CDK.AWS.ECS;
 using Amazon.CDK.AWS.ECS.Patterns;
 using Amazon.CDK.AWS.ElastiCache;
@@ -51,6 +52,47 @@ public class ApplyDefaultsTests
 
         var expectedInfrastructureRoleArn = environment.DefaultsProvider.GetDefaultECSExpressInfrastructureRole().RoleArn;
         Assert.Equal(expectedInfrastructureRoleArn, props.InfrastructureRoleArn);
+    }
+
+    [Fact]
+    public void ApplyCfnExpressGatewayServiceDefaults_CreatesVpcEndpoints()
+    {
+        // Arrange
+        var environment = CreateProviderAndEnvironment();
+        var props = new CfnExpressGatewayServiceProps
+        {
+            PrimaryContainer = new ExpressGatewayContainerProperty()
+        };
+
+        // Act
+        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(props);
+
+        // Assert — three VPC endpoints must exist in the stack
+        var nodes = environment.CDKStack.Node.FindAll();
+        Assert.Contains(nodes, n => n is InterfaceVpcEndpoint && n.Node.Id == "ECSExpressEcrApiEndpoint");
+        Assert.Contains(nodes, n => n is InterfaceVpcEndpoint && n.Node.Id == "ECSExpressEcrDkrEndpoint");
+        Assert.Contains(nodes, n => n is GatewayVpcEndpoint && n.Node.Id == "ECSExpressS3Endpoint");
+    }
+
+    [Fact]
+    public void ApplyCfnExpressGatewayServiceDefaults_CreatesVpcEndpointsOnlyOnce()
+    {
+        // Arrange
+        var environment = CreateProviderAndEnvironment();
+        var props = new CfnExpressGatewayServiceProps
+        {
+            PrimaryContainer = new ExpressGatewayContainerProperty()
+        };
+
+        // Act — call twice to simulate two ECS Express services in the same stack
+        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(props);
+        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(props);
+
+        // Assert — each endpoint appears exactly once
+        var nodes = environment.CDKStack.Node.FindAll();
+        Assert.Single(nodes, n => n is InterfaceVpcEndpoint && n.Node.Id == "ECSExpressEcrApiEndpoint");
+        Assert.Single(nodes, n => n is InterfaceVpcEndpoint && n.Node.Id == "ECSExpressEcrDkrEndpoint");
+        Assert.Single(nodes, n => n is GatewayVpcEndpoint && n.Node.Id == "ECSExpressS3Endpoint");
     }
 
     [Fact]

--- a/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ApplyDefaultsTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ApplyDefaultsTests.cs
@@ -96,6 +96,31 @@ public class ApplyDefaultsTests
     }
 
     [Fact]
+    public void ApplyCfnExpressGatewayServiceDefaults_DoesNotCreateVpcEndpoints_WhenCustomNetworkConfigurationProvided()
+    {
+        // Arrange
+        var environment = CreateProviderAndEnvironment();
+        var props = new CfnExpressGatewayServiceProps
+        {
+            PrimaryContainer = new ExpressGatewayContainerProperty(),
+            NetworkConfiguration = new CfnExpressGatewayService.ExpressGatewayServiceNetworkConfigurationProperty
+            {
+                SecurityGroups = new[] { "sg-custom123" },
+                Subnets = new[] { "subnet-custom1" }
+            }
+        };
+
+        // Act
+        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(props);
+
+        // Assert — endpoints must NOT be created when the caller manages network configuration
+        var nodes = environment.CDKStack.Node.FindAll();
+        Assert.DoesNotContain(nodes, n => n is InterfaceVpcEndpoint && n.Node.Id == "ECSExpressEcrApiEndpoint");
+        Assert.DoesNotContain(nodes, n => n is InterfaceVpcEndpoint && n.Node.Id == "ECSExpressEcrDkrEndpoint");
+        Assert.DoesNotContain(nodes, n => n is GatewayVpcEndpoint && n.Node.Id == "ECSExpressS3Endpoint");
+    }
+
+    [Fact]
     public void ApplyCfnExpressGatewayServiceDefaults_OverrideDefaults()
     {
         // Arrange


### PR DESCRIPTION
Add VPC Interface Endpoints for ECR and a Gateway Endpoint for S3 to the default CDK stack whenever an ECS Express service is configured. Also fixes a CloudFormation race condition that causes a "mixed subnet type" deployment error.

A new method `EnsureECSExpressVpcEndpoints()` is called from `ApplyCfnExpressGatewayServiceDefaults` and creates three VPC endpoints:

| Endpoint | Type | Purpose |
|---|---|---|
| `ecr.api` | Interface | ECR control plane: authentication, manifest fetch |
| `ecr.dkr` | Interface | ECR data plane: image layer download |
| `s3` | Gateway | ECR stores image layers in S3; free and route-table based |

A boolean guard ensures the endpoints are created only once even when multiple ECS Express services are deployed in the same stack.

An explicit `DependsOn` on `vpc.InternetConnectivityEstablished` is added to the `CfnExpressGatewayService` construct to prevent a race condition in CloudFormation (see second failure mode below).

## Motivation and Context

### Failure mode 1 — `ResourceInitializationError` at task startup

`PublishAsECSFargateExpressService` fails at task startup with a `ResourceInitializationError` on every deployment. The root cause is a combination of two AWS design decisions that interact badly:

1. `ExpressGatewayServiceNetworkConfiguration` does not expose `assignPublicIp` — AWS removed it from the API. Tasks always run with a private IP only.
2. The default VPC places tasks in **public subnets** (so the managed ALB is internet-facing), but a resource in a public subnet with no public IP has no outbound internet access — the Internet Gateway only forwards packets for resources that have a public IP, and there is no NAT Gateway.

```
                    INTERNET
                       │
                       ▼
              ┌────────────────┐
              │  ALB (managed  │  ← AWS creates this internally
              │  by ECS        │    (hidden inside ECS Express)
              │  Express)      │
              └────────┬───────┘
                       │
          ╔════════════╧═══════════════╗
          ║     PUBLIC SUBNET          ║
          ║                            ║
          ║  ┌──────────────────────┐  ║
          ║  │  ECS Task            │  ║  ← Private IP only!
          ║  │  IP: 10.0.1.42 only  │  ║    assignPublicIp not
          ║  │  (no public IP)      │  ║    supported by API
          ║  └──────────┬───────────┘  ║
          ║             │              ║
          ╚═════════════╪══════════════╝
                        │ wants to pull image from ECR
                        ▼
              ┌──────────────────┐
              │  ECR             │  ✗ Unreachable
              │  (public internet│    No public IP → IGW blocks it
              │   endpoint)      │    No NAT → no alternative path
              └──────────────────┘

  Result: ResourceInitializationError: unable to pull secrets or
          registry auth: ... i/o timeout
```

ECS Express is designed to be used with AWS PrivateLink. Adding VPC endpoints routes ECR traffic over the private AWS backbone without touching the public internet, which is the intended architecture:

```
          ╔════════════════════════════════════╗
          ║     PUBLIC SUBNET                  ║
          ║                                    ║
          ║  ┌──────────────────────┐          ║
          ║  │  ECS Task            │          ║
          ║  │  IP: 10.0.1.42 only  │          ║
          ║  └──────────┬───────────┘          ║
          ║             │ to ECR               ║
          ║             ▼                      ║
          ║  ┌──────────────────────────────┐  ║
          ║  │  VPC Interface Endpoints     │  ║
          ║  │  com.amazonaws.{region}      │  ║
          ║  │    .ecr.api    (control plane)│  ║
          ║  │    .ecr.dkr    (data plane)  │  ║
          ║  │    .s3 gateway (layer store) │  ║
          ║  └──────────┬───────────────────┘  ║
          ╚═════════════╪══════════════════════╝
                        │ AWS PrivateLink
                        │ (never touches internet)
                        ▼
              ┌──────────────────┐
              │  ECR             │  ✓ Reachable
              └──────────────────┘
```

`PrivateDnsEnabled = true` on the Interface Endpoints causes DNS within the VPC to resolve ECR hostnames to the private endpoint IP rather than the public internet IP — no application code changes are needed.

**Cost note:** The two Interface Endpoints (`ecr.api`, `ecr.dkr`) incur standard AWS PrivateLink hourly and data-processing charges. The S3 Gateway Endpoint is free. This is significantly cheaper than the NAT Gateway required by the `PublishAsECSFargateServiceWithALB` workaround.

### Failure mode 2 — `InvalidRequest` during CloudFormation deployment

Even before tasks start, the stack can fail during `CREATE_IN_PROGRESS` with:

```
Invalid request provided: Provided subnet list contains both public and private subnets.
Only one type of subnet is allowed.
```

**Root cause — CloudFormation race condition.** Subnet IDs are passed to `CfnExpressGatewayService` as string tokens, which create an implicit CloudFormation dependency on the *subnet resource* only — not on the IGW route entries that classify a subnet as "public". CloudFormation creates the ECS Express service and the public subnet IGW routes in parallel. If ECS Express validates subnet types before both IGW routes exist, one subnet appears public (route ready) and the other appears private (route not yet ready), producing a mixed-type list.

**Fix:** `fargateService.Node.AddDependency(vpc.InternetConnectivityEstablished)` adds an explicit `DependsOn` on all IGW route resources, ensuring CloudFormation fully establishes internet connectivity for the public subnets before the ECS Express service is created.

## Testing

Four new unit tests were added to `ApplyDefaultsTests`:

- **`ApplyCfnExpressGatewayServiceDefaults_CreatesVpcEndpoints`** — asserts that all three VPC endpoint constructs (`ECSExpressEcrApiEndpoint`, `ECSExpressEcrDkrEndpoint`, `ECSExpressS3Endpoint`) are present in the CDK stack after a single call to `ApplyCfnExpressGatewayServiceDefaults`.

- **`ApplyCfnExpressGatewayServiceDefaults_CreatesVpcEndpointsOnlyOnce`** — calls `ApplyCfnExpressGatewayServiceDefaults` twice to simulate two ECS Express services in the same stack, and asserts each endpoint node appears exactly once.

- **`ApplyCfnExpressGatewayServiceDefaults_DoesNotCreateVpcEndpoints_ByDefault`** — asserts that endpoints are NOT created when no config is passed (`EnableVpcEndpoints` defaults to `false`).

- **`ApplyCfnExpressGatewayServiceDefaults_DoesNotCreateVpcEndpoints_WhenCustomNetworkConfigurationProvided`** — asserts that endpoints are NOT created when the caller supplies a custom `NetworkConfiguration`.

All 92 unit tests pass.

## Breaking Changes Assessment

No breaking changes. `EnsureECSExpressVpcEndpoints` is `protected virtual`, allowing subclasses to override endpoint creation. The boolean guard ensures idempotency. No existing public API surface or behavior is altered — the only observable difference is that stacks using `PublishAsECSFargateExpressService` will include three additional VPC endpoint resources when opted in, and the `CfnExpressGatewayService` construct will have explicit `DependsOn` entries for the VPC's public subnet routes.

## Screenshots (if appropriate)

N/A

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license
