### PR TITLE
fix: AgentCore extensions not marked experimental

### DIFF
--- a/.autover/changes/428ed8c0-3c14-4f05-885e-bb7cb21afb48.json
+++ b/.autover/changes/428ed8c0-3c14-4f05-885e-bb7cb21afb48.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Apply [Experimental(ASPIREAWSAGENTCORE001)] to AgentCore extension methods individually so warnings fire at consumer call sites (class-level attribute does not propagate to extension method invocations)."
+      ]
+    }
+  ]
+}

--- a/.autover/changes/428ed8c0-3c14-4f05-885e-bb7cb21afb48.json
+++ b/.autover/changes/428ed8c0-3c14-4f05-885e-bb7cb21afb48.json
@@ -4,7 +4,8 @@
       "Name": "Aspire.Hosting.AWS",
       "Type": "Patch",
       "ChangelogMessages": [
-        "Apply [Experimental(ASPIREAWSAGENTCORE001)] to AgentCore extension methods individually so warnings fire at consumer call sites (class-level attribute does not propagate to extension method invocations)."
+        "Apply [Experimental(ASPIREAWSAGENTCORE001)] to AgentCore extension methods individually so warnings fire at consumer call sites.",
+        "Inject AWS_ENDPOINT_URL_BEDROCK_AGENTCORE via a BeforeStartEvent hook instead of a custom WithReference overload, so consumers use Aspire's stock WithReference without overload-resolution conflicts."
       ]
     }
   ]

--- a/src/Aspire.Hosting.AWS/AgentCore/AgentCoreResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.AWS/AgentCore/AgentCoreResourceBuilderExtensions.cs
@@ -21,7 +21,7 @@ public static class AgentCoreResourceBuilderExtensions
     /// <summary>
     /// Registers an AgentCore agent with a dedicated runtime emulator and chat app.
     /// Returns the agent's <see cref="IResourceBuilder{ProjectResource}"/>.
-    /// Use <c>.WithReference(agent)</c> from another project to inject the runtime
+    /// Use Aspire's <c>.WithReference(agent)</c> from another project to inject the runtime
     /// emulator endpoint as the <c>AWS_ENDPOINT_URL_BEDROCK_AGENTCORE</c> environment variable.
     /// </summary>
     /// <typeparam name="TProject">The agent project type.</typeparam>
@@ -148,64 +148,12 @@ public static class AgentCoreResourceBuilderExtensions
                 await annotation.StopEmulatorsAsync();
             });
 
+        // Wire AWS_ENDPOINT_URL_BEDROCK_AGENTCORE on consumers that .WithReference(agent).
+        // Hooks Aspire's stock WithReference relationship instead of shadowing the overload,
+        // so users keep using the standard Aspire idiom without overload-resolution surprises.
+        EnsureReferenceHook(builder);
+
         return agentApp;
-    }
-
-    /// <summary>
-    /// Wires a project to an AgentCore agent by injecting the runtime emulator endpoint
-    /// as the <c>AWS_ENDPOINT_URL_BEDROCK_AGENTCORE</c> environment variable.
-    /// The AWS SDK picks this up automatically for endpoint routing — no manual
-    /// <c>ServiceURL</c> configuration is needed in the consuming project.
-    /// </summary>
-    /// <typeparam name="TDestination">The destination resource type.</typeparam>
-    /// <param name="builder">The project resource builder.</param>
-    /// <param name="agent">The AgentCore runtime resource builder returned by <see cref="AddAgentCoreRuntime{TProject}"/>.</param>
-    /// <returns>The destination resource builder for further chaining.</returns>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown when the project already has a reference to another AgentCore agent.
-    /// </exception>
-    [Experimental(Constants.ASPIREAWSAGENTCORE001)]
-    public static IResourceBuilder<TDestination> WithReference<TDestination>(
-        this IResourceBuilder<TDestination> builder,
-        IResourceBuilder<ProjectResource> agent)
-        where TDestination : IResourceWithEnvironment
-    {
-        var annotation = agent.Resource.Annotations
-            .OfType<AgentCoreRuntimeAnnotation>()
-            .FirstOrDefault();
-
-        if (annotation is null)
-        {
-            return builder.WithReference(agent as IResourceBuilder<IResourceWithServiceDiscovery>);
-        }
-
-        var hasExistingReference = builder.Resource.Annotations
-            .OfType<AgentCoreReferenceAnnotation>()
-            .Any();
-
-        if (hasExistingReference)
-        {
-            throw new InvalidOperationException(
-                $"Project '{builder.Resource.Name}' already has a WithReference to an AgentCore agent. " +
-                "Only one AgentCore runtime reference is supported per project because the " +
-                "AWS_ENDPOINT_URL_BEDROCK_AGENTCORE environment variable can only point to a single endpoint.");
-        }
-
-        builder.Resource.Annotations.Add(new AgentCoreReferenceAnnotation());
-
-        builder.WithEnvironment(async context =>
-        {
-            if (context.ExecutionContext.IsPublishMode)
-            {
-                return;
-            }
-
-            await annotation.EmulatorStarted.Task;
-            context.EnvironmentVariables["AWS_ENDPOINT_URL_BEDROCK_AGENTCORE"] =
-                $"http://localhost:{annotation.RuntimeEmulatorPort}";
-        });
-
-        return builder;
     }
 
     /// <summary>
@@ -277,6 +225,122 @@ public static class AgentCoreResourceBuilderExtensions
         }
 
         return uri.Port;
+    }
+
+    /// <summary>
+    /// DI marker singleton used to detect whether the reference hook has already been
+    /// subscribed for the current app builder. The instance is never resolved — only its
+    /// presence in <see cref="IServiceCollection"/> is checked.
+    /// </summary>
+    private sealed class AgentCoreReferenceHookMarker;
+
+    /// <summary>
+    /// Subscribes a one-time, app-wide <see cref="BeforeStartEvent"/> handler that wires
+    /// <c>AWS_ENDPOINT_URL_BEDROCK_AGENTCORE</c> onto any resource that calls Aspire's
+    /// stock <c>WithReference(agent)</c> against an AgentCore runtime.
+    ///
+    /// <para>How it works:</para>
+    /// <list type="number">
+    /// <item><description>
+    /// Aspire's <c>WithReference</c> writes a <see cref="ResourceRelationshipAnnotation"/>
+    /// with <c>Type == "Reference"</c> on the consumer, pointing at the source resource —
+    /// for every <c>WithReference</c> overload.
+    /// </description></item>
+    /// <item><description>
+    /// On <see cref="BeforeStartEvent"/> the handler walks every
+    /// <see cref="IResourceWithEnvironment"/> in the model and inspects its relationship
+    /// annotations. References whose target carries an <see cref="AgentCoreRuntimeAnnotation"/>
+    /// (i.e. were created by <c>AddAgentCoreRuntime</c>) are treated as AgentCore references.
+    /// Multiple annotations pointing at the same source are deduped.
+    /// </description></item>
+    /// <item><description>
+    /// If a consumer references two or more <i>distinct</i> AgentCore runtimes the handler
+    /// throws — <c>AWS_ENDPOINT_URL_BEDROCK_AGENTCORE</c> is a single-valued AWS SDK
+    /// endpoint override and cannot point to multiple runtimes simultaneously.
+    /// </description></item>
+    /// <item><description>
+    /// For the resolved single agent, an <see cref="EnvironmentCallbackAnnotation"/> is added
+    /// to the consumer. The callback awaits the agent's
+    /// <see cref="AgentCoreRuntimeAnnotation.EmulatorStarted"/> task — set when the agent's
+    /// <see cref="BeforeResourceStartedEvent"/> handler has bound the runtime emulator port —
+    /// and writes <c>AWS_ENDPOINT_URL_BEDROCK_AGENTCORE=http://localhost:{port}</c>. Publish
+    /// mode is skipped because the emulator only runs locally.
+    /// </description></item>
+    /// </list>
+    ///
+    /// <para>
+    /// Subscription is guarded by <see cref="AgentCoreReferenceHookMarker"/> in
+    /// <see cref="IServiceCollection"/>: every <c>AddAgentCoreRuntime</c> call invokes this
+    /// method, but the handler walks the entire model, so subscribing N times for N agents
+    /// would inject the env var N times per consumer.
+    /// </para>
+    /// </summary>
+    private static void EnsureReferenceHook(IDistributedApplicationBuilder builder)
+    {
+        if (builder.Services.Any(s => s.ServiceType == typeof(AgentCoreReferenceHookMarker)))
+        {
+            return;
+        }
+        builder.Services.AddSingleton<AgentCoreReferenceHookMarker>();
+
+        builder.Eventing.Subscribe<BeforeStartEvent>(static (@event, ct) =>
+        {
+            foreach (var consumer in @event.Model.Resources)
+            {
+                // Only resources that accept env vars can receive AWS_ENDPOINT_URL_BEDROCK_AGENTCORE.
+                if (consumer is not IResourceWithEnvironment)
+                {
+                    continue;
+                }
+
+                // Pick out relationship annotations whose target is an AgentCore runtime.
+                // Aspire writes a ResourceRelationshipAnnotation(Type = "Reference") for every
+                // WithReference call regardless of overload, so this catches all reference shapes.
+                // Dedupe by source resource: two WithReference(sameAgent) calls produce two
+                // relationship annotations, but they're the same logical reference.
+                var agentRefs = consumer.Annotations
+                    .OfType<ResourceRelationshipAnnotation>()
+                    .Where(r => r.Type == "Reference")
+                    .Select(r => (Source: r.Resource, Annotation: r.Resource.Annotations.OfType<AgentCoreRuntimeAnnotation>().FirstOrDefault()))
+                    .Where(x => x.Annotation is not null)
+                    .GroupBy(x => x.Source)
+                    .Select(g => g.First())
+                    .ToList();
+
+                if (agentRefs.Count == 0)
+                {
+                    continue;
+                }
+
+                // AWS_ENDPOINT_URL_BEDROCK_AGENTCORE is single-valued — referencing two
+                // distinct AgentCore runtimes from the same consumer is unsupported.
+                if (agentRefs.Count > 1)
+                {
+                    throw new InvalidOperationException(
+                        $"Resource '{consumer.Name}' has WithReference calls to multiple AgentCore runtimes " +
+                        $"({string.Join(", ", agentRefs.Select(r => r.Source.Name))}). " +
+                        "Only one AgentCore runtime reference is supported per resource because the " +
+                        "AWS_ENDPOINT_URL_BEDROCK_AGENTCORE environment variable can only point to a single endpoint.");
+                }
+
+                // Defer the env var value until the agent's emulator has actually bound a port.
+                // EmulatorStarted is completed by the agent's own BeforeResourceStartedEvent handler.
+                var ann = agentRefs[0].Annotation!;
+                consumer.Annotations.Add(new EnvironmentCallbackAnnotation(async ctx =>
+                {
+                    if (ctx.ExecutionContext.IsPublishMode)
+                    {
+                        return;
+                    }
+
+                    await ann.EmulatorStarted.Task;
+                    ctx.EnvironmentVariables["AWS_ENDPOINT_URL_BEDROCK_AGENTCORE"] =
+                        $"http://localhost:{ann.RuntimeEmulatorPort}";
+                }));
+            }
+
+            return Task.CompletedTask;
+        });
     }
 }
 #endif

--- a/src/Aspire.Hosting.AWS/AgentCore/AgentCoreResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.AWS/AgentCore/AgentCoreResourceBuilderExtensions.cs
@@ -16,7 +16,6 @@ namespace Aspire.Hosting;
 /// Extension methods for adding AgentCore local development resources.
 /// All emulators run as embedded in-process Kestrel servers — no Docker or separate processes required.
 /// </summary>
-[Experimental(Constants.ASPIREAWSAGENTCORE001)]
 public static class AgentCoreResourceBuilderExtensions
 {
     /// <summary>
@@ -30,6 +29,7 @@ public static class AgentCoreResourceBuilderExtensions
     /// <param name="name">The name of the resource.</param>
     /// <param name="options">Optional configuration for the local development experience.</param>
     /// <returns>The agent's resource builder for further configuration.</returns>
+    [Experimental(Constants.ASPIREAWSAGENTCORE001)]
     public static IResourceBuilder<ProjectResource> AddAgentCoreRuntime<TProject>(
         this IDistributedApplicationBuilder builder,
         [ResourceName] string name,
@@ -164,6 +164,7 @@ public static class AgentCoreResourceBuilderExtensions
     /// <exception cref="InvalidOperationException">
     /// Thrown when the project already has a reference to another AgentCore agent.
     /// </exception>
+    [Experimental(Constants.ASPIREAWSAGENTCORE001)]
     public static IResourceBuilder<TDestination> WithReference<TDestination>(
         this IResourceBuilder<TDestination> builder,
         IResourceBuilder<ProjectResource> agent)
@@ -212,6 +213,7 @@ public static class AgentCoreResourceBuilderExtensions
     /// </summary>
     /// <param name="agentApp">The agent resource builder.</param>
     /// <returns>The resource builder for further chaining.</returns>
+    [Experimental(Constants.ASPIREAWSAGENTCORE001)]
     public static IResourceBuilder<ProjectResource> WithStreaming(
         this IResourceBuilder<ProjectResource> agentApp)
     {
@@ -234,6 +236,7 @@ public static class AgentCoreResourceBuilderExtensions
     /// </summary>
     /// <param name="agentApp">The agent resource builder.</param>
     /// <returns>The resource builder for further chaining.</returns>
+    [Experimental(Constants.ASPIREAWSAGENTCORE001)]
     public static IResourceBuilder<ProjectResource> WithInMemory(
         this IResourceBuilder<ProjectResource> agentApp)
     {

--- a/src/Aspire.Hosting.AWS/AgentCore/AgentCoreRuntimeAnnotation.cs
+++ b/src/Aspire.Hosting.AWS/AgentCore/AgentCoreRuntimeAnnotation.cs
@@ -35,9 +35,4 @@ internal class AgentCoreRuntimeAnnotation : IResourceAnnotation
     }
 }
 
-/// <summary>
-/// Marker annotation to track that a project already has an AgentCore runtime reference.
-/// Used to enforce the single-reference constraint.
-/// </summary>
-internal class AgentCoreReferenceAnnotation : IResourceAnnotation;
 #endif

--- a/tests/Aspire.Hosting.AWS.UnitTests/AgentCoreResourceBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/AgentCoreResourceBuilderExtensionsTests.cs
@@ -3,6 +3,7 @@
 
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.AWS.AgentCore;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace Aspire.Hosting.AWS.UnitTests;
@@ -127,8 +128,12 @@ public class AgentCoreResourceBuilderExtensionsTests
     }
 
     [Fact]
-    public void WithReference_AddsReferenceAnnotationToConsumer()
+    public void WithReference_OnAgent_RecordsRelationshipForLifecycleHook()
     {
+        // Consumers wire to AgentCore runtimes using Aspire's stock WithReference overload.
+        // The AgentCore integration injects AWS_ENDPOINT_URL_BEDROCK_AGENTCORE during
+        // BeforeStartEvent by walking the ResourceRelationshipAnnotation entries Aspire writes.
+        // This test verifies the integration point — that the relationship the hook reads is present.
         var builder = DistributedApplication.CreateBuilder();
 
         var agent = builder.AddAgentCoreRuntime<FakeAgent>("my-agent");
@@ -136,38 +141,119 @@ public class AgentCoreResourceBuilderExtensionsTests
 
         consumer.WithReference(agent);
 
-        var refAnnotation = consumer.Resource.Annotations
-            .OfType<AgentCoreReferenceAnnotation>()
-            .SingleOrDefault();
+        var pointsToAgent = consumer.Resource.Annotations
+            .OfType<ResourceRelationshipAnnotation>()
+            .Any(r => r.Type == "Reference" && ReferenceEquals(r.Resource, agent.Resource));
 
-        Assert.NotNull(refAnnotation);
+        Assert.True(pointsToAgent);
     }
 
     [Fact]
-    public void WithReference_ThrowsOnDuplicateReference()
+    public async Task BeforeStartEvent_InjectsBedrockAgentCoreEndpoint_OnReferencingConsumer()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        // End-to-end coverage of the lifecycle hook in EnsureReferenceHook:
+        //  1. consumer.WithReference(agent) writes Aspire's ResourceRelationshipAnnotation
+        //  2. our BeforeStartEvent handler walks those, finds the AgentCoreRuntimeAnnotation
+        //  3. it adds an EnvironmentCallbackAnnotation that resolves AWS_ENDPOINT_URL_BEDROCK_AGENTCORE
+        //
+        // This is the contract test that catches Aspire-side breakages: if Aspire renames
+        // the relationship type, stops writing it, restructures BeforeStartEvent, or changes
+        // any of the annotation shapes our hook depends on, this test fails — even though the
+        // surface API of AddAgentCoreRuntime/WithReference still compiles.
+        var builder = CreatePublishModeBuilder();
 
         var agent = builder.AddAgentCoreRuntime<FakeAgent>("my-agent");
         var consumer = builder.AddProject<FakeConsumer>("consumer", o => o.ExcludeLaunchProfile = true);
-
         consumer.WithReference(agent);
 
-        Assert.Throws<InvalidOperationException>(() => consumer.WithReference(agent));
+        // Pre-resolve the agent's port — in production this happens in the agent's own
+        // BeforeResourceStartedEvent handler, but that path requires a real orchestrator.
+        // Completing EmulatorStarted unblocks our consumer-side env callback.
+        var ann = agent.Resource.Annotations.OfType<AgentCoreRuntimeAnnotation>().Single();
+        ann.RuntimeEmulatorPort = 12345;
+        ann.EmulatorStarted.SetResult();
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        await builder.Eventing.PublishAsync(new BeforeStartEvent(app.Services, model));
+
+        // Use Run-mode execution context so the env callback writes the var (it skips publish mode by design).
+        var envVars = await EvaluateEnvironmentVariables(consumer.Resource, app.Services);
+        Assert.Equal("http://localhost:12345", envVars["AWS_ENDPOINT_URL_BEDROCK_AGENTCORE"]);
     }
 
     [Fact]
-    public void WithReference_ThrowsOnSecondDifferentAgent()
+    public async Task BeforeStartEvent_DoesNotInjectEndpoint_WhenConsumerHasNoAgentCoreReference()
     {
-        var builder = DistributedApplication.CreateBuilder();
+        // Guard against the hook injecting AWS_ENDPOINT_URL_BEDROCK_AGENTCORE on resources
+        // that reference unrelated projects. The hook must only fire when the referenced
+        // resource carries an AgentCoreRuntimeAnnotation.
+        var builder = CreatePublishModeBuilder();
+
+        // Need at least one AddAgentCoreRuntime call for the hook to be registered.
+        builder.AddAgentCoreRuntime<FakeAgent>("unrelated-agent");
+
+        var plainProject = builder.AddProject<FakeAgent>("plain-project", o => o.ExcludeLaunchProfile = true);
+        var consumer = builder.AddProject<FakeConsumer>("consumer", o => o.ExcludeLaunchProfile = true);
+        consumer.WithReference(plainProject);
+
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+        await builder.Eventing.PublishAsync(new BeforeStartEvent(app.Services, model));
+
+        var envVars = await EvaluateEnvironmentVariables(consumer.Resource, app.Services);
+        Assert.False(envVars.ContainsKey("AWS_ENDPOINT_URL_BEDROCK_AGENTCORE"));
+    }
+
+    [Fact]
+    public async Task BeforeStartEvent_Throws_WhenConsumerReferencesMultipleAgentCoreRuntimes()
+    {
+        // AWS_ENDPOINT_URL_BEDROCK_AGENTCORE is a single-valued AWS SDK endpoint override;
+        // pointing it at two distinct runtimes is unsupported. Validation moved from chain-time
+        // to start-time when we removed the custom WithReference overload.
+        var builder = CreatePublishModeBuilder();
 
         var agent1 = builder.AddAgentCoreRuntime<FakeAgent>("agent-1");
         var agent2 = builder.AddAgentCoreRuntime<FakeConsumer>("agent-2");
-        var consumer = builder.AddProject<Fake_Agent_Name>("consumer", o => o.ExcludeLaunchProfile = true);
-
+        var consumer = builder.AddProject<FakeAgent>("consumer", o => o.ExcludeLaunchProfile = true);
         consumer.WithReference(agent1);
+        consumer.WithReference(agent2);
 
-        Assert.Throws<InvalidOperationException>(() => consumer.WithReference(agent2));
+        using var app = builder.Build();
+        var model = app.Services.GetRequiredService<DistributedApplicationModel>();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            builder.Eventing.PublishAsync(new BeforeStartEvent(app.Services, model)));
+    }
+
+    // Build in Publish mode to skip Aspire's DCP wiring (DCP isn't available in unit tests).
+    // Our EnsureReferenceHook subscribes to BeforeStartEvent regardless of mode, so the test
+    // still exercises the hook end-to-end. The hook's runtime callback skips publish mode, so
+    // EvaluateEnvironmentVariables synthesizes a Run-mode context for the env eval step.
+    private static IDistributedApplicationBuilder CreatePublishModeBuilder()
+        => DistributedApplication.CreateBuilder(new DistributedApplicationOptions
+        {
+            Args = ["--operation", "publish", "--publisher", "manifest"]
+        });
+
+    private static async Task<Dictionary<string, string>> EvaluateEnvironmentVariables(IResource resource, IServiceProvider services)
+    {
+        var result = new Dictionary<string, string>();
+        var runContext = new DistributedApplicationExecutionContext(
+            new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run) { ServiceProvider = services });
+
+        foreach (var callback in resource.Annotations.OfType<EnvironmentCallbackAnnotation>())
+        {
+            var raw = new Dictionary<string, object>();
+            var ctx = new EnvironmentCallbackContext(runContext, resource, raw);
+            await callback.Callback(ctx);
+            foreach (var (k, v) in raw)
+            {
+                result[k] = v?.ToString() ?? string.Empty;
+            }
+        }
+
+        return result;
     }
 
     [Fact]
@@ -195,9 +281,5 @@ public class AgentCoreResourceBuilderExtensionsTests
         Assert.True(annotation.HasMemory);
     }
 
-    private sealed class Fake_Agent_Name : IProjectMetadata
-    {
-        public string ProjectPath => "fakeAgentName";
-    }
 }
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Apply `[Experimental(ASPIREAWSAGENTCORE001)]` to AgentCore extension methods individually so warnings fire at consumer call sites (class-level attribute does not propagate to extension method invocations).