### PR TITLE
Add support for S3 assets when provisioning AWS app resources

### DIFF
--- a/.autover/changes/43eddc2c-7870-4bf5-b72a-b5536a4a7648.json
+++ b/.autover/changes/43eddc2c-7870-4bf5-b72a-b5536a4a7648.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add support for S3 assets when provisioning AWS app resources"
+      ]
+    }
+  ]
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,7 @@
     <PackageVersion Include="AWSSDK.Core" Version="4.0.6.1" />
     <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.18.1" />
     <PackageVersion Include="AWSSDK.Lambda" Version="4.0.15.2" />
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.21.2" />
     <PackageVersion Include="AWSSDK.SecurityToken" Version="4.0.6.3" />
     <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.0.2.30" />
     <PackageVersion Include="AWSSDK.SQS" Version="4.0.2.28" />

--- a/playground/CloudFormationProvisioning/AWSCDK.AppHost/CustomStack.cs
+++ b/playground/CloudFormationProvisioning/AWSCDK.AppHost/CustomStack.cs
@@ -2,6 +2,7 @@
 
 using Amazon.CDK;
 using Amazon.CDK.AWS.S3;
+using Amazon.CDK.AWS.S3.Deployment;
 using Amazon.CDK.AWS.SQS;
 using Constructs;
 
@@ -9,7 +10,6 @@ namespace AWSCDK.AppHost;
 
 public class CustomStack : Stack
 {
-
     public IBucket Bucket { get; }
 
     public IQueue Queue { get; }
@@ -19,6 +19,14 @@ public class CustomStack : Stack
     {
         Bucket = new Bucket(this, "Bucket");
         Queue = new Queue(this, "Queue");
-    }
 
+        // BucketDeployment is included to demonstrate Aspire's CDK file asset provisioning.
+        // It creates a Lambda-backed custom resource whose handler is packaged as a file asset,
+        // which Aspire uploads to the CDK bootstrap bucket before deploying the stack.
+        new BucketDeployment(this, "SampleContentDeployment", new BucketDeploymentProps
+        {
+            Sources = [Source.Asset("./sample-content")],
+            DestinationBucket = Bucket,
+        });
+    }
 }

--- a/playground/CloudFormationProvisioning/AWSCDK.AppHost/sample-content/config.json
+++ b/playground/CloudFormationProvisioning/AWSCDK.AppHost/sample-content/config.json
@@ -1,0 +1,4 @@
+{
+  "app": "aspire-cdk-demo",
+  "version": "1.0"
+}

--- a/src/Aspire.Hosting.AWS/Aspire.Hosting.AWS.csproj
+++ b/src/Aspire.Hosting.AWS/Aspire.Hosting.AWS.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="AWSSDK.Core" />
     <PackageReference Include="AWSSDK.CloudFormation" />
     <PackageReference Include="AWSSDK.Lambda" />
+    <PackageReference Include="AWSSDK.S3" />
     <PackageReference Include="AWSSDK.SecurityToken" />	  
     <PackageReference Include="AWSSDK.SSO" />	  
     <PackageReference Include="AWSSDK.SSOOIDC" />	  

--- a/src/Aspire.Hosting.AWS/Provisioning/CDKAssetUploader.cs
+++ b/src/Aspire.Hosting.AWS/Provisioning/CDKAssetUploader.cs
@@ -1,0 +1,210 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+using System.IO.Compression;
+using Amazon.CDK.CloudAssemblySchema;
+using Amazon.CDK.CXAPI;
+using Amazon.Runtime.Credentials;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+using Microsoft.Extensions.Logging;
+
+namespace Aspire.Hosting.AWS.Provisioning;
+
+internal sealed class CDKAssetUploader
+{
+    private readonly IAWSSDKConfig? _awsSdkConfig;
+    private readonly ILogger _logger;
+    private readonly Func<IAmazonS3>? _s3ClientFactory;
+    private readonly Func<IAmazonSecurityTokenService>? _stsClientFactory;
+
+    public CDKAssetUploader(IAWSSDKConfig? awsSdkConfig, ILogger logger)
+    {
+        _awsSdkConfig = awsSdkConfig;
+        _logger = logger;
+    }
+
+    internal CDKAssetUploader(ILogger logger, Func<IAmazonS3> s3ClientFactory, Func<IAmazonSecurityTokenService> stsClientFactory)
+    {
+        _logger = logger;
+        _s3ClientFactory = s3ClientFactory;
+        _stsClientFactory = stsClientFactory;
+    }
+
+    public async Task UploadAssetsAsync(AssetManifestArtifact artifact, CancellationToken cancellationToken)
+    {
+        var fileAssets = artifact.Contents.Files;
+        if (fileAssets == null || fileAssets.Count == 0)
+        {
+            return;
+        }
+
+        await UploadFileAssetsAsync(fileAssets, artifact.Assembly.Directory, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal async Task UploadFileAssetsAsync(IDictionary<string, IFileAsset> fileAssets, string assemblyDirectory, CancellationToken cancellationToken)
+    {
+        var (accountId, region) = await GetCallerAccountAndRegionAsync(cancellationToken).ConfigureAwait(false);
+        using var s3Client = CreateS3Client();
+
+        foreach (var (_, fileAsset) in fileAssets)
+        {
+            await UploadFileAssetAsync(s3Client, fileAsset, assemblyDirectory, accountId, region, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task UploadFileAssetAsync(IAmazonS3 s3Client, IFileAsset fileAsset, string assemblyDirectory, string accountId, string region, CancellationToken cancellationToken)
+    {
+        var source = fileAsset.Source;
+
+        if (source.Executable is { Length: > 0 })
+        {
+            _logger.LogWarning("Skipping CDK asset with executable source; executable-generated assets are not supported");
+            return;
+        }
+
+        if (source.Path == null)
+        {
+            return;
+        }
+
+        var sourcePath = Path.Combine(assemblyDirectory, source.Path);
+        var packaging = source.Packaging ?? FileAssetPackaging.FILE;
+
+        foreach (var (_, destination) in fileAsset.Destinations)
+        {
+            var bucketName = ResolveTokens(destination.BucketName, accountId, region);
+            var objectKey = destination.ObjectKey;
+
+            if (await AssetExistsInS3Async(s3Client, bucketName, objectKey, cancellationToken).ConfigureAwait(false))
+            {
+                _logger.LogDebug("CDK asset {ObjectKey} already exists in {Bucket}, skipping upload", objectKey, bucketName);
+                continue;
+            }
+
+            _logger.LogInformation("Uploading CDK asset {ObjectKey} to s3://{Bucket}", objectKey, bucketName);
+
+            if (packaging == FileAssetPackaging.ZIP_DIRECTORY)
+            {
+                await UploadZippedDirectoryAsync(s3Client, sourcePath, bucketName, objectKey, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await UploadFileAsync(s3Client, sourcePath, bucketName, objectKey, cancellationToken).ConfigureAwait(false);
+            }
+
+            _logger.LogInformation("Successfully uploaded CDK asset {ObjectKey} to s3://{Bucket}", objectKey, bucketName);
+        }
+    }
+
+    private static async Task<bool> AssetExistsInS3Async(IAmazonS3 s3Client, string bucketName, string objectKey, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await s3Client.GetObjectMetadataAsync(bucketName, objectKey, cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+        catch (AmazonS3Exception ex) when (ex.StatusCode == System.Net.HttpStatusCode.NotFound)
+        {
+            return false;
+        }
+    }
+
+    private static async Task UploadFileAsync(IAmazonS3 s3Client, string filePath, string bucketName, string objectKey, CancellationToken cancellationToken)
+    {
+        using var fileStream = File.OpenRead(filePath);
+        var request = new PutObjectRequest
+        {
+            BucketName = bucketName,
+            Key = objectKey,
+            InputStream = fileStream,
+        };
+        await s3Client.PutObjectAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task UploadZippedDirectoryAsync(IAmazonS3 s3Client, string directoryPath, string bucketName, string objectKey, CancellationToken cancellationToken)
+    {
+        using var memoryStream = new MemoryStream();
+        ZipDirectory(directoryPath, memoryStream);
+        memoryStream.Position = 0;
+
+        var request = new PutObjectRequest
+        {
+            BucketName = bucketName,
+            Key = objectKey,
+            InputStream = memoryStream,
+        };
+        await s3Client.PutObjectAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static void ZipDirectory(string directoryPath, Stream outputStream)
+    {
+        using var archive = new ZipArchive(outputStream, ZipArchiveMode.Create, leaveOpen: true);
+        foreach (var file in new DirectoryInfo(directoryPath).GetFiles("*", SearchOption.AllDirectories))
+        {
+            var entryName = Path.GetRelativePath(directoryPath, file.FullName).Replace('\\', '/');
+            var entry = archive.CreateEntry(entryName, CompressionLevel.Fastest);
+            using var entryStream = entry.Open();
+            using var fileStream = file.OpenRead();
+            fileStream.CopyTo(entryStream);
+        }
+    }
+
+    internal static string ResolveTokens(string value, string accountId, string region) =>
+        value
+            .Replace("${AWS::AccountId}", accountId, StringComparison.Ordinal)
+            .Replace("${AWS::Region}", region, StringComparison.Ordinal);
+
+    private async Task<(string accountId, string region)> GetCallerAccountAndRegionAsync(CancellationToken cancellationToken)
+    {
+        using var stsClient = CreateStsClient();
+        var response = await stsClient.GetCallerIdentityAsync(new GetCallerIdentityRequest(), cancellationToken).ConfigureAwait(false);
+        var region = stsClient.Config.RegionEndpoint?.SystemName ?? "us-east-1";
+        return (response.Account, region);
+    }
+
+    private IAmazonS3 CreateS3Client()
+    {
+        if (_s3ClientFactory != null)
+        {
+            return _s3ClientFactory();
+        }
+
+        AmazonS3Client client;
+        if (_awsSdkConfig != null)
+        {
+            var config = _awsSdkConfig.CreateServiceConfig<AmazonS3Config>();
+            var credentials = DefaultAWSCredentialsIdentityResolver.GetCredentials(config);
+            client = new AmazonS3Client(credentials, config);
+        }
+        else
+        {
+            client = new AmazonS3Client();
+        }
+        client.BeforeRequestEvent += SdkUtilities.ConfigureUserAgentString;
+        return client;
+    }
+
+    private IAmazonSecurityTokenService CreateStsClient()
+    {
+        if (_stsClientFactory != null)
+        {
+            return _stsClientFactory();
+        }
+
+        AmazonSecurityTokenServiceClient client;
+        if (_awsSdkConfig != null)
+        {
+            var config = _awsSdkConfig.CreateServiceConfig<AmazonSecurityTokenServiceConfig>();
+            var credentials = DefaultAWSCredentialsIdentityResolver.GetCredentials(config);
+            client = new AmazonSecurityTokenServiceClient(credentials, config);
+        }
+        else
+        {
+            client = new AmazonSecurityTokenServiceClient();
+        }
+        client.BeforeRequestEvent += SdkUtilities.ConfigureUserAgentString;
+        return client;
+    }
+}

--- a/src/Aspire.Hosting.AWS/Provisioning/CDKAssetUploader.cs
+++ b/src/Aspire.Hosting.AWS/Provisioning/CDKAssetUploader.cs
@@ -46,6 +46,9 @@ internal sealed class CDKAssetUploader
     internal async Task UploadFileAssetsAsync(IDictionary<string, IFileAsset> fileAssets, string assemblyDirectory, CancellationToken cancellationToken)
     {
         var (accountId, region) = await GetCallerAccountAndRegionAsync(cancellationToken).ConfigureAwait(false);
+
+        // All CDK bootstrap bucket destinations for a single stack target the same region
+        // (${AWS::Region} resolves to the deployment region), so one S3 client covers all destinations.
         using var s3Client = CreateS3Client();
 
         foreach (var (_, fileAsset) in fileAssets)
@@ -109,6 +112,12 @@ internal sealed class CDKAssetUploader
         {
             return false;
         }
+        catch (AmazonS3Exception ex) when (ex.StatusCode == System.Net.HttpStatusCode.Forbidden)
+        {
+            // The CDK bootstrap bucket policy may return 403 for a missing object when the caller
+            // lacks s3:ListBucket. Treat this as not-found and attempt the upload.
+            return false;
+        }
     }
 
     private static async Task UploadFileAsync(IAmazonS3 s3Client, string filePath, string bucketName, string objectKey, CancellationToken cancellationToken)
@@ -160,7 +169,13 @@ internal sealed class CDKAssetUploader
     {
         using var stsClient = CreateStsClient();
         var response = await stsClient.GetCallerIdentityAsync(new GetCallerIdentityRequest(), cancellationToken).ConfigureAwait(false);
-        var region = stsClient.Config.RegionEndpoint?.SystemName ?? "us-east-1";
+        var region = stsClient.Config.RegionEndpoint?.SystemName;
+        if (string.IsNullOrEmpty(region))
+        {
+            throw new AWSProvisioningException(
+                "Failed to determine the AWS region for CDK asset upload. " +
+                "Configure a region via IAWSSDKConfig, the AWS_REGION environment variable, or your AWS config file.");
+        }
         return (response.Account, region);
     }
 

--- a/src/Aspire.Hosting.AWS/Provisioning/CDKStackResourceProvisioner.cs
+++ b/src/Aspire.Hosting.AWS/Provisioning/CDKStackResourceProvisioner.cs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
+using Amazon.CDK.CloudAssemblySchema;
 using Amazon.CDK.CXAPI;
 using Amazon.CloudFormation;
 using Aspire.Hosting.ApplicationModel;
@@ -27,18 +28,36 @@ internal sealed class CDKStackResourceProvisioner(
             throw new AWSProvisioningException("Failed to provision stack assets. Could not retrieve stack artifact.");
         }
 
-        var assetArtifacts = artifact.Dependencies.OfType<AssetManifestArtifact>().ToList();
+        var manifests = artifact.Dependencies
+            .OfType<AssetManifestArtifact>()
+            .Select(a => a.Contents)
+            .ToList();
 
-        if (assetArtifacts.Any(a => a.Contents.DockerImages?.Count > 0))
+        await CheckAndUploadManifestsAsync(manifests, artifact.Assembly.Directory, resource.AWSSDKConfig, logger, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static async Task CheckAndUploadManifestsAsync(
+        IEnumerable<IAssetManifest> manifests,
+        string assemblyDirectory,
+        IAWSSDKConfig? awsSdkConfig,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var manifestList = manifests.ToList();
+
+        if (manifestList.Any(m => m.DockerImages?.Count > 0))
         {
             logger.LogError("Container image assets are currently not supported");
             throw new AWSProvisioningException("Failed to provision stack assets. Provisioning container image assets are currently not supported.");
         }
 
-        var uploader = new CDKAssetUploader(resource.AWSSDKConfig, logger);
-        foreach (var assetArtifact in assetArtifacts)
+        var uploader = new CDKAssetUploader(awsSdkConfig, logger);
+        foreach (var manifest in manifestList)
         {
-            await uploader.UploadAssetsAsync(assetArtifact, cancellationToken).ConfigureAwait(false);
+            if (manifest.Files is { Count: > 0 })
+            {
+                await uploader.UploadFileAssetsAsync(manifest.Files, assemblyDirectory, cancellationToken).ConfigureAwait(false);
+            }
         }
     }
 

--- a/src/Aspire.Hosting.AWS/Provisioning/CDKStackResourceProvisioner.cs
+++ b/src/Aspire.Hosting.AWS/Provisioning/CDKStackResourceProvisioner.cs
@@ -16,30 +16,30 @@ internal sealed class CDKStackResourceProvisioner(
     protected override async Task GetOrCreateResourceAsync(StackResource resource, CancellationToken cancellationToken)
     {
         var logger = LoggerService.GetLogger(resource);
-        await ProvisionCDKStackAssetsAsync((StackResource)resource, logger).ConfigureAwait(false);
+        await ProvisionCDKStackAssetsAsync(resource, logger, cancellationToken).ConfigureAwait(false);
         await base.GetOrCreateResourceAsync(resource, cancellationToken).ConfigureAwait(false);
     }
 
-    private static Task ProvisionCDKStackAssetsAsync(StackResource resource, ILogger logger)
+    private static async Task ProvisionCDKStackAssetsAsync(StackResource resource, ILogger logger, CancellationToken cancellationToken)
     {
-        // Currently CDK Stack Assets like S3 and Container images are not supported. When a stack contains those assets
-        // we stop provisioning as it can introduce unwanted issues.
         if (!resource.TryGetStackArtifact(out var artifact))
         {
             throw new AWSProvisioningException("Failed to provision stack assets. Could not retrieve stack artifact.");
         }
 
-        if (!artifact.Dependencies
-                .OfType<AssetManifestArtifact>()
-                .Any(dependency =>
-                    dependency.Contents.Files?.Count > 1
-                    || dependency.Contents.DockerImages?.Count > 0))
+        var assetArtifacts = artifact.Dependencies.OfType<AssetManifestArtifact>().ToList();
+
+        if (assetArtifacts.Any(a => a.Contents.DockerImages?.Count > 0))
         {
-            return Task.CompletedTask;
+            logger.LogError("Container image assets are currently not supported");
+            throw new AWSProvisioningException("Failed to provision stack assets. Provisioning container image assets are currently not supported.");
         }
 
-        logger.LogError("File or container image assets are currently not supported");
-        throw new AWSProvisioningException("Failed to provision stack assets. Provisioning file or container image assets are currently not supported.");
+        var uploader = new CDKAssetUploader(resource.AWSSDKConfig, logger);
+        foreach (var assetArtifact in assetArtifacts)
+        {
+            await uploader.UploadAssetsAsync(assetArtifact, cancellationToken).ConfigureAwait(false);
+        }
     }
 
     protected override void HandleTemplateProvisioningException(Exception ex, StackResource resource, ILogger logger)

--- a/tests/Aspire.Hosting.AWS.UnitTests/CDKAssetUploaderTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/CDKAssetUploaderTests.cs
@@ -188,6 +188,63 @@ public class CDKAssetUploaderTests
         mockS3.Verify(s => s.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
+    [Fact]
+    public async Task UploadFileAssetsAsync_Treats403AsNotFound_AndUploads()
+    {
+        var tempFile = Path.GetTempFileName();
+        File.WriteAllText(tempFile, "lambda code");
+        var tempDir = Path.GetDirectoryName(tempFile)!;
+
+        try
+        {
+            var mockS3 = new Mock<IAmazonS3>();
+            // Bootstrap bucket policy may return 403 when caller lacks s3:ListBucket
+            mockS3.Setup(s => s.GetObjectMetadataAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                  .ThrowsAsync(new AmazonS3Exception("Forbidden") { StatusCode = System.Net.HttpStatusCode.Forbidden });
+            mockS3.Setup(s => s.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+                  .ReturnsAsync(new PutObjectResponse());
+
+            var mockSts = BuildMockSts("123456789012", "us-east-1");
+            var uploader = new CDKAssetUploader(NullLogger.Instance, () => mockS3.Object, () => mockSts.Object);
+
+            var assets = BuildFileAssets(Path.GetFileName(tempFile), FileAssetPackaging.FILE,
+                "cdk-assets-${AWS::AccountId}-${AWS::Region}", "abc123.bin");
+
+            await uploader.UploadFileAssetsAsync(assets, tempDir, CancellationToken.None);
+
+            mockS3.Verify(s => s.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task UploadFileAssetsAsync_ThrowsWhenNoRegionConfigured()
+    {
+        var mockS3 = new Mock<IAmazonS3>();
+
+        // IClientConfig.RegionEndpoint is an interface member, so it can be mocked to return
+        // null regardless of environment variables — unlike the concrete ClientConfig getter
+        // which falls back to the SDK's region resolution chain.
+        var mockConfig = new Mock<Amazon.Runtime.IClientConfig>();
+        mockConfig.Setup(c => c.RegionEndpoint).Returns((Amazon.RegionEndpoint?)null!);
+
+        var mockSts = new Mock<IAmazonSecurityTokenService>();
+        mockSts.Setup(s => s.Config).Returns(mockConfig.Object);
+        mockSts.Setup(s => s.GetCallerIdentityAsync(It.IsAny<GetCallerIdentityRequest>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(new GetCallerIdentityResponse { Account = "123456789012" });
+
+        var uploader = new CDKAssetUploader(NullLogger.Instance, () => mockS3.Object, () => mockSts.Object);
+        var assets = BuildFileAssets("file.zip", FileAssetPackaging.FILE, "my-bucket", "key.zip");
+
+        var ex = await Assert.ThrowsAsync<AWSProvisioningException>(
+            () => uploader.UploadFileAssetsAsync(assets, Path.GetTempPath(), CancellationToken.None));
+
+        Assert.Contains("region", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
     private static Mock<IAmazonSecurityTokenService> BuildMockSts(string accountId, string region)
     {
         var mockSts = new Mock<IAmazonSecurityTokenService>();

--- a/tests/Aspire.Hosting.AWS.UnitTests/CDKAssetUploaderTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/CDKAssetUploaderTests.cs
@@ -1,0 +1,241 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+using System.IO.Compression;
+using Amazon;
+using Amazon.CDK.CloudAssemblySchema;
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Amazon.SecurityToken;
+using Amazon.SecurityToken.Model;
+using Aspire.Hosting.AWS.Provisioning;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Aspire.Hosting.AWS.UnitTests;
+
+public class CDKAssetUploaderTests
+{
+    [Theory]
+    [InlineData("cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}", "123456789012", "us-west-2", "cdk-hnb659fds-assets-123456789012-us-west-2")]
+    [InlineData("my-bucket-${AWS::AccountId}", "000000000000", "eu-west-1", "my-bucket-000000000000")]
+    [InlineData("no-tokens-here", "123456789012", "us-east-1", "no-tokens-here")]
+    [InlineData("${AWS::Region}-bucket-${AWS::AccountId}", "111111111111", "ap-southeast-2", "ap-southeast-2-bucket-111111111111")]
+    public void ResolveTokens_SubstitutesAccountAndRegion(string template, string accountId, string region, string expected)
+    {
+        var result = CDKAssetUploader.ResolveTokens(template, accountId, region);
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ZipDirectory_CreatesZipWithCorrectEntries()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            File.WriteAllText(Path.Combine(tempDir, "index.py"), "def handler(event, context): return 'hello'");
+            var subDir = Path.Combine(tempDir, "utils");
+            Directory.CreateDirectory(subDir);
+            File.WriteAllText(Path.Combine(subDir, "helper.py"), "def help(): pass");
+
+            using var stream = new MemoryStream();
+            CDKAssetUploader.ZipDirectory(tempDir, stream);
+            stream.Position = 0;
+
+            using var archive = new ZipArchive(stream, ZipArchiveMode.Read);
+            var entryNames = archive.Entries.Select(e => e.FullName).OrderBy(n => n).ToList();
+
+            Assert.Contains("index.py", entryNames);
+            Assert.Contains("utils/helper.py", entryNames);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task UploadFileAssetsAsync_SkipsExistingS3Objects()
+    {
+        var tempFile = Path.GetTempFileName();
+        File.WriteAllText(tempFile, "lambda code");
+        var tempDir = Path.GetDirectoryName(tempFile)!;
+
+        try
+        {
+            var mockS3 = new Mock<IAmazonS3>();
+            mockS3.Setup(s => s.GetObjectMetadataAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                  .ReturnsAsync(new GetObjectMetadataResponse());
+
+            var mockSts = BuildMockSts("123456789012", "us-east-1");
+            var uploader = new CDKAssetUploader(NullLogger.Instance, () => mockS3.Object, () => mockSts.Object);
+
+            var assets = BuildFileAssets(Path.GetFileName(tempFile), FileAssetPackaging.FILE,
+                "cdk-assets-${AWS::AccountId}-${AWS::Region}", "abc123.zip");
+
+            await uploader.UploadFileAssetsAsync(assets, tempDir, CancellationToken.None);
+
+            mockS3.Verify(s => s.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task UploadFileAssetsAsync_UploadsFileWhenNotInS3()
+    {
+        var tempFile = Path.GetTempFileName();
+        File.WriteAllText(tempFile, "lambda code");
+        var tempDir = Path.GetDirectoryName(tempFile)!;
+
+        try
+        {
+            var mockS3 = new Mock<IAmazonS3>();
+            mockS3.Setup(s => s.GetObjectMetadataAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                  .ThrowsAsync(new AmazonS3Exception("Not Found") { StatusCode = System.Net.HttpStatusCode.NotFound });
+            mockS3.Setup(s => s.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+                  .ReturnsAsync(new PutObjectResponse());
+
+            var mockSts = BuildMockSts("123456789012", "us-east-1");
+            var uploader = new CDKAssetUploader(NullLogger.Instance, () => mockS3.Object, () => mockSts.Object);
+
+            var assets = BuildFileAssets(Path.GetFileName(tempFile), FileAssetPackaging.FILE,
+                "cdk-assets-${AWS::AccountId}-${AWS::Region}", "abc123.bin");
+
+            await uploader.UploadFileAssetsAsync(assets, tempDir, CancellationToken.None);
+
+            mockS3.Verify(s => s.PutObjectAsync(
+                It.Is<PutObjectRequest>(r =>
+                    r.BucketName == "cdk-assets-123456789012-us-east-1" &&
+                    r.Key == "abc123.bin"),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+        finally
+        {
+            File.Delete(tempFile);
+        }
+    }
+
+    [Fact]
+    public async Task UploadFileAssetsAsync_ZipsAndUploadsDirectory()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        var assetDirName = "function";
+        var assetDir = Path.Combine(tempDir, assetDirName);
+        Directory.CreateDirectory(assetDir);
+        File.WriteAllText(Path.Combine(assetDir, "index.py"), "def handler(event, context): return 'hi'");
+
+        try
+        {
+            string? capturedBucket = null;
+            string? capturedKey = null;
+            byte[]? capturedZipBytes = null;
+
+            var mockS3 = new Mock<IAmazonS3>();
+            mockS3.Setup(s => s.GetObjectMetadataAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                  .ThrowsAsync(new AmazonS3Exception("Not Found") { StatusCode = System.Net.HttpStatusCode.NotFound });
+            mockS3.Setup(s => s.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+                  .Callback<PutObjectRequest, CancellationToken>((req, _) =>
+                  {
+                      capturedBucket = req.BucketName;
+                      capturedKey = req.Key;
+                      // Read the stream content before it gets disposed
+                      using var copy = new MemoryStream();
+                      req.InputStream.CopyTo(copy);
+                      capturedZipBytes = copy.ToArray();
+                  })
+                  .ReturnsAsync(new PutObjectResponse());
+
+            var mockSts = BuildMockSts("123456789012", "us-west-2");
+            var uploader = new CDKAssetUploader(NullLogger.Instance, () => mockS3.Object, () => mockSts.Object);
+
+            var assets = BuildFileAssets(assetDirName, FileAssetPackaging.ZIP_DIRECTORY,
+                "cdk-assets-${AWS::AccountId}-${AWS::Region}", "deadbeef.zip");
+
+            await uploader.UploadFileAssetsAsync(assets, tempDir, CancellationToken.None);
+
+            Assert.Equal("cdk-assets-123456789012-us-west-2", capturedBucket);
+            Assert.Equal("deadbeef.zip", capturedKey);
+            Assert.NotNull(capturedZipBytes);
+
+            using var archive = new ZipArchive(new MemoryStream(capturedZipBytes), ZipArchiveMode.Read);
+            Assert.Single(archive.Entries);
+            Assert.Equal("index.py", archive.Entries[0].FullName);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task UploadFileAssetsAsync_SkipsExecutableAssets()
+    {
+        var mockS3 = new Mock<IAmazonS3>();
+        var mockSts = BuildMockSts("123456789012", "us-east-1");
+        var uploader = new CDKAssetUploader(NullLogger.Instance, () => mockS3.Object, () => mockSts.Object);
+
+        var assets = BuildExecutableFileAssets("cdk-bucket", "exec-asset.zip");
+
+        await uploader.UploadFileAssetsAsync(assets, Path.GetTempPath(), CancellationToken.None);
+
+        mockS3.Verify(s => s.GetObjectMetadataAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        mockS3.Verify(s => s.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static Mock<IAmazonSecurityTokenService> BuildMockSts(string accountId, string region)
+    {
+        var mockSts = new Mock<IAmazonSecurityTokenService>();
+        var config = new AmazonSecurityTokenServiceConfig { RegionEndpoint = RegionEndpoint.GetBySystemName(region) };
+        mockSts.Setup(s => s.Config).Returns(config);
+        mockSts.Setup(s => s.GetCallerIdentityAsync(It.IsAny<GetCallerIdentityRequest>(), It.IsAny<CancellationToken>()))
+               .ReturnsAsync(new GetCallerIdentityResponse { Account = accountId });
+        return mockSts;
+    }
+
+    private static Dictionary<string, IFileAsset> BuildFileAssets(string sourcePath, FileAssetPackaging packaging, string bucketName, string objectKey)
+    {
+        var fileSource = new Mock<IFileSource>();
+        fileSource.Setup(s => s.Path).Returns(sourcePath);
+        fileSource.Setup(s => s.Packaging).Returns(packaging);
+        fileSource.Setup(s => s.Executable).Returns((string[]?)null);
+
+        var destination = new Mock<IFileDestination>();
+        destination.Setup(d => d.BucketName).Returns(bucketName);
+        destination.Setup(d => d.ObjectKey).Returns(objectKey);
+
+        var fileAsset = new Mock<IFileAsset>();
+        fileAsset.Setup(a => a.Source).Returns(fileSource.Object);
+        fileAsset.Setup(a => a.Destinations).Returns(new Dictionary<string, IFileDestination>
+        {
+            ["current_account-current_region"] = destination.Object
+        });
+
+        return new Dictionary<string, IFileAsset> { ["asset-hash"] = fileAsset.Object };
+    }
+
+    private static Dictionary<string, IFileAsset> BuildExecutableFileAssets(string bucketName, string objectKey)
+    {
+        var fileSource = new Mock<IFileSource>();
+        fileSource.Setup(s => s.Executable).Returns(new[] { "node", "bundle.js" });
+        fileSource.Setup(s => s.Path).Returns((string?)null);
+
+        var destination = new Mock<IFileDestination>();
+        destination.Setup(d => d.BucketName).Returns(bucketName);
+        destination.Setup(d => d.ObjectKey).Returns(objectKey);
+
+        var fileAsset = new Mock<IFileAsset>();
+        fileAsset.Setup(a => a.Source).Returns(fileSource.Object);
+        fileAsset.Setup(a => a.Destinations).Returns(new Dictionary<string, IFileDestination>
+        {
+            ["current_account-current_region"] = destination.Object
+        });
+
+        return new Dictionary<string, IFileAsset> { ["exec-asset"] = fileAsset.Object };
+    }
+}


### PR DESCRIPTION
## Motivation and Context
https://github.com/aws/integrations-on-dotnet-aspire-for-aws/issues/132

## Description

Previously, CDK stacks that contained file assets (e.g. `Code.FromAsset`, `Source.Asset`) would fail during Aspire provisioning with "File or container image assets are currently not supported." This PR implements the asset upload logic that the CDK CLI performs as part of `cdk deploy`, enabling the Aspire provisioning path to handle those stacks without requiring the CDK CLI.

### What changed

**`CDKAssetUploader`** (new class in `Provisioning/`) performs the asset upload work before CloudFormation stack creation or update:

- Calls STS `GetCallerIdentity` to resolve the AWS account ID and region, then substitutes CDK token placeholders (`${AWS::AccountId}`, `${AWS::Region}`) in destination bucket names.
- For each file asset in the CDK asset manifest, checks whether the object already exists in the CDK bootstrap S3 bucket (CDK uses content-addressed keys, so unchanged assets are skipped).
- Uploads `FILE` packaging assets directly and creates a zip archive on the fly for `ZIP_DIRECTORY` packaging assets before uploading.
- Skips assets with an executable source (e.g. assets produced by running a bundler command) with a logged warning, as those are not supported.

**`CDKStackResourceProvisioner`** — replaced the blanket exception for file assets with calls to `CDKAssetUploader`. The provisioner still rejects stacks that reference container image assets, which are not supported by this change.

**`AWSSDK.S3`** added as a package dependency to support the S3 upload operations.

### What is NOT handled

Container image (Docker) assets are still not supported. Stacks that reference ECR image assets will continue to fail with a clear error message.

### Playground

`CustomStack` in the `AWSCDK.AppHost` playground now includes a `BucketDeployment` construct that deploys a sample `config.json` file to S3. `BucketDeployment` internally creates a Lambda-backed custom resource whose handler is packaged as a file asset, making it a real-world demonstration of the new asset upload path.