### PR TITLE
bug: fix dotnet pack prerelease package dependency error

### DIFF
--- a/src/Aspire.Hosting.AWS/Aspire.Hosting.AWS.csproj
+++ b/src/Aspire.Hosting.AWS/Aspire.Hosting.AWS.csproj
@@ -5,7 +5,11 @@
     <IsPackable>true</IsPackable>
     <PackageTags>aspire integration hosting aws</PackageTags>
     <Description>Add support for provisioning AWS application resources and configuring the AWS SDK for .NET.</Description>
-    <NoWarn>$(NoWarn);CS8002</NoWarn> <!-- AWS CDK packages are not signed -->
+    <!-- AWS CDK packages are not signed (CS8002). -->
+    <!-- Stable package depends on prerelease
+         AWS.AgentCore.Testing because its Aspire extensions are marked [Experimental] and
+         consumers explicitly opt in (NU5104). -->
+    <NoWarn>$(NoWarn);CS8002;NU5104</NoWarn>
     <Version>13.3.0</Version>
     <PackageReadmeFile>docs\README.md</PackageReadmeFile>
   </PropertyGroup>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`dotnet pack` failed because we are using a pre-release version of `AWS.AgentCore.Testing`. This is intentional, so I suppressed the error.

