### PR TITLE
Fix issue with deployments including Aspire binding text in CF templates

### DIFF
--- a/.autover/changes/b91df5e5-1bb4-4c1c-b931-ecd0a2132f5e.json
+++ b/.autover/changes/b91df5e5-1bb4-4c1c-b931-ecd0a2132f5e.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fix issue with CloudFormation template include Aspire value expressions"
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDeployStep.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDeployStep.cs
@@ -66,7 +66,7 @@ internal class CDKDeployStep(IProcessCommandService processCommandService, ILogg
 
             foreach (var param in resolvedParameters)
             {
-                cdkDeployCommand += $" --parameters \"{param.TemplateParameterName}={param.Value}\"";
+                cdkDeployCommand += $" --parameters \'{param.TemplateParameterName}={param.Value}\'";
             }
 
             string shellCommand;

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AbstractAWSPublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AbstractAWSPublishTarget.cs
@@ -246,7 +246,10 @@ public abstract class AbstractAWSPublishTarget(ILogger logger) : IAWSPublishTarg
         return value switch
         {
             string s => s,
-            IManifestExpressionProvider manifest => manifest.ValueExpression,
+            // Expressions are not supported because they wouldn't be resolved in the CF template during deployment.
+            // these values are most likely local runtime generated values which won't be valid when deployed. For
+            // example this would write out an HTTP_PORTS field but that is configured by an ECS Task Definition.
+            IManifestExpressionProvider _ => null, 
             _ => value.ToString()
         };
     }

--- a/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
+++ b/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
@@ -1704,6 +1704,9 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             Assert.DoesNotContain("dummy1a", cfTemplateContent);
             Assert.DoesNotContain("vpc-12345", cfTemplateContent);
 
+            // Look to make sure no Aspire binding values slipped into the CF template which would not be resolved.
+            Assert.DoesNotContain(".bindings.", cfTemplateContent);
+
             var cfTemplateDoc = JsonDocument.Parse(File.ReadAllText(cfTemplatePath));
 
             await cfTemplateValidation(cfTemplateDoc);


### PR DESCRIPTION
## Description
PR https://github.com/aws/integrations-on-dotnet-aspire-for-aws/pull/193 added support for including environment variables and Aspire parameters into the CF template. This introduced a bug where if the environment was a value expression the expression would get added into the template which are not resolved. 

These expression are generally for setting up the local development environment variable and will be different when deployed to AWS. For example the HTTP_PORTS is being added to the environment for web applications with a value expression. The value causes the ASP.NET Core application to try and use a different port then was expected for container port and fails the launch.

We might revisit this in the future to see if there is a way to support some value expressions but right now I want to get this released to unblock failed deployments because of the HTTP_PORTS env slipping in.
