### PR TITLE
Add support for deploying AgentCore applications

### DIFF
--- a/.autover/changes/157ae91a-a436-422b-87b3-53825aba703b.json
+++ b/.autover/changes/157ae91a-a436-422b-87b3-53825aba703b.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "[Preview] Add support for deploying to Bedrock AgentCore"
+      ]
+    }
+  ]
+}

--- a/docs/deployment-design.md
+++ b/docs/deployment-design.md
@@ -343,7 +343,7 @@ the standard reference convention:
 AWS:Resources:{agentName}:AgentRuntimeArn
 ```
 
-which is delivered as the environment variable `AWS_RESOURCES__{AGENT}__AGENTRUNTIMEARN`. The
+which is delivered as the environment variable `AWS__Resources__{agentName}__AgentRuntimeArn`. The
 consuming application reads this single key in both local and deployed modes:
 
 ```csharp

--- a/docs/deployment-design.md
+++ b/docs/deployment-design.md
@@ -11,10 +11,11 @@ The AWS deployment system for .NET Aspire transforms Aspire AppHost resources in
 3. [Publish Extension Methods](#publish-extension-methods)
 4. [CDK Props and Construct Callbacks](#cdk-props-and-construct-callbacks)
 5. [Default Constructs and Attributes](#default-constructs-and-attributes)
-6. [CDKDefaultsProvider System](#cdkdefaultsprovider-system)
-7. [Publish Target Selection](#publish-target-selection)
-8. [Resource References and Connectivity](#resource-references-and-connectivity)
-9. [Adding New Publish Targets](#adding-new-publish-targets)
+6. [ECS Task Roles](#ecs-task-roles)
+7. [CDKDefaultsProvider System](#cdkdefaultsprovider-system)
+8. [Publish Target Selection](#publish-target-selection)
+9. [Resource References and Connectivity](#resource-references-and-connectivity)
+10. [Adding New Publish Targets](#adding-new-publish-targets)
 
 ---
 
@@ -199,7 +200,7 @@ lambdaFunction.PublishAsLambdaFunction(new PublishLambdaFunctionConfig
 
 ### AgentCore Callbacks Example
 
-AgentCore publish targets expose callbacks for both the `CfnRuntime` and `CfnRuntimeEndpoint` constructs:
+AgentCore publish targets expose callbacks for the `CfnRuntime` construct:
 
 ```csharp
 builder.AddAgentCoreRuntime<Projects.MyAgent>("my-agent")
@@ -212,15 +213,167 @@ builder.AddAgentCoreRuntime<Projects.MyAgent>("my-agent")
         ConstructCfnRuntimeCallback = (ctx, construct) =>
         {
             // Access the runtime after creation
-        },
-        PropsCfnRuntimeEndpointCallback = (ctx, props) =>
-        {
-            props.Description = "Production endpoint";
         }
     });
 ```
 
+The publish target creates only the `CfnRuntime`; it does not create a named `CfnRuntimeEndpoint`.
+Bedrock AgentCore automatically provisions a `DEFAULT` endpoint for every runtime, and consumers
+invoke the agent using the runtime ARN (see below). A dedicated named endpoint may be added as an
+opt-in capability in a future version.
+
 Note that projects registered with `AddAgentCoreRuntime<T>()` are automatically deployed to Bedrock AgentCore without needing to call `PublishAsAgentCoreRuntime()`. The explicit method is only needed when you want to customize the CDK props or constructs via callbacks.
+
+### AgentCore Platform and IAM Requirements
+
+Bedrock AgentCore imposes several service-specific requirements that the integration handles automatically. They are worth knowing because they differ from the ECS Fargate publish targets.
+
+#### arm64 container image
+
+Bedrock AgentCore only runs **`arm64`** container images. A runtime created with an amd64/x86_64 image fails at deploy time with:
+
+```
+Invalid request provided: Architecture incompatible for uri '...'. Supported platforms: [arm64]
+```
+
+To guarantee the published image is always built for the correct architecture, `AddAgentCoreRuntime<T>()` pins the agent project's container build platform to `linux/arm64` using Aspire's `WithContainerBuildOptions`:
+
+```csharp
+builder.AddProject<TProject>(projectName, o => o.ExcludeLaunchProfile = true)
+    .WithHttpEndpoint(name: "http")
+    .WithEnvironment("AWS_AGENTCORE_ASPIRE_MANAGED", "true")
+    // Bedrock AgentCore only runs arm64 images; force linux/arm64 regardless of host architecture.
+    .WithContainerBuildOptions(context => context.TargetPlatform = ContainerTargetPlatform.LinuxArm64);
+```
+
+This applies at publish/build time only — local development runs the project directly without a container, so the host architecture is irrelevant there.
+
+> **Build environment note:** When publishing from an amd64 host, building a `linux/arm64` image requires cross-architecture build support (Docker Buildx with QEMU/binfmt). On an arm64 host (e.g. Apple Silicon) the image builds natively.
+
+#### Execution role trust policy
+
+The runtime's IAM execution role must be assumable by the Bedrock AgentCore **control-plane** service principal, which is **`bedrock-agentcore.amazonaws.com`** — *not* `bedrock.amazonaws.com`. Using the wrong principal fails at deploy time with:
+
+```
+Invalid request provided: Role validation failed for '...'. Please verify that the role exists
+and its trust policy allows assumption by this service (Service: BedrockAgentCoreControl, ...)
+```
+
+`CreateDefaultAgentCoreRuntimeRole()` creates the role with the correct principal and scopes the trust policy with `aws:SourceAccount`/`aws:SourceArn` conditions to guard against the confused-deputy problem:
+
+```csharp
+protected virtual IRole CreateDefaultAgentCoreRuntimeRole()
+{
+    var stack = EnvironmentResource.CDKStack;
+
+    var role = new Role(stack, "DefaultAgentCoreRuntimeRole", new RoleProps
+    {
+        AssumedBy = new ServicePrincipal("bedrock-agentcore.amazonaws.com", new ServicePrincipalOpts
+        {
+            Conditions = new Dictionary<string, object>
+            {
+                ["StringEquals"] = new Dictionary<string, object>
+                {
+                    ["aws:SourceAccount"] = stack.Account
+                },
+                ["ArnLike"] = new Dictionary<string, object>
+                {
+                    ["aws:SourceArn"] = $"arn:{stack.Partition}:bedrock-agentcore:{stack.Region}:{stack.Account}:*"
+                }
+            }
+        }),
+        ManagedPolicies = new[]
+        {
+            ManagedPolicy.FromAwsManagedPolicyName("AmazonEC2ContainerRegistryReadOnly"),
+            ManagedPolicy.FromAwsManagedPolicyName("CloudWatchLogsFullAccess"),
+        }
+    });
+
+    // Grant the model invocation actions (see "Model invocation permissions" below).
+    role.AddToPrincipalPolicy(new PolicyStatement(new PolicyStatementProps
+    {
+        Effect = Effect.ALLOW,
+        Actions = new[] { "bedrock:InvokeModel*" },
+        Resources = new[]
+        {
+            $"arn:{stack.Partition}:bedrock:*::foundation-model/*",
+            $"arn:{stack.Partition}:bedrock:*:{stack.Account}:inference-profile/*"
+        }
+    }));
+
+    return role;
+}
+```
+
+Because the role is shared across all AgentCore runtimes in the stack and the per-runtime ARN is not known when the role is created, the `aws:SourceArn` condition uses an account/region-scoped wildcard rather than a specific runtime ARN. To supply your own role instead, expose an `IRole` property marked with `[DefaultAgentCoreRuntimeRole]` on a custom stack (see [Default Constructs and Attributes](#default-constructs-and-attributes)).
+
+#### Model invocation permissions
+
+The agent code running inside the runtime calls Bedrock foundation models, so the default execution role is granted the model invocation actions. Without them, invocation fails at runtime with:
+
+```
+AccessDeniedException: User: arn:aws:sts::<account>:assumed-role/...DefaultAgentCoreRuntimeRole.../...
+is not authorized to perform: bedrock:InvokeModel on resource:
+arn:aws:bedrock:us-west-2:<account>:inference-profile/global.anthropic.claude-sonnet-4-6
+because no identity-based policy allows the bedrock:InvokeModel action
+```
+
+The inline policy uses the `bedrock:InvokeModel*` wildcard (covering `InvokeModel`, `InvokeModelWithResponseStream`, and related actions) and scopes the resource to **both**:
+
+- `foundation-model/*` (account-less ARN, region wildcarded) — direct model invocation, and the underlying foundation models that a `global.*` inference profile routes to across regions.
+- `inference-profile/*` (account-scoped, region wildcarded) — invocation through a cross-region inference profile. This is required because newer models (e.g. Claude Sonnet 4.6) are commonly invoked via an inference-profile ARN, which does **not** match the `foundation-model` pattern. When invoking through a profile, Bedrock authorizes against both the profile ARN and the underlying foundation-model ARNs, so both resource forms must be allowed.
+
+> **Scope note:** this grants `InvokeModel*` on all foundation models and inference profiles in the account/partition. To restrict to specific model IDs, supply your own role via the `[DefaultAgentCoreRuntimeRole]` attribute.
+
+### Referencing an AgentCore Runtime (resolving the runtime ARN)
+
+A consuming resource references an agent with the standard Aspire idiom:
+
+```csharp
+var agent = builder.AddAgentCoreRuntime<Projects.MyAgent>("my-agent");
+
+builder.AddProject<Projects.Backend>("backend")
+    .WithReference(agent);
+```
+
+`WithReference(agent)` injects the agent's runtime ARN into the consumer's `IConfiguration` under
+the standard reference convention:
+
+```
+AWS:Resources:{agentName}:AgentRuntimeArn
+```
+
+which is delivered as the environment variable `AWS_RESOURCES__{AGENT}__AGENTRUNTIMEARN`. The
+consuming application reads this single key in both local and deployed modes:
+
+```csharp
+var agentRuntimeArn = builder.Configuration["AWS:Resources:my-agent:AgentRuntimeArn"];
+
+var response = await agentClient.InvokeAgentRuntimeAsync(new InvokeAgentRuntimeRequest
+{
+    AgentRuntimeArn = agentRuntimeArn,
+    Payload = payloadStream
+});
+```
+
+- **Local development** — the reference hook sets the key to the placeholder `"local-agent"`
+  alongside the `AWS_ENDPOINT_URL_BEDROCK_AGENTCORE` endpoint override. The emulator ignores the ARN,
+  so the placeholder is sufficient and the SDK is routed to the in-process emulator.
+- **Deployment** — the `AgentCoreRuntimePublishTarget` returns the value from
+  `GetReferenceConnectionInfo`, mapping the key to the `CfnRuntime`'s `AttrAgentRuntimeArn`. This
+  resolves to a CloudFormation `Fn::GetAtt` token, so the deployed consumer's compute resource (e.g.
+  the ECS container definition) receives the real runtime ARN as an environment variable. This is the
+  same relationship-to-environment-variable mechanism used by other AWS references (S3, DynamoDB,
+  ElastiCache).
+
+In addition to the environment variable, a consumer that references an agent is granted permission to
+invoke it. When the referencing ECS service was assigned the integration's default task role (see
+[ECS Task Roles](#ecs-task-roles)), the `AgentCoreRuntimePublishTarget` attaches an inline policy to
+that task role allowing `bedrock-agentcore:Invoke*`, scoped to the runtime ARN and its child endpoints
+(`{runtimeArn}` and `{runtimeArn}/*`). If the user supplied their own task role, no policy is attached —
+granting invoke permission is then the user's responsibility. This is driven by the
+`ReferenceRequiresTaskRolePolicy()` / `ApplyReferenceTaskRolePolicy()` reference hooks (see
+[Resource References and Connectivity](#resource-references-and-connectivity)).
 
 ### CDKPublishTargetContext
 
@@ -305,6 +458,47 @@ protected virtual ICluster CreateDefaultECSCluster()
     });
 }
 ```
+
+---
+
+## ECS Task Roles
+
+An ECS task definition has two distinct IAM roles:
+
+- **Execution role** — used by the ECS/Fargate platform to pull the image, write logs, and resolve secrets. The integration assigns a shared default for this (e.g. `DefaultECSExpressExecutionRole`).
+- **Task role** — the role the application's *own* code assumes at runtime to call AWS APIs (S3, DynamoDB, Bedrock AgentCore, etc.).
+
+All three ECS publish targets — `PublishAsECSFargateExpressService` (`CfnExpressGatewayService.TaskRoleArn`), `PublishAsECSFargateService` (`FargateTaskDefinition.TaskRole`), and `PublishAsECSFargateServiceWithALB` (`ApplicationLoadBalancedTaskImageOptions.TaskRole`) — assign a **default task role when the user has not supplied one**. This gives every service a consistent, controllable identity and a place for references to attach scoped permissions.
+
+### Per-service, created empty
+
+Unlike the shared execution/infrastructure roles, the task role is **created per service** (named `{resourceName}-DefaultTaskRole`) rather than shared. A shared role would leak one service's reference permissions (e.g. AgentCore invoke) to every other service. It is created empty (trusted by `ecs-tasks.amazonaws.com`, no managed policies) by `CreateDefaultECSTaskRole`:
+
+```csharp
+protected internal virtual IRole CreateDefaultECSTaskRole(string resourceName)
+{
+    return new Role(EnvironmentResource.CDKStack, $"{resourceName}-DefaultTaskRole", new RoleProps
+    {
+        AssumedBy = new ServicePrincipal("ecs-tasks.amazonaws.com")
+    });
+}
+```
+
+Each publish target creates the role only when the relevant prop is unset (after the user's props callback and the `Apply*Defaults` call have run), assigns it, and exposes it to the reference system via the connection-points `ReferenceTaskRole` property:
+
+```csharp
+IRole? defaultTaskRole = null;
+if (string.IsNullOrEmpty(fargateServiceProps.TaskRoleArn))   // L2 targets check the IRole TaskRole prop instead
+{
+    defaultTaskRole = environment.DefaultsProvider.CreateDefaultECSTaskRole(projectResource.Name);
+    fargateServiceProps.TaskRoleArn = defaultTaskRole.RoleArn;
+}
+// defaultTaskRole is passed to the connection-points object; ReferenceTaskRole returns it (else null)
+```
+
+### Interaction with references
+
+Because only the integration-created role is exposed through `ReferenceTaskRole`, the task-role policy hooks (see [Task Role Policies](#4-task-role-policies)) run **only** when the default role was used. If the user supplies their own task role — via a props callback on the publish target — the integration never mutates it, and the user owns granting any permissions their references need. The concrete payoff: a service that `WithReference`s an AgentCore agent automatically gets `bedrock-agentcore:Invoke*` on its default task role.
 
 ---
 
@@ -401,6 +595,8 @@ public virtual void ApplyAgentCoreRuntimeDefaults(CfnRuntimeProps props)
 
     if (string.IsNullOrEmpty(props.RoleArn))
     {
+        // GetDefaultAgentCoreRuntimeRole() creates a role trusted by bedrock-agentcore.amazonaws.com.
+        // See "AgentCore Platform and IAM Requirements" for details.
         props.RoleArn = GetDefaultAgentCoreRuntimeRole().RoleArn;
     }
 }
@@ -813,9 +1009,38 @@ public override void ApplyReferenceSecurityGroup(
 }
 ```
 
+### 4. Task Role Policies
+
+Some references require the *referencing* resource's IAM task role to be granted permissions, not just network access. For example, an ECS service that references an AgentCore runtime invokes it at runtime via the AgentCore data-plane APIs and so needs `bedrock-agentcore:Invoke*` on its task role.
+
+This mirrors the security-group hook. The referenced resource's publish target declares whether it needs a policy and, if so, attaches one to the task role exposed by the referencing construct:
+
+```csharp
+// AgentCore Publish Target
+public override bool ReferenceRequiresTaskRolePolicy() => true;
+
+public override void ApplyReferenceTaskRolePolicy(
+    AWSLinkedObjectsAnnotation linkedAnnotation,
+    IRole taskRole)
+{
+    if (linkedAnnotation.Construct is not CfnRuntime runtime)
+        return;
+
+    var runtimeArn = runtime.AttrAgentRuntimeArn;
+    taskRole.AddToPrincipalPolicy(new PolicyStatement(new PolicyStatementProps
+    {
+        Effect = Effect.ALLOW,
+        Actions = new[] { "bedrock-agentcore:Invoke*" },
+        Resources = new[] { runtimeArn, Fn.Join("", new[] { runtimeArn, "/*" }) }
+    }));
+}
+```
+
+The hook only fires when the referencing construct exposes a `ReferenceTaskRole` (see the connection-points pattern below), which is set **only** when the integration created the default task role. If the user supplied their own task role, no policy is attached and granting the permission is the user's responsibility. See [ECS Task Roles](#ecs-task-roles) for how the default task role is created and wired.
+
 ### Connection Points Pattern
 
-Each CDK construct type has a corresponding "Connection Points" class that provides a uniform interface for setting environment variables, VPC, and security groups:
+Each CDK construct type has a corresponding "Connection Points" class that provides a uniform interface for setting environment variables, VPC, security groups, and the task role:
 
 ```csharp
 public class AbstractCDKConstructConnectionPoints
@@ -823,6 +1048,9 @@ public class AbstractCDKConstructConnectionPoints
     public virtual IDictionary<string, string>? EnvironmentVariables { get; set; }
     public virtual ISecurityGroup? ReferenceSecurityGroup { get; }
     public virtual IVpc? Vpc { get; set; }
+    // Non-null only when the publish target created the default task role, so a
+    // user-supplied role is never mutated by a reference's task-role policy hook.
+    public virtual IRole? ReferenceTaskRole { get; }
 }
 ```
 
@@ -1196,7 +1424,7 @@ The AWS deployment system for .NET Aspire provides a flexible, extensible archit
 5. **Default Constructs**: Override shared resources using attributes in your custom stack
 6. **Versioned Defaults**: CDKDefaultsProvider allows opt-in to breaking changes
 7. **Automatic Selection**: Resources without explicit publish targets are matched automatically — including annotation-based detection (e.g., AgentCore agents are auto-detected via `AgentCoreRuntimeAnnotation`)
-8. **Reference Handling**: Automatic configuration of environment variables, VPC, and security groups
+8. **Reference Handling**: Automatic configuration of environment variables, VPC, security groups, and task-role policies (e.g. AgentCore invoke permissions)
 9. **Extensibility**: Add new publish targets for new resource types or alternative deployment options
 
 ### Supported Publish Targets
@@ -1207,6 +1435,6 @@ The AWS deployment system for .NET Aspire provides a flexible, extensible archit
 | Console `ProjectResource` (no endpoints) | ECS Fargate Service | `FargateService` |
 | `LambdaProjectResource` | AWS Lambda Function | `Function` |
 | `RedisResource` / `ValkeyResource` | ElastiCache Serverless Cluster | `CfnServerlessCache` |
-| `ProjectResource` with `AgentCoreRuntimeAnnotation` | Bedrock AgentCore Runtime | `CfnRuntime` + `CfnRuntimeEndpoint` |
+| `ProjectResource` with `AgentCoreRuntimeAnnotation` | Bedrock AgentCore Runtime | `CfnRuntime` |
 
 This design enables both simple deployments with sensible defaults and complex customizations for production workloads.

--- a/docs/deployment-design.md
+++ b/docs/deployment-design.md
@@ -121,6 +121,18 @@ builder.AddAWSCDKEnvironment<DeploymentStack>(
 
 By default, Aspire resources are mapped to AWS services based on their type. You can override this behavior using Publish extension methods:
 
+### Available Publish Extension Methods
+
+| Method | Resource Type | Deploys To |
+|--------|--------------|------------|
+| `PublishAsECSFargateExpressService()` | `ProjectResource` (web) | ECS Fargate Express Service with shared ALB |
+| `PublishAsECSFargateService()` | `ProjectResource` (console) | ECS Fargate Service (no HTTP endpoint) |
+| `PublishAsECSFargateServiceWithALB()` | `ProjectResource` (web) | ECS Fargate Service with dedicated ALB |
+| `PublishAsLambdaFunction()` | `LambdaProjectResource` | AWS Lambda Function |
+| `PublishAsElasticCacheProvisionCluster()` | `RedisResource` / `ValkeyResource` | ElastiCache Provisioned Cluster |
+| `PublishAsElasticCacheServerlessCluster()` | `RedisResource` / `ValkeyResource` | ElastiCache Serverless Cluster |
+| `PublishAsAgentCoreRuntime()` | `ProjectResource` (AgentCore) | Bedrock AgentCore Container Runtime |
+
 ### Overriding Defaults
 
 ```csharp
@@ -185,6 +197,31 @@ lambdaFunction.PublishAsLambdaFunction(new PublishLambdaFunctionConfig
 });
 ```
 
+### AgentCore Callbacks Example
+
+AgentCore publish targets expose callbacks for both the `CfnRuntime` and `CfnRuntimeEndpoint` constructs:
+
+```csharp
+builder.AddAgentCoreRuntime<Projects.MyAgent>("my-agent")
+    .PublishAsAgentCoreRuntime(new PublishAgentCoreRuntimeConfig
+    {
+        PropsCfnRuntimeCallback = (ctx, props) =>
+        {
+            props.Description = "My production agent";
+        },
+        ConstructCfnRuntimeCallback = (ctx, construct) =>
+        {
+            // Access the runtime after creation
+        },
+        PropsCfnRuntimeEndpointCallback = (ctx, props) =>
+        {
+            props.Description = "Production endpoint";
+        }
+    });
+```
+
+Note that projects registered with `AddAgentCoreRuntime<T>()` are automatically deployed to Bedrock AgentCore without needing to call `PublishAsAgentCoreRuntime()`. The explicit method is only needed when you want to customize the CDK props or constructs via callbacks.
+
 ### CDKPublishTargetContext
 
 The context object passed to callbacks provides:
@@ -229,6 +266,19 @@ public class DeploymentStack : Stack
 
 Now all resources requiring a VPC will use the account's default VPC instead of creating a new one.
 
+### Available Default Construct Attributes
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `[DefaultVpc]` | `IVpc` | Default VPC for all resources |
+| `[DefaultECSCluster]` | `ICluster` | Default ECS Cluster for Fargate services |
+| `[DefaultECSClusterSecurityGroup]` | `ISecurityGroup` | Security group for ECS cluster |
+| `[DefaultECSExpressExecutionRole]` | `IRole` | Execution role for ECS Express services |
+| `[DefaultECSExpressInfrastructureRole]` | `IRole` | Infrastructure role for ECS Express services |
+| `[DefaultElastiCacheCfnSubnetGroup]` | `CfnSubnetGroup` | Subnet group for ElastiCache provisioned clusters |
+| `[DefaultElastiCacheNodeSecurityGroup]` | `ISecurityGroup` | Security group for ElastiCache provisioned clusters |
+| `[DefaultElastiCacheServerlessSecurityGroup]` | `ISecurityGroup` | Security group for ElastiCache serverless clusters |
+| `[DefaultAgentCoreRuntimeRole]` | `IRole` | Execution role for Bedrock AgentCore runtimes |
 
 ### Default Construct Creation
 
@@ -307,6 +357,9 @@ public virtual LambdaProjectResourcePublishTarget DefaultLambdaProjectResourcePu
 
 public virtual RedisResourcePublishTarget DefaultRedisResourcePublishTarget 
     { get; set; } = RedisResourcePublishTarget.ElastiCacheServerlessCluster;
+
+public virtual AgentCoreProjectResourcePublishTarget DefaultAgentCoreProjectResourcePublishTarget 
+    { get; set; } = AgentCoreProjectResourcePublishTarget.AgentCoreRuntime;
 ```
 
 #### 2. Resource-Specific Defaults
@@ -332,6 +385,23 @@ public virtual void ApplyCfnExpressGatewayServiceDefaults(CfnExpressGatewayServi
     if (props.PrimaryContainer is ExpressGatewayContainerProperty container)
     {
         container.Port ??= 8080;  // Default container port
+    }
+}
+
+// Example: AgentCore runtime defaults
+public virtual void ApplyAgentCoreRuntimeDefaults(CfnRuntimeProps props)
+{
+    if (props.NetworkConfiguration == null)
+    {
+        props.NetworkConfiguration = new CfnRuntime.NetworkConfigurationProperty
+        {
+            NetworkMode = AgentCoreRuntimeNetworkMode  // Default: "PUBLIC"
+        };
+    }
+
+    if (string.IsNullOrEmpty(props.RoleArn))
+    {
+        props.RoleArn = GetDefaultAgentCoreRuntimeRole().RoleArn;
     }
 }
 ```
@@ -509,6 +579,33 @@ public override IsDefaultPublishTargetMatchResult IsDefaultPublishTargetMatch(
 }
 ```
 
+**Example: Bedrock AgentCore Runtime (annotation-based detection)**
+
+AgentCore uses a different detection strategy from Lambda and ECS. While Lambda checks the resource type (`LambdaProjectResource`) and ECS checks for endpoints, AgentCore detects the `AgentCoreRuntimeAnnotation` that `AddAgentCoreRuntime<T>()` attaches to the `ProjectResource`. This is necessary because AgentCore agents are standard `ProjectResource` instances, distinguished only by their annotation.
+
+```csharp
+public override IsDefaultPublishTargetMatchResult IsDefaultPublishTargetMatch(
+    CDKDefaultsProvider cdkDefaultsProvider, 
+    IResource resource)
+{
+    // Match any ProjectResource that was registered via AddAgentCoreRuntime<T>()
+    if (resource is ProjectResource &&
+        resource.Annotations.OfType<AgentCoreRuntimeAnnotation>().Any())
+    {
+        return new IsDefaultPublishTargetMatchResult
+        {
+            IsMatch = true,
+            PublishTargetAnnotation = new PublishAgentCoreRuntimeAnnotation(),
+            Rank = IsDefaultPublishTargetMatchResult.DEFAULT_MATCH_RANK + 200
+        };
+    }
+
+    return IsDefaultPublishTargetMatchResult.NO_MATCH;
+}
+```
+
+The rank of `DEFAULT_MATCH_RANK + 200` ensures AgentCore wins over both the web project default (rank 200) and the console project default (rank 100) when the annotation is present.
+
 ### Ranking System
 
 The rank determines priority when multiple targets match. An example of a scenario where there can be multiple matches is an Aspire `ProjectResource` that has endpoints (i.e. Web Project). The publishing target for web a web project match as well as the generic .NET project. The rank allows the system to prefer the web project match over the generic .NET project.
@@ -526,6 +623,8 @@ public virtual WebProjectResourcePublishTarget DefaultWebProjectResourcePublishT
 ```
 
 Publish targets check these properties in their `IsDefaultPublishTargetMatch()` implementation, allowing users to change defaults by customizing the provider.
+
+Note that some publish targets use annotation-based detection instead of (or in addition to) the defaults provider enum. For example, the AgentCore publish target matches any `ProjectResource` that has an `AgentCoreRuntimeAnnotation`, which is added by `AddAgentCoreRuntime<T>()`. This pattern is useful when a specialized deployment target applies to a standard resource type distinguished by an annotation rather than a dedicated subclass.
 
 ---
 
@@ -1096,8 +1195,18 @@ The AWS deployment system for .NET Aspire provides a flexible, extensible archit
 4. **Customization**: Use callbacks to modify CDK props and constructs
 5. **Default Constructs**: Override shared resources using attributes in your custom stack
 6. **Versioned Defaults**: CDKDefaultsProvider allows opt-in to breaking changes
-7. **Automatic Selection**: Resources without explicit publish targets are matched automatically
+7. **Automatic Selection**: Resources without explicit publish targets are matched automatically — including annotation-based detection (e.g., AgentCore agents are auto-detected via `AgentCoreRuntimeAnnotation`)
 8. **Reference Handling**: Automatic configuration of environment variables, VPC, and security groups
 9. **Extensibility**: Add new publish targets for new resource types or alternative deployment options
+
+### Supported Publish Targets
+
+| Aspire Resource | Default AWS Target | CDK Construct |
+|----------------|-------------------|---------------|
+| Web `ProjectResource` (with endpoints) | ECS Fargate Express Service | `CfnExpressGatewayService` |
+| Console `ProjectResource` (no endpoints) | ECS Fargate Service | `FargateService` |
+| `LambdaProjectResource` | AWS Lambda Function | `Function` |
+| `RedisResource` / `ValkeyResource` | ElastiCache Serverless Cluster | `CfnServerlessCache` |
+| `ProjectResource` with `AgentCoreRuntimeAnnotation` | Bedrock AgentCore Runtime | `CfnRuntime` + `CfnRuntimeEndpoint` |
 
 This design enables both simple deployments with sensible defaults and complex customizations for production workloads.

--- a/integrations-on-dotnet-aspire-for-aws.sln
+++ b/integrations-on-dotnet-aspire-for-aws.sln
@@ -96,6 +96,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgentCore.StreamingAgent", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgentCore.ChatUI", "playground\AgentCore\AgentCore.ChatUI\AgentCore.ChatUI.csproj", "{A7D9BE9B-D93D-4293-BAC1-B32E144AA84A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Publishing.HoroscopeAgent", "playground\Publishing\Publishing.HoroscopeAgent\Publishing.HoroscopeAgent.csproj", "{A3BF9A43-3708-6FDE-B53B-8ED52AE9779D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -514,6 +516,18 @@ Global
 		{A7D9BE9B-D93D-4293-BAC1-B32E144AA84A}.Release|x64.Build.0 = Release|Any CPU
 		{A7D9BE9B-D93D-4293-BAC1-B32E144AA84A}.Release|x86.ActiveCfg = Release|Any CPU
 		{A7D9BE9B-D93D-4293-BAC1-B32E144AA84A}.Release|x86.Build.0 = Release|Any CPU
+		{A3BF9A43-3708-6FDE-B53B-8ED52AE9779D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3BF9A43-3708-6FDE-B53B-8ED52AE9779D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3BF9A43-3708-6FDE-B53B-8ED52AE9779D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A3BF9A43-3708-6FDE-B53B-8ED52AE9779D}.Debug|x64.Build.0 = Debug|Any CPU
+		{A3BF9A43-3708-6FDE-B53B-8ED52AE9779D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A3BF9A43-3708-6FDE-B53B-8ED52AE9779D}.Debug|x86.Build.0 = Debug|Any CPU
+		{A3BF9A43-3708-6FDE-B53B-8ED52AE9779D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A3BF9A43-3708-6FDE-B53B-8ED52AE9779D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A3BF9A43-3708-6FDE-B53B-8ED52AE9779D}.Release|x64.ActiveCfg = Release|Any CPU
+		{A3BF9A43-3708-6FDE-B53B-8ED52AE9779D}.Release|x64.Build.0 = Release|Any CPU
+		{A3BF9A43-3708-6FDE-B53B-8ED52AE9779D}.Release|x86.ActiveCfg = Release|Any CPU
+		{A3BF9A43-3708-6FDE-B53B-8ED52AE9779D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -559,6 +573,7 @@ Global
 		{352351D7-5E50-4542-ADD1-6D8E860F9079} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 		{8AF39284-B5D3-408E-A39A-27A88AF7D6F9} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
 		{A7D9BE9B-D93D-4293-BAC1-B32E144AA84A} = {A1B2C3D4-E5F6-7890-ABCD-EF1234567890}
+		{A3BF9A43-3708-6FDE-B53B-8ED52AE9779D} = {95D2252C-FE45-4452-80A8-3C425756CB5D}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {FBA55172-92F1-4495-A082-E0ABE4F4AF09}

--- a/playground/Publishing/Backend/Backend.csproj
+++ b/playground/Publishing/Backend/Backend.csproj
@@ -1,7 +1,6 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
     <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
@@ -10,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" />
-    <PackageReference Include="Aspire.StackExchange.Redis" />    
+    <PackageReference Include="Aspire.StackExchange.Redis" />
+    <PackageReference Include="AWSSDK.BedrockAgentCore" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" />
   </ItemGroup>
 
   <ItemGroup>

--- a/playground/Publishing/Backend/Program.cs
+++ b/playground/Publishing/Backend/Program.cs
@@ -16,9 +16,19 @@ builder.Services.AddHttpClient<FrontendApiClient>(client =>
 // set by Aspire's WithReference(horoscopeAgent) — no manual ServiceURL configuration needed.
 builder.Services.TryAddAWSService<IAmazonBedrockAgentCore>();
 
+// WithReference(horoscopeAgent) injects the agent's runtime ARN under this IConfiguration key.
+// Locally it resolves to the "local-agent" placeholder (the emulator ignores it); when deployed
+// the generated CDK stack sets it to the real AWS::BedrockAgentCore::Runtime ARN — same code path.
+var agentRuntimeArn = builder.Configuration["AWS:Resources:HoroscopeAgent:AgentRuntimeArn"]
+    ?? throw new InvalidOperationException(
+        "Missing configuration 'AWS:Resources:HoroscopeAgent:AgentRuntimeArn'. " +
+        "Ensure the backend has WithReference(horoscopeAgent) in the AppHost.");
+
 var app = builder.Build();
 
 app.MapDefaultEndpoints();
+
+app.MapGet("/", () => Results.Ok("Welcome to the backend! Try /horoscope/{sign} to get today's horoscope for a zodiac sign."));
 
 app.MapGet("/horoscope/{sign}", async (string sign, IAmazonBedrockAgentCore agentClient) =>
 {
@@ -27,8 +37,9 @@ app.MapGet("/horoscope/{sign}", async (string sign, IAmazonBedrockAgentCore agen
 
     var response = await agentClient.InvokeAgentRuntimeAsync(new Amazon.BedrockAgentCore.Model.InvokeAgentRuntimeRequest
     {
-        AgentRuntimeArn = "local-agent",
-        Payload = payloadStream
+        AgentRuntimeArn = agentRuntimeArn,
+        Payload = payloadStream,
+        ContentType = "application/json"
     });
 
     using var reader = new StreamReader(response.Response);

--- a/playground/Publishing/Backend/Program.cs
+++ b/playground/Publishing/Backend/Program.cs
@@ -1,17 +1,40 @@
-﻿using Backend;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
+using System.Text.Json;
+using Amazon.BedrockAgentCore;
+using Backend;
 
-var builder = Host.CreateApplicationBuilder(args)
-    .AddServiceDefaults();
+var builder = WebApplication.CreateBuilder(args);
+builder.AddServiceDefaults();
 
 builder.AddRedisClient("cache");
 builder.Services.AddHostedService<BackgroundProcessor>();
 builder.Services.AddHttpClient<FrontendApiClient>(client =>
     {
-        // This URL uses "https+http://" to indicate HTTPS is preferred over HTTP.
-        // Learn more about service discovery scheme resolution at https://aka.ms/dotnet/sdschemes.
         client.BaseAddress = new("https+http://Frontend");
     });
 
-await builder.Build().RunAsync();
+// The AWS SDK automatically picks up AWS_ENDPOINT_URL_BEDROCK_AGENTCORE
+// set by Aspire's WithReference(horoscopeAgent) — no manual ServiceURL configuration needed.
+builder.Services.TryAddAWSService<IAmazonBedrockAgentCore>();
+
+var app = builder.Build();
+
+app.MapDefaultEndpoints();
+
+app.MapGet("/horoscope/{sign}", async (string sign, IAmazonBedrockAgentCore agentClient) =>
+{
+    var payload = JsonSerializer.Serialize(new { prompt = $"Give me today's horoscope for {sign}." });
+    using var payloadStream = new MemoryStream(System.Text.Encoding.UTF8.GetBytes(payload));
+
+    var response = await agentClient.InvokeAgentRuntimeAsync(new Amazon.BedrockAgentCore.Model.InvokeAgentRuntimeRequest
+    {
+        AgentRuntimeArn = "local-agent",
+        Payload = payloadStream
+    });
+
+    using var reader = new StreamReader(response.Response);
+    var body = await reader.ReadToEndAsync();
+
+    return Results.Ok(new { sign, horoscope = body });
+});
+
+app.Run();

--- a/playground/Publishing/Publishing.AppHost/DeploymentStack.cs
+++ b/playground/Publishing/Publishing.AppHost/DeploymentStack.cs
@@ -1,5 +1,6 @@
 ﻿using Amazon.CDK;
 using Amazon.CDK.AWS.EC2;
+using Amazon.CDK.AWS.IAM;
 using Amazon.CDK.AWS.SQS;
 using Aspire.Hosting.AWS.Deployment;
 using Constructs;

--- a/playground/Publishing/Publishing.AppHost/Program.cs
+++ b/playground/Publishing/Publishing.AppHost/Program.cs
@@ -23,7 +23,7 @@ var awsSdkConfig = builder.AddAWSSDKConfig().WithRegion(Amazon.RegionEndpoint.US
 
 builder.AddAWSCDKEnvironment("aws", 
                                     CDKDefaultsProviderFactory.Preview_V1, 
-                                    (app, props) => new DeploymentStack(app, "AspirePlay1", props), 
+                                    (app, props) => new DeploymentStack(app, "AspirePlay5", props), 
                                     new AWSCDKEnvironmentResourceConfig { AWSSDKConfig = awsSdkConfig });
 
 var cdkStackResource = builder.AddAWSCDKStack("AWSLambdaPlaygroundResources");
@@ -37,7 +37,9 @@ builder.Configuration["Parameters:db-connection"] = "Server=localhost;Database=m
 var apiKey = builder.AddParameter("api-key");
 var dbConnection = builder.AddParameter("db-connection", secret: true);
 
-var horoscopeAgent = builder.AddAgentCoreRuntime<Projects.Publishing_HoroscopeAgent>("HoroscopeAgent");
+var horoscopeAgent = builder.AddAgentCoreRuntime<Projects.Publishing_HoroscopeAgent>("HoroscopeAgent")
+        .WithReference(cache)
+        .WaitFor(cache);
 
 var frontend = builder.AddProject<Projects.Frontend>("Frontend")
         .WithEnvironment("ENV_LAMBDA_1", "LambdaValue1")

--- a/playground/Publishing/Publishing.AppHost/Program.cs
+++ b/playground/Publishing/Publishing.AppHost/Program.cs
@@ -15,6 +15,7 @@ using Lambda.AppHost;
 #pragma warning disable ASPIREAWSPUBLISHERS001
 #pragma warning disable ASPIRECOMPUTE001
 #pragma warning disable ASPIREINTERACTION001
+#pragma warning disable ASPIREAWSAGENTCORE001
 
 var builder = DistributedApplication.CreateBuilder(args);
 
@@ -35,6 +36,8 @@ builder.Configuration["Parameters:api-key"] = "default-api-key";
 builder.Configuration["Parameters:db-connection"] = "Server=localhost;Database=mydb";
 var apiKey = builder.AddParameter("api-key");
 var dbConnection = builder.AddParameter("db-connection", secret: true);
+
+var horoscopeAgent = builder.AddAgentCoreRuntime<Projects.Publishing_HoroscopeAgent>("HoroscopeAgent");
 
 var frontend = builder.AddProject<Projects.Frontend>("Frontend")
         .WithEnvironment("ENV_LAMBDA_1", "LambdaValue1")
@@ -57,6 +60,7 @@ builder.AddProject<Projects.Backend>("backend")
         })
         .WithReference(frontend)
         .WithReference(cache)
+        .WithReference(horoscopeAgent)
         .WaitFor(cache);
 
 builder.AddAWSLambdaFunction<Projects.SQSProcessorFunction>("SQSProcessorFunction", "SQSProcessorFunction::SQSProcessorFunction.Function::FunctionHandler")

--- a/playground/Publishing/Publishing.AppHost/Program.cs
+++ b/playground/Publishing/Publishing.AppHost/Program.cs
@@ -23,7 +23,7 @@ var awsSdkConfig = builder.AddAWSSDKConfig().WithRegion(Amazon.RegionEndpoint.US
 
 builder.AddAWSCDKEnvironment("aws", 
                                     CDKDefaultsProviderFactory.Preview_V1, 
-                                    (app, props) => new DeploymentStack(app, "AspirePlay5", props), 
+                                    (app, props) => new DeploymentStack(app, "AspirePlay1", props), 
                                     new AWSCDKEnvironmentResourceConfig { AWSSDKConfig = awsSdkConfig });
 
 var cdkStackResource = builder.AddAWSCDKStack("AWSLambdaPlaygroundResources");
@@ -37,9 +37,7 @@ builder.Configuration["Parameters:db-connection"] = "Server=localhost;Database=m
 var apiKey = builder.AddParameter("api-key");
 var dbConnection = builder.AddParameter("db-connection", secret: true);
 
-var horoscopeAgent = builder.AddAgentCoreRuntime<Projects.Publishing_HoroscopeAgent>("HoroscopeAgent")
-        .WithReference(cache)
-        .WaitFor(cache);
+var horoscopeAgent = builder.AddAgentCoreRuntime<Projects.Publishing_HoroscopeAgent>("HoroscopeAgent");
 
 var frontend = builder.AddProject<Projects.Frontend>("Frontend")
         .WithEnvironment("ENV_LAMBDA_1", "LambdaValue1")

--- a/playground/Publishing/Publishing.AppHost/Properties/launchSettings.json
+++ b/playground/Publishing/Publishing.AppHost/Properties/launchSettings.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17296;http://localhost:15137",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21296",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22291"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15136",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19286",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20267",
+        "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+      }
+    }
+  }
+}

--- a/playground/Publishing/Publishing.AppHost/Publishing.AppHost.csproj
+++ b/playground/Publishing/Publishing.AppHost/Publishing.AppHost.csproj
@@ -23,4 +23,11 @@
 	  <ProjectReference Include="..\Publishing.HoroscopeAgent\Publishing.HoroscopeAgent.csproj" />
 	</ItemGroup>
 
+	<ItemGroup>
+	  <None Update="Properties\launchSettings.json">
+	    <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+	    <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+	  </None>
+	</ItemGroup>
+
 </Project>

--- a/playground/Publishing/Publishing.AppHost/Publishing.AppHost.csproj
+++ b/playground/Publishing/Publishing.AppHost/Publishing.AppHost.csproj
@@ -20,6 +20,7 @@
 	  <ProjectReference Include="..\Backend\Backend.csproj" />
 	  <ProjectReference Include="..\Frontend\Frontend.csproj" />
 	  <ProjectReference Include="..\SQSProcessorFunction\SQSProcessorFunction.csproj" />
+	  <ProjectReference Include="..\Publishing.HoroscopeAgent\Publishing.HoroscopeAgent.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/playground/Publishing/Publishing.HoroscopeAgent/HoroscopeAgent.cs
+++ b/playground/Publishing/Publishing.HoroscopeAgent/HoroscopeAgent.cs
@@ -1,0 +1,67 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+using System.ComponentModel;
+using AWS.AgentCore.Hosting;
+using Microsoft.Agents.AI;
+using Publishing.HoroscopeAgent.Models;
+
+namespace Publishing.HoroscopeAgent;
+
+public class HoroscopeAgent(ChatClientAgent chatAgent, ILogger<HoroscopeAgent> logger)
+{
+    [AgentCoreHandler]
+    public async Task<string> HandleInvocation(
+        PromptRequest request,
+        AgentCoreRuntimeContext context,
+        CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Horoscope invocation — SessionId={SessionId}, RequestId={RequestId}",
+            context.SessionId, context.RequestId);
+
+        var session = await chatAgent.CreateSessionAsync(cancellationToken: cancellationToken);
+
+        var response = await chatAgent.RunAsync(
+            request.Prompt ?? "Give me a general horoscope for today.",
+            session: session,
+            cancellationToken: cancellationToken);
+
+        return response.ToString();
+    }
+
+    [AgentCorePing]
+    public object Ping() => new { status = "Healthy", time_of_last_update = DateTimeOffset.UtcNow.ToUnixTimeSeconds() };
+
+    [Description("Gets today's horoscope for a given zodiac sign. Valid signs are: Aries, Taurus, Gemini, Cancer, Leo, Virgo, Libra, Scorpio, Sagittarius, Capricorn, Aquarius, Pisces.")]
+    public static string GetHoroscope(
+        [Description("The zodiac sign to get the horoscope for")] string sign,
+        [Description("The current date in yyyy-MM-dd format")] string date)
+        => $"Horoscope for {sign} on {date}: The stars are aligned in your favor today. Trust your instincts and embrace new opportunities.";
+
+    [Description("Gets the zodiac sign for a given birth date.")]
+    public static string GetZodiacSign([Description("The birth date in MM-dd format")] string birthDate)
+    {
+        if (!DateTime.TryParseExact($"2000-{birthDate}", "yyyy-MM-dd",
+                System.Globalization.CultureInfo.InvariantCulture,
+                System.Globalization.DateTimeStyles.None, out var date))
+            return "Invalid date format. Please use MM-dd format.";
+
+        return date switch
+        {
+            { Month: 3, Day: >= 21 } or { Month: 4, Day: <= 19 } => "Aries",
+            { Month: 4, Day: >= 20 } or { Month: 5, Day: <= 20 } => "Taurus",
+            { Month: 5, Day: >= 21 } or { Month: 6, Day: <= 20 } => "Gemini",
+            { Month: 6, Day: >= 21 } or { Month: 7, Day: <= 22 } => "Cancer",
+            { Month: 7, Day: >= 23 } or { Month: 8, Day: <= 22 } => "Leo",
+            { Month: 8, Day: >= 23 } or { Month: 9, Day: <= 22 } => "Virgo",
+            { Month: 9, Day: >= 23 } or { Month: 10, Day: <= 22 } => "Libra",
+            { Month: 10, Day: >= 23 } or { Month: 11, Day: <= 21 } => "Scorpio",
+            { Month: 11, Day: >= 22 } or { Month: 12, Day: <= 21 } => "Sagittarius",
+            { Month: 12, Day: >= 22 } or { Month: 1, Day: <= 19 } => "Capricorn",
+            { Month: 1, Day: >= 20 } or { Month: 2, Day: <= 18 } => "Aquarius",
+            _ => "Pisces"
+        };
+    }
+
+    [Description("Gets the current date in yyyy-MM-dd format.")]
+    public static string GetCurrentDate() => DateTime.UtcNow.ToString("yyyy-MM-dd");
+}

--- a/playground/Publishing/Publishing.HoroscopeAgent/HoroscopeAgent.cs
+++ b/playground/Publishing/Publishing.HoroscopeAgent/HoroscopeAgent.cs
@@ -1,29 +1,51 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 
-using System.ComponentModel;
 using AWS.AgentCore.Hosting;
 using Microsoft.Agents.AI;
 using Publishing.HoroscopeAgent.Models;
+using StackExchange.Redis;
+using System.ComponentModel;
 
 namespace Publishing.HoroscopeAgent;
 
-public class HoroscopeAgent(ChatClientAgent chatAgent, ILogger<HoroscopeAgent> logger)
+public class HoroscopeAgent
 {
+    private ChatClientAgent _chatAgent;
+    private ILogger<HoroscopeAgent> _logger;
+    private IDatabase _database;
+
+    public HoroscopeAgent(ChatClientAgent chatAgent, IConnectionMultiplexer mp, ILogger<HoroscopeAgent> logger)
+    {
+        _chatAgent = chatAgent;
+        _database = mp.GetDatabase();
+        _logger = logger;
+    }
+
     [AgentCoreHandler]
     public async Task<string> HandleInvocation(
         PromptRequest request,
         AgentCoreRuntimeContext context,
         CancellationToken cancellationToken)
     {
-        logger.LogInformation("Horoscope invocation — SessionId={SessionId}, RequestId={RequestId}",
+        _logger.LogInformation("Horoscope invocation — SessionId={SessionId}, RequestId={RequestId}",
             context.SessionId, context.RequestId);
 
-        var session = await chatAgent.CreateSessionAsync(cancellationToken: cancellationToken);
+        var session = await _chatAgent.CreateSessionAsync(cancellationToken: cancellationToken);
 
-        var response = await chatAgent.RunAsync(
-            request.Prompt ?? "Give me a general horoscope for today.",
+        var prompt = request.Prompt ?? "Give me a general horoscope for today.";
+
+        if(_database.StringGet(prompt) is var cachedResponse && cachedResponse.HasValue)
+        {
+            _logger.LogInformation("Returning cached response for prompt: {Prompt}", prompt);
+            return cachedResponse.ToString();
+        }
+
+        var response = await _chatAgent.RunAsync(
+            prompt,
             session: session,
             cancellationToken: cancellationToken);
+
+        _database.StringSet(prompt, response.ToString(), TimeSpan.FromMinutes(10));
 
         return response.ToString();
     }

--- a/playground/Publishing/Publishing.HoroscopeAgent/Models/PromptRequest.cs
+++ b/playground/Publishing/Publishing.HoroscopeAgent/Models/PromptRequest.cs
@@ -1,0 +1,5 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+namespace Publishing.HoroscopeAgent.Models;
+
+public record PromptRequest(string? Prompt);

--- a/playground/Publishing/Publishing.HoroscopeAgent/Publishing.HoroscopeAgent.csproj
+++ b/playground/Publishing/Publishing.HoroscopeAgent/Publishing.HoroscopeAgent.csproj
@@ -8,6 +8,11 @@
 
     <ItemGroup>
         <PackageReference Include="AWS.AgentCore.Hosting" />
+		<PackageReference Include="Aspire.StackExchange.Redis" />
+	</ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\Publishing.ServiceDefaults\Publishing.ServiceDefaults.csproj" />
     </ItemGroup>
 
 </Project>

--- a/playground/Publishing/Publishing.HoroscopeAgent/Publishing.HoroscopeAgent.csproj
+++ b/playground/Publishing/Publishing.HoroscopeAgent/Publishing.HoroscopeAgent.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="AWS.AgentCore.Hosting" />
+    </ItemGroup>
+
+</Project>

--- a/playground/Publishing/Publishing.HoroscopeAgent/Startup.cs
+++ b/playground/Publishing/Publishing.HoroscopeAgent/Startup.cs
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+using AWS.AgentCore.Hosting;
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+
+namespace Publishing.HoroscopeAgent;
+
+[AgentCoreStartup]
+public class Startup
+{
+    public void ConfigureServices(WebApplicationBuilder builder)
+    {
+        builder.AddAgentCore(options =>
+        {
+            options.ModelId = "global.anthropic.claude-sonnet-4-6";
+            options.AgentOptions = new ChatClientAgentOptions
+            {
+                ChatOptions = new()
+                {
+                    Tools =
+                    [
+                        AIFunctionFactory.Create(HoroscopeAgent.GetHoroscope),
+                        AIFunctionFactory.Create(HoroscopeAgent.GetZodiacSign),
+                        AIFunctionFactory.Create(HoroscopeAgent.GetCurrentDate)
+                    ]
+                }
+            };
+        });
+    }
+}

--- a/playground/Publishing/Publishing.HoroscopeAgent/Startup.cs
+++ b/playground/Publishing/Publishing.HoroscopeAgent/Startup.cs
@@ -11,6 +11,9 @@ public class Startup
 {
     public void ConfigureServices(WebApplicationBuilder builder)
     {
+        builder.AddServiceDefaults();
+        builder.AddRedisClient("cache");
+
         builder.AddAgentCore(options =>
         {
             options.ModelId = "global.anthropic.claude-sonnet-4-6";

--- a/src/Aspire.Hosting.AWS/AgentCore/AgentCoreResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.AWS/AgentCore/AgentCoreResourceBuilderExtensions.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.AWS;
 using Aspire.Hosting.AWS.AgentCore;
+using Aspire.Hosting.Publishing;
 using AWS.AgentCore.Testing;
 using AWS.AgentCore.Testing.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -45,7 +46,11 @@ public static class AgentCoreResourceBuilderExtensions
 
         var agentApp = builder.AddProject<TProject>(projectName, o => o.ExcludeLaunchProfile = true)
             .WithHttpEndpoint(name: "http")
-            .WithEnvironment("AWS_AGENTCORE_ASPIRE_MANAGED", "true");
+            .WithEnvironment("AWS_AGENTCORE_ASPIRE_MANAGED", "true")
+            // Bedrock AgentCore only runs arm64 container images, so the published image must be
+            // built for linux/arm64 regardless of the host architecture. This affects publish only;
+            // local development runs the project directly without a container.
+            .WithContainerBuildOptions(context => context.TargetPlatform = ContainerTargetPlatform.LinuxArm64);
 
         // Suppress default endpoint URLs — we add our own with display names
         agentApp.WithUrls(context =>
@@ -326,6 +331,9 @@ public static class AgentCoreResourceBuilderExtensions
                 // Defer the env var value until the agent's emulator has actually bound a port.
                 // EmulatorStarted is completed by the agent's own BeforeResourceStartedEvent handler.
                 var ann = agentRefs[0].Annotation!;
+                var agentName = agentRefs[0].Source.Name;
+                var agentRuntimeArnKey =
+                    $"{Constants.DefaultConfigSection}:{agentName}:{Constants.AgentRuntimeArnOutputName}".ToEnvironmentVariables();
                 consumer.Annotations.Add(new EnvironmentCallbackAnnotation(async ctx =>
                 {
                     if (ctx.ExecutionContext.IsPublishMode)
@@ -336,6 +344,11 @@ public static class AgentCoreResourceBuilderExtensions
                     await ann.EmulatorStarted.Task;
                     ctx.EnvironmentVariables["AWS_ENDPOINT_URL_BEDROCK_AGENTCORE"] =
                         $"http://localhost:{ann.RuntimeEmulatorPort}";
+
+                    // Mirror the deployment convention so app code reads the same IConfiguration key
+                    // in both modes. The emulator ignores the ARN, so a placeholder is sufficient locally;
+                    // at deploy time the CDK stack sets this to the real AWS::BedrockAgentCore::Runtime ARN.
+                    ctx.EnvironmentVariables[agentRuntimeArnKey] = "local-agent";
                 }));
             }
 

--- a/src/Aspire.Hosting.AWS/Constants.cs
+++ b/src/Aspire.Hosting.AWS/Constants.cs
@@ -24,6 +24,13 @@ internal static class Constants
     /// </summary>
     public const string DefaultConfigSection = "AWS:Resources";
 
+    /// <summary>
+    /// The output name appended to an AgentCore runtime's config section when a resource references it.
+    /// The full key is <c>AWS:Resources:{agentName}:AgentRuntimeArn</c>. Shared between the local
+    /// development reference hook and the deployment publish target so the convention can never drift.
+    /// </summary>
+    internal const string AgentRuntimeArnOutputName = "AgentRuntimeArn";
+
     internal const string IsAspireHostedEnvVariable = "ASPIRE_HOSTED";
     
     /// <summary>

--- a/src/Aspire.Hosting.AWS/Deployment/AWSCDKEnvironmentExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/AWSCDKEnvironmentExtensions.cs
@@ -38,6 +38,10 @@ public static class AWSCDKEnvironmentExtensions
         builder.Services.AddTransient<IAWSPublishTarget, ElastiCacheProvisionClusterPublishTarget>();
         builder.Services.AddTransient<IAWSPublishTarget, ElastiCacheServerlessClusterPublishTarget>();
         builder.Services.AddTransient<IAWSPublishTarget, LambdaFunctionPublishTarget>();
+
+#if NET10_0_OR_GREATER
+        builder.Services.AddTransient<IAWSPublishTarget, AgentCoreRuntimePublishTarget>();
+#endif
     }
 
     /// <summary>
@@ -332,5 +336,24 @@ public static class AWSCDKEnvironmentExtensions
         builder.Resource.Annotations.Add(annotation);
 
         return builder;
-    }    
+    }
+
+#if NET10_0_OR_GREATER
+    /// <summary>
+    /// Deploy project to AWS Bedrock AgentCore as a container runtime.
+    /// The CDK <see href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-bedrockagentcore-runtime.html">AWS::BedrockAgentCore::Runtime</see>
+    /// construct is used to create the AgentCore runtime.
+    /// </summary>
+    /// <param name="builder">The resource builder for the resource to configure.</param>
+    /// <param name="config">Configuration for attaching callbacks to customize the CDK construct's props and associate the created CDK construct to other CDK constructs.</param>
+    /// <returns>The same resource builder instance for chaining additional configuration.</returns>
+    [Experimental(Constants.ASPIREAWSPUBLISHERS001)]
+    public static IResourceBuilder<ProjectResource> PublishAsAgentCoreRuntime(this IResourceBuilder<ProjectResource> builder, PublishAgentCoreRuntimeConfig? config = null)
+    {
+        var annotation = new PublishAgentCoreRuntimeAnnotation { Config = config ?? new PublishAgentCoreRuntimeConfig() };
+        builder.Resource.Annotations.Add(annotation);
+
+        return builder;
+    }
+#endif
 }

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaultAttributes.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaultAttributes.cs
@@ -84,3 +84,15 @@ public class DefaultElastiCacheServerlessSecurityGroupAttribute : Attribute
 {
 
 }
+
+#if NET10_0_OR_GREATER
+/// <summary>
+/// Attribute applied on a property or field in the CDK deployment stack of type <see cref="Amazon.CDK.AWS.IAM.IRole"/>.
+/// This will be used for the Bedrock AgentCore runtime execution role.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public class DefaultAgentCoreRuntimeRoleAttribute : Attribute
+{
+
+}
+#endif

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.AgentCoreRuntime.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.AgentCoreRuntime.cs
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#if NET10_0_OR_GREATER
+
+using Amazon.CDK.AWS.BedrockAgentCore;
+using Amazon.CDK.AWS.IAM;
+
+namespace Aspire.Hosting.AWS.Deployment.CDKDefaults;
+
+public partial class CDKDefaultsProvider
+{
+    /// <summary>
+    /// Gets the default network mode for AgentCore runtimes.
+    /// </summary>
+    /// <remarks>
+    /// Default is "PUBLIC" which means the runtime is accessible without requiring a VPC.
+    /// </remarks>
+    public virtual string AgentCoreRuntimeNetworkMode => "PUBLIC";
+
+    private IRole? _defaultAgentCoreRuntimeRole;
+
+    /// <summary>
+    /// Gets the default IAM role for AgentCore runtimes. The role is shared across all AgentCore runtimes in the stack.
+    /// </summary>
+    /// <returns>The default IAM role for AgentCore runtimes.</returns>
+    public IRole GetDefaultAgentCoreRuntimeRole()
+    {
+        if (_defaultAgentCoreRuntimeRole == null)
+        {
+            var definedDefault = FindDefaultConstructByAttribute<DefaultAgentCoreRuntimeRoleAttribute, IRole>();
+            if (definedDefault != null)
+            {
+                _defaultAgentCoreRuntimeRole = definedDefault;
+            }
+            else
+            {
+                _defaultAgentCoreRuntimeRole = CreateDefaultAgentCoreRuntimeRole();
+            }
+        }
+
+        return _defaultAgentCoreRuntimeRole;
+    }
+
+    /// <summary>
+    /// Creates the default IAM role for AgentCore runtimes with trust policy for the bedrock service principal.
+    /// </summary>
+    /// <returns>The created IAM role.</returns>
+    protected virtual IRole CreateDefaultAgentCoreRuntimeRole()
+    {
+        return new Role(EnvironmentResource.CDKStack, "DefaultAgentCoreRuntimeRole", new RoleProps
+        {
+            AssumedBy = new ServicePrincipal("bedrock.amazonaws.com"),
+            ManagedPolicies = new[]
+            {
+                ManagedPolicy.FromAwsManagedPolicyName("AmazonEC2ContainerRegistryReadOnly"),
+                ManagedPolicy.FromAwsManagedPolicyName("CloudWatchLogsFullAccess"),
+            }
+        });
+    }
+
+    /// <summary>
+    /// Applies default configuration values to the specified AgentCore runtime properties if they are not already set.
+    /// </summary>
+    /// <param name="props">The AgentCore runtime properties to which default values will be applied.</param>
+    protected internal virtual void ApplyAgentCoreRuntimeDefaults(CfnRuntimeProps props)
+    {
+        if (props.NetworkConfiguration == null)
+        {
+            props.NetworkConfiguration = new CfnRuntime.NetworkConfigurationProperty
+            {
+                NetworkMode = AgentCoreRuntimeNetworkMode
+            };
+        }
+
+        if (string.IsNullOrEmpty(props.RoleArn))
+        {
+            props.RoleArn = GetDefaultAgentCoreRuntimeRole().RoleArn;
+        }
+    }
+}
+
+#endif

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.AgentCoreRuntime.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.AgentCoreRuntime.cs
@@ -2,6 +2,7 @@
 
 #if NET10_0_OR_GREATER
 
+using Amazon.CDK;
 using Amazon.CDK.AWS.BedrockAgentCore;
 using Amazon.CDK.AWS.IAM;
 
@@ -42,20 +43,56 @@ public partial class CDKDefaultsProvider
     }
 
     /// <summary>
-    /// Creates the default IAM role for AgentCore runtimes with trust policy for the bedrock service principal.
+    /// Creates the default IAM role for AgentCore runtimes with a trust policy for the Bedrock AgentCore service principal.
     /// </summary>
     /// <returns>The created IAM role.</returns>
     protected virtual IRole CreateDefaultAgentCoreRuntimeRole()
     {
-        return new Role(EnvironmentResource.CDKStack, "DefaultAgentCoreRuntimeRole", new RoleProps
+        var stack = EnvironmentResource.CDKStack;
+
+        // Bedrock AgentCore runtimes are assumed by the bedrock-agentcore service principal (NOT
+        // bedrock.amazonaws.com). The trust policy is scoped with aws:SourceAccount/aws:SourceArn
+        // conditions to guard against the confused-deputy problem, per the AgentCore documentation.
+        var role = new Role(stack, "DefaultAgentCoreRuntimeRole", new RoleProps
         {
-            AssumedBy = new ServicePrincipal("bedrock.amazonaws.com"),
+            AssumedBy = new ServicePrincipal("bedrock-agentcore.amazonaws.com", new ServicePrincipalOpts
+            {
+                Conditions = new Dictionary<string, object>
+                {
+                    ["StringEquals"] = new Dictionary<string, object>
+                    {
+                        ["aws:SourceAccount"] = stack.Account
+                    },
+                    ["ArnLike"] = new Dictionary<string, object>
+                    {
+                        ["aws:SourceArn"] = $"arn:{stack.Partition}:bedrock-agentcore:{stack.Region}:{stack.Account}:*"
+                    }
+                }
+            }),
             ManagedPolicies = new[]
             {
                 ManagedPolicy.FromAwsManagedPolicyName("AmazonEC2ContainerRegistryReadOnly"),
                 ManagedPolicy.FromAwsManagedPolicyName("CloudWatchLogsFullAccess"),
             }
         });
+
+        // The agent code running in the runtime invokes Bedrock models, so grant the model invocation
+        // actions (InvokeModel, InvokeModelWithResponseStream, etc.) via the InvokeModel* wildcard.
+        // Invocation can target a model directly or route through a (cross-region) inference profile, so
+        // the policy covers both: foundation models (account-less ARN, region wildcarded so a global
+        // profile's underlying models in any region are allowed) and inference profiles in this account.
+        role.AddToPrincipalPolicy(new PolicyStatement(new PolicyStatementProps
+        {
+            Effect = Effect.ALLOW,
+            Actions = new[] { "bedrock:InvokeModel*" },
+            Resources = new[]
+            {
+                $"arn:{stack.Partition}:bedrock:*::foundation-model/*",
+                $"arn:{stack.Partition}:bedrock:*:{stack.Account}:inference-profile/*"
+            }
+        }));
+
+        return role;
     }
 
     /// <summary>

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.DefaultConstructs.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.DefaultConstructs.cs
@@ -246,6 +246,22 @@ public partial class CDKDefaultsProvider
         });
     }
 
+    /// <summary>
+    /// Creates the default ECS task role assigned to a service's task definition when the user has not
+    /// supplied one. This is the role the application's own code assumes at runtime to call AWS APIs, so
+    /// it is created per-service (rather than shared) and starts empty: reference hooks attach scoped
+    /// policies as needed (for example, AgentCore invoke permissions when a service references an agent).
+    /// </summary>
+    /// <param name="resourceName">The Aspire resource name, used to give the role a stable, unique construct id.</param>
+    /// <returns>The created task role, trusted by the ecs-tasks service principal.</returns>
+    protected internal virtual IRole CreateDefaultECSTaskRole(string resourceName)
+    {
+        return new Role(EnvironmentResource.CDKStack, $"{resourceName}-DefaultTaskRole", new RoleProps
+        {
+            AssumedBy = new ServicePrincipal("ecs-tasks.amazonaws.com")
+        });
+    }
+
     private TConstruct? FindDefaultConstructByAttribute<TAttribute, TConstruct>()
         where TAttribute : Attribute
         where TConstruct : class

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.DefaultConstructs.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.DefaultConstructs.cs
@@ -37,6 +37,22 @@ public partial class CDKDefaultsProvider
         });
     }
 
+    /// <summary>
+    /// Gets the subnet IDs of the default VPC to place VPC-attached resources in. Private subnets are
+    /// preferred; public subnets are used only when the VPC has no private subnets. At most two subnets
+    /// are returned (matching the ElastiCache subnet group selection).
+    /// </summary>
+    /// <returns>The selected subnet IDs.</returns>
+    protected internal virtual string[] GetDefaultVpcSubnetIds()
+    {
+        var vpc = GetDefaultVpc();
+        var subnetIds = vpc.PrivateSubnets.Select(s => s.SubnetId).ToArray();
+        if (!subnetIds.Any())
+            subnetIds = vpc.PublicSubnets.Select(s => s.SubnetId).ToArray();
+
+        return subnetIds.Take(2).ToArray();
+    }
+
     private ICluster? _defaultECSCluster;
     public ICluster GetDefaultECSCluster()
     {

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.PublishTargets.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.PublishTargets.cs
@@ -92,4 +92,25 @@ public partial class CDKDefaultsProvider
     /// The default publishing target to use when publishing <see cref="Aspire.Hosting.ApplicationModel.RedisResource">RedisResource</see> or <see cref="Aspire.Hosting.ApplicationModel.ValkeyResource">ValkeyResource</see>. The default value is <see cref="RedisResourcePublishTarget.ElastiCacheServerlessCluster"/>.
     /// </summary>
     public virtual RedisResourcePublishTarget DefaultRedisResourcePublishTarget { get; set; } = RedisResourcePublishTarget.ElastiCacheServerlessCluster;
+
+#if NET10_0_OR_GREATER
+    /// <summary>
+    /// Specifies the available publishing targets for AgentCore project resources registered via
+    /// <see cref="Aspire.Hosting.AWS.AgentCore.AgentCoreResourceBuilderExtensions.AddAgentCoreRuntime{TProject}"/>.
+    /// </summary>
+    public enum AgentCoreProjectResourcePublishTarget
+    {
+        /// <summary>
+        /// Deploy to AWS Bedrock AgentCore as a container runtime.
+        /// The CDK <a href="https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-bedrockagentcore-runtime.html">AWS::BedrockAgentCore::Runtime</a>
+        /// construct is used to create the AgentCore runtime.
+        /// </summary>
+        AgentCoreRuntime
+    }
+
+    /// <summary>
+    /// The default publishing target to use when publishing AgentCore project resources. The default value is <see cref="AgentCoreProjectResourcePublishTarget.AgentCoreRuntime"/>.
+    /// </summary>
+    public virtual AgentCoreProjectResourcePublishTarget DefaultAgentCoreProjectResourcePublishTarget { get; set; } = AgentCoreProjectResourcePublishTarget.AgentCoreRuntime;
+#endif
 }

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProviderPreviewV1.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProviderPreviewV1.cs
@@ -28,6 +28,10 @@ namespace Aspire.Hosting.AWS.Deployment.CDKDefaults;
 ///         <term>Redis or Valkey Resource</term>
 ///         <description>ElastiCache Serverless Cluster</description>
 ///     </item>
+///     <item>
+///         <term>AgentCore Agents</term>
+///         <description>Bedrock AgentCore Runtime</description>
+///     </item>
 /// </list>
 /// </summary>
 /// <param name="environmentResource">The <see cref="AWSCDKEnvironmentResource"/> the CDKDefaultsProvider will create defaults for.</param>

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AbstractAWSPublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AbstractAWSPublishTarget.cs
@@ -132,10 +132,29 @@ public abstract class AbstractAWSPublishTarget(ILogger logger) : IAWSPublishTarg
     /// <param name="getter">The function used to get the existing security groups from the construct</param>
     /// <param name="setter">The action used to set the security groups on the construct</param>
     /// <returns></returns>
-    protected ISecurityGroup CreateEmptyReferenceSecurityGroup<T>(AWSCDKEnvironmentResource environmentResource, 
+    protected ISecurityGroup CreateEmptyReferenceSecurityGroup<T>(AWSCDKEnvironmentResource environmentResource,
         IResource resource, T construct, Func<T, ISecurityGroup[]?> getter, Action<T, ISecurityGroup[]> setter)
     {
-        var securityGroup = new SecurityGroup(
+        var securityGroup = CreateReferenceSecurityGroup(environmentResource, resource);
+
+        AppendSecurityGroup(construct, getter, setter, securityGroup);
+
+        return securityGroup;
+    }
+
+    /// <summary>
+    /// Creates a security group in the default VPC used to link the resource to its Aspire references.
+    /// The security group allows all outbound traffic and is added as an ingress rule on referenced
+    /// resources (for example an ElastiCache cluster). Unlike <see cref="CreateEmptyReferenceSecurityGroup{T}"/>
+    /// this does not attach the security group to a construct, for publish targets that store security group
+    /// IDs directly (e.g. the AgentCore runtime's VPC network configuration) rather than CDK objects.
+    /// </summary>
+    /// <param name="environmentResource">The owning environment</param>
+    /// <param name="resource">The Aspire resource being published</param>
+    /// <returns>The created security group.</returns>
+    protected ISecurityGroup CreateReferenceSecurityGroup(AWSCDKEnvironmentResource environmentResource, IResource resource)
+    {
+        return new SecurityGroup(
             environmentResource.CDKStack,
             $"{resource.Name}-Ref",
             new SecurityGroupProps
@@ -144,10 +163,6 @@ public abstract class AbstractAWSPublishTarget(ILogger logger) : IAWSPublishTarg
                 Description = $"Security group for linking {resource.Name} to Aspire References",
                 AllowAllOutbound = true
             });
-        
-        AppendSecurityGroup(construct, getter, setter, securityGroup);
-        
-        return securityGroup;
     }
 
     private void AppendSecurityGroup<T>(T construct, Func<T, ISecurityGroup[]?> getter, Action<T, ISecurityGroup[]> setter, ISecurityGroup securityGroup)

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AbstractAWSPublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AbstractAWSPublishTarget.cs
@@ -6,6 +6,7 @@ using Constructs;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics.CodeAnalysis;
 using Amazon.CDK.AWS.EC2;
+using Amazon.CDK.AWS.IAM;
 using Aspire.Hosting.AWS.Deployment.CDKDefaults;
 using IResource = Aspire.Hosting.ApplicationModel.IResource;
 
@@ -52,7 +53,19 @@ public abstract class AbstractAWSPublishTarget(ILogger logger) : IAWSPublishTarg
     /// <inheritdoc/>
     public virtual void ApplyReferenceSecurityGroup(AWSLinkedObjectsAnnotation linkedAnnotation, ISecurityGroup securityGroup)
     {
-        
+
+    }
+
+    /// <inheritdoc/>
+    public virtual bool ReferenceRequiresTaskRolePolicy()
+    {
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public virtual void ApplyReferenceTaskRolePolicy(AWSLinkedObjectsAnnotation linkedAnnotation, IRole taskRole)
+    {
+
     }
 
     /// <summary>
@@ -190,6 +203,11 @@ public abstract class AbstractAWSPublishTarget(ILogger logger) : IAWSPublishTarg
             if (linkAnnotation.PublishTarget.ReferenceRequiresSecurityGroup() && referencePoints.ReferenceSecurityGroup != null)
             {
                 linkAnnotation.PublishTarget.ApplyReferenceSecurityGroup(linkAnnotation, referencePoints.ReferenceSecurityGroup);
+            }
+
+            if (linkAnnotation.PublishTarget.ReferenceRequiresTaskRolePolicy() && referencePoints.ReferenceTaskRole != null)
+            {
+                linkAnnotation.PublishTarget.ApplyReferenceTaskRolePolicy(linkAnnotation, referencePoints.ReferenceTaskRole);
             }
         }
 

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AbstractCDKConstructConnectionPoints.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AbstractCDKConstructConnectionPoints.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Amazon.CDK.AWS.EC2;
+using Amazon.CDK.AWS.IAM;
 
 namespace Aspire.Hosting.AWS.Deployment.CDKPublishTargets;
 
@@ -27,7 +28,16 @@ public class AbstractCDKConstructConnectionPoints
     /// default security group as an ingress rule.
     /// </summary>
     public virtual ISecurityGroup? ReferenceSecurityGroup { get; } = null;
-    
+
+    /// <summary>
+    /// Gets the task role that the publish target created by default for the construct, or <c>null</c>
+    /// when the user supplied their own task role. When a reference requires permissions on the
+    /// referencing construct's task role (for example, granting AgentCore invoke permissions), the
+    /// reference's publish target attaches a scoped policy to this role. It is only set when the role
+    /// was created by the integration so that user-supplied roles are never mutated.
+    /// </summary>
+    public virtual IRole? ReferenceTaskRole { get; } = null;
+
     /// <summary>
     /// Gets and sets the VPC for the construct. This is should be overriden when VPC configuration is optional
     /// like a Lambda function. If a reference requires the construct to be in the VPC this property will set the

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AgentCoreRuntimePublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AgentCoreRuntimePublishTarget.cs
@@ -1,0 +1,110 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#if NET10_0_OR_GREATER
+
+#pragma warning disable ASPIREPUBLISHERS001
+#pragma warning disable ASPIREAWSPUBLISHERS001
+
+using Amazon.CDK.AWS.BedrockAgentCore;
+using Amazon.CDK.AWS.Ecr.Assets;
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.AWS.AgentCore;
+using Aspire.Hosting.AWS.Deployment.CDKDefaults;
+using Aspire.Hosting.AWS.Deployment.Services;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics.CodeAnalysis;
+using IResource = Aspire.Hosting.ApplicationModel.IResource;
+
+namespace Aspire.Hosting.AWS.Deployment.CDKPublishTargets;
+
+[Experimental(Constants.ASPIREAWSPUBLISHERS001)]
+internal class AgentCoreRuntimePublishTarget(ITarballContainerImageBuilder imageBuilder, ILogger<AgentCoreRuntimePublishTarget> logger) : AbstractAWSPublishTarget(logger)
+{
+    public override string PublishTargetName => "Bedrock AgentCore Runtime";
+
+    public override Type PublishTargetAnnotation => typeof(PublishAgentCoreRuntimeAnnotation);
+
+    public override async Task GenerateConstructAsync(AWSCDKEnvironmentResource environment, IResource resource, IAWSPublishTargetAnnotation annotation, CancellationToken cancellationToken)
+    {
+        var projectResource = resource as ProjectResource
+                              ?? throw new InvalidOperationException($"Resource {resource.Name} is not a valid ProjectResource.");
+
+        var publishAnnotation = annotation as PublishAgentCoreRuntimeAnnotation
+                                ?? throw new InvalidOperationException($"Annotation for resource {resource.Name} is not a valid {nameof(PublishAgentCoreRuntimeAnnotation)}.");
+
+        var imageTarballPath = await imageBuilder.CreateTarballImageAsync(projectResource, cancellationToken);
+
+        var asset = new TarballImageAsset(environment.CDKStack, $"ContainerTarBall-{projectResource.Name}", new TarballImageAssetProps
+        {
+            TarballFile = imageTarballPath
+        });
+
+        var runtimeProps = new CfnRuntimeProps
+        {
+            AgentRuntimeName = projectResource.Name,
+            AgentRuntimeArtifact = new CfnRuntime.AgentRuntimeArtifactProperty
+            {
+                ContainerConfiguration = new CfnRuntime.ContainerConfigurationProperty
+                {
+                    ContainerUri = asset.ImageUri
+                }
+            },
+            EnvironmentVariables = new Dictionary<string, string>()
+        };
+
+        var referencePoints = new AgentCoreRuntimeConnectionPoints(runtimeProps);
+        ProcessRelationShips(referencePoints, projectResource, environment);
+
+        publishAnnotation.Config.PropsCfnRuntimeCallback?.Invoke(CreatePublishTargetContext(environment), runtimeProps);
+        environment.DefaultsProvider.ApplyAgentCoreRuntimeDefaults(runtimeProps);
+
+        var runtime = new CfnRuntime(environment.CDKStack, $"AgentRuntime-{projectResource.Name}", runtimeProps);
+        publishAnnotation.Config.ConstructCfnRuntimeCallback?.Invoke(CreatePublishTargetContext(environment), runtime);
+
+        var endpointProps = new CfnRuntimeEndpointProps
+        {
+            AgentRuntimeId = runtime.AttrAgentRuntimeId,
+            Name = $"{projectResource.Name}-endpoint",
+            AgentRuntimeVersion = runtime.AttrAgentRuntimeVersion
+        };
+        publishAnnotation.Config.PropsCfnRuntimeEndpointCallback?.Invoke(CreatePublishTargetContext(environment), endpointProps);
+
+        var endpoint = new CfnRuntimeEndpoint(environment.CDKStack, $"AgentRuntimeEndpoint-{projectResource.Name}", endpointProps);
+        publishAnnotation.Config.ConstructCfnRuntimeEndpointCallback?.Invoke(CreatePublishTargetContext(environment), endpoint);
+
+        ApplyAWSLinkedObjectsAnnotation(environment, projectResource, runtime, this);
+    }
+
+    public override IsDefaultPublishTargetMatchResult IsDefaultPublishTargetMatch(CDKDefaultsProvider cdkDefaultsProvider, IResource resource)
+    {
+        if (resource is ProjectResource &&
+            resource.Annotations.OfType<AgentCoreRuntimeAnnotation>().Any())
+        {
+            return new IsDefaultPublishTargetMatchResult
+            {
+                IsMatch = true,
+                PublishTargetAnnotation = new PublishAgentCoreRuntimeAnnotation(),
+                Rank = IsDefaultPublishTargetMatchResult.DEFAULT_MATCH_RANK + 200
+            };
+        }
+
+        return IsDefaultPublishTargetMatchResult.NO_MATCH;
+    }
+
+    public override ReferenceConnectionInfo GetReferenceConnectionInfo(AWSLinkedObjectsAnnotation linkedAnnotation)
+    {
+        return new ReferenceConnectionInfo();
+    }
+}
+
+[Experimental(Constants.ASPIREAWSPUBLISHERS001)]
+internal class AgentCoreRuntimeConnectionPoints(CfnRuntimeProps props) : AbstractCDKConstructConnectionPoints
+{
+    public override IDictionary<string, string>? EnvironmentVariables
+    {
+        get => props.EnvironmentVariables as IDictionary<string, string> ?? new Dictionary<string, string>();
+        set => props.EnvironmentVariables = value ?? new Dictionary<string, string>();
+    }
+}
+
+#endif

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AgentCoreRuntimePublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AgentCoreRuntimePublishTarget.cs
@@ -54,11 +54,11 @@ internal class AgentCoreRuntimePublishTarget(ITarballContainerImageBuilder image
             EnvironmentVariables = new Dictionary<string, string>()
         };
 
-        var referencePoints = new AgentCoreRuntimeConnectionPoints(runtimeProps);
-        ProcessRelationShips(referencePoints, projectResource, environment);
-
         publishAnnotation.Config.PropsCfnRuntimeCallback?.Invoke(CreatePublishTargetContext(environment), runtimeProps);
         environment.DefaultsProvider.ApplyAgentCoreRuntimeDefaults(runtimeProps);
+
+        var referencePoints = new AgentCoreRuntimeConnectionPoints(runtimeProps);
+        ProcessRelationShips(referencePoints, projectResource, environment);
 
         var runtime = new CfnRuntime(environment.CDKStack, $"AgentRuntime-{projectResource.Name}", runtimeProps);
         publishAnnotation.Config.ConstructCfnRuntimeCallback?.Invoke(CreatePublishTargetContext(environment), runtime);
@@ -69,7 +69,8 @@ internal class AgentCoreRuntimePublishTarget(ITarballContainerImageBuilder image
     public override IsDefaultPublishTargetMatchResult IsDefaultPublishTargetMatch(CDKDefaultsProvider cdkDefaultsProvider, IResource resource)
     {
         if (resource is ProjectResource &&
-            resource.Annotations.OfType<AgentCoreRuntimeAnnotation>().Any())
+            resource.Annotations.OfType<AgentCoreRuntimeAnnotation>().Any() &&
+             cdkDefaultsProvider.DefaultAgentCoreProjectResourcePublishTarget == CDKDefaultsProvider.AgentCoreProjectResourcePublishTarget.AgentCoreRuntime)
         {
             return new IsDefaultPublishTargetMatchResult
             {
@@ -89,7 +90,7 @@ internal class AgentCoreRuntimePublishTarget(ITarballContainerImageBuilder image
             return result;
 
         // Expose the runtime ARN to referencing apps under the standard reference convention:
-        //   AWS:Resources:{agentName}:AgentRuntimeArn  ->  AWS_RESOURCES__{AGENT}__AGENTRUNTIMEARN
+        //   AWS:Resources:{agentName}:AgentRuntimeArn  ->  AWS__Resources__{agentName}__AgentRuntimeArn
         // AttrAgentRuntimeArn resolves to a CloudFormation Fn::GetAtt token during synthesis.
         var prefix = $"{Constants.DefaultConfigSection}:{linkedAnnotation.Resource.Name}".ToEnvironmentVariables();
         result.EnvironmentVariables = new Dictionary<string, string>

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AgentCoreRuntimePublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AgentCoreRuntimePublishTarget.cs
@@ -7,6 +7,7 @@
 
 using Amazon.CDK;
 using Amazon.CDK.AWS.BedrockAgentCore;
+using Amazon.CDK.AWS.EC2;
 using Amazon.CDK.AWS.Ecr.Assets;
 using Amazon.CDK.AWS.IAM;
 using Aspire.Hosting.ApplicationModel;
@@ -43,7 +44,7 @@ internal class AgentCoreRuntimePublishTarget(ITarballContainerImageBuilder image
 
         var runtimeProps = new CfnRuntimeProps
         {
-            AgentRuntimeName = projectResource.Name,
+            AgentRuntimeName = $"{environment.CDKStack.StackName}_{projectResource.Name}",
             AgentRuntimeArtifact = new CfnRuntime.AgentRuntimeArtifactProperty
             {
                 ContainerConfiguration = new CfnRuntime.ContainerConfigurationProperty
@@ -51,13 +52,19 @@ internal class AgentCoreRuntimePublishTarget(ITarballContainerImageBuilder image
                     ContainerUri = asset.ImageUri
                 }
             },
-            EnvironmentVariables = new Dictionary<string, string>()
+            EnvironmentVariables = new Dictionary<string, string>(),            
         };
 
         publishAnnotation.Config.PropsCfnRuntimeCallback?.Invoke(CreatePublishTargetContext(environment), runtimeProps);
         environment.DefaultsProvider.ApplyAgentCoreRuntimeDefaults(runtimeProps);
 
-        var referencePoints = new AgentCoreRuntimeConnectionPoints(runtimeProps);
+        var referencePoints = new AgentCoreRuntimeConnectionPoints(
+            runtimeProps,
+            environment,
+            () => CreateReferenceSecurityGroup(environment, projectResource),
+            publishAnnotation.Config.VpcSubnetIds,
+            projectResource.Name,
+            logger);
         ProcessRelationShips(referencePoints, projectResource, environment);
 
         var runtime = new CfnRuntime(environment.CDKStack, $"AgentRuntime-{projectResource.Name}", runtimeProps);
@@ -127,12 +134,113 @@ internal class AgentCoreRuntimePublishTarget(ITarballContainerImageBuilder image
 }
 
 [Experimental(Constants.ASPIREAWSPUBLISHERS001)]
-internal class AgentCoreRuntimeConnectionPoints(CfnRuntimeProps props) : AbstractCDKConstructConnectionPoints
+internal class AgentCoreRuntimeConnectionPoints(
+    CfnRuntimeProps props,
+    AWSCDKEnvironmentResource environment,
+    Func<ISecurityGroup> securityGroupFactory,
+    string[]? configuredSubnetIds,
+    string resourceName,
+    ILogger logger) : AbstractCDKConstructConnectionPoints
 {
+    private ISecurityGroup? _referenceSecurityGroup;
+    private IVpc? _vpc;
+
     public override IDictionary<string, string>? EnvironmentVariables
     {
         get => props.EnvironmentVariables as IDictionary<string, string> ?? new Dictionary<string, string>();
         set => props.EnvironmentVariables = value ?? new Dictionary<string, string>();
+    }
+
+    /// <summary>
+    /// Setting the VPC switches the runtime's network configuration from the default PUBLIC mode to VPC
+    /// mode. AgentCore runtimes only support a single network mode, so a VPC-requiring reference (e.g.
+    /// ElastiCache) forces VPC mode. Subnets are resolved in priority order: the subnets configured on
+    /// the publish config, then subnets already set on the network config (e.g. via a props callback),
+    /// then the default VPC's subnets.
+    /// </summary>
+    public override IVpc? Vpc
+    {
+        get => _vpc;
+        set
+        {
+            _vpc = value;
+            if (value == null)
+                return;
+
+            var vpcConfig = GetOrCreateVpcConfig();
+
+            if (configuredSubnetIds is { Length: > 0 })
+            {
+                vpcConfig.Subnets = configuredSubnetIds;
+            }
+            else if (vpcConfig.Subnets is string[] { Length: > 0 })
+            {
+                // Subnets already provided via a PropsCfnRuntimeCallback; leave them as-is.
+            }
+            else
+            {
+                vpcConfig.Subnets = environment.DefaultsProvider.GetDefaultVpcSubnetIds();
+
+                // Bedrock AgentCore only supports a subset of a region's availability zones, and that set
+                // is not known at synthesis time, so the default VPC's subnets cannot be filtered
+                // automatically. Mirror the ElastiCache cluster-mode logging so the user knows how to react
+                // if deployment fails because a default subnet is in an unsupported availability zone.
+                logger.LogInformation("Placing AgentCore runtime {Resource} in the default VPC's subnets. If deployment fails with an error about subnets in unsupported availability zones, set the {Property} property on {Config} to subnet IDs in AgentCore-supported availability zones.", resourceName, nameof(PublishAgentCoreRuntimeConfig.VpcSubnetIds), nameof(PublishAgentCoreRuntimeConfig));
+
+                // When the VPC has no private subnets the runtime is placed in public subnets. Like a
+                // Lambda function, a runtime in a public subnet is not assigned a public IP address and so
+                // cannot reach the internet or public AWS service endpoints (e.g. Bedrock, ECR, CloudWatch
+                // Logs) it needs at runtime. Warn so the user can attach private subnets with a NAT gateway.
+                if (!value.PrivateSubnets.Any())
+                {
+                    logger.LogWarning("AgentCore runtime {Resource} references a resource that requires the runtime to be attached to a VPC, but the configured VPC contains only public subnets and no private subnets. A runtime placed in public subnets is not assigned a public IP address and therefore cannot reach the internet or public AWS service endpoints (such as Bedrock, ECR, and CloudWatch Logs). To allow that access through a NAT Gateway, attach the runtime to private subnets by setting the {Property} property on {Config} to private subnet IDs.", resourceName, nameof(PublishAgentCoreRuntimeConfig.VpcSubnetIds), nameof(PublishAgentCoreRuntimeConfig));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Lazily creates the reference security group for the runtime and adds its id to the VPC network
+    /// configuration. Referenced resources add this security group as an ingress rule to allow access.
+    /// </summary>
+    public override ISecurityGroup? ReferenceSecurityGroup
+    {
+        get
+        {
+            if (_referenceSecurityGroup == null)
+            {
+                _referenceSecurityGroup = securityGroupFactory();
+
+                var vpcConfig = GetOrCreateVpcConfig();
+                var existing = vpcConfig.SecurityGroups as string[] ?? [];
+                vpcConfig.SecurityGroups = existing.Append(_referenceSecurityGroup.SecurityGroupId).ToArray();
+            }
+
+            return _referenceSecurityGroup;
+        }
+    }
+
+    /// <summary>
+    /// Ensures the runtime props carry a VPC network configuration, switching <c>NetworkMode</c> to VPC,
+    /// and returns the <see cref="CfnRuntime.VpcConfigProperty"/> to populate.
+    /// </summary>
+    private CfnRuntime.VpcConfigProperty GetOrCreateVpcConfig()
+    {
+        if (props.NetworkConfiguration is not CfnRuntime.NetworkConfigurationProperty networkConfig)
+        {
+            networkConfig = new CfnRuntime.NetworkConfigurationProperty();
+            props.NetworkConfiguration = networkConfig;
+        }
+
+        networkConfig.NetworkMode = "VPC";
+
+        if (networkConfig.NetworkModeConfig is not CfnRuntime.VpcConfigProperty vpcConfig)
+        {
+            vpcConfig = new CfnRuntime.VpcConfigProperty();
+            networkConfig.NetworkModeConfig = vpcConfig;
+        }
+
+        return vpcConfig;
     }
 }
 

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AgentCoreRuntimePublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AgentCoreRuntimePublishTarget.cs
@@ -5,8 +5,10 @@
 #pragma warning disable ASPIREPUBLISHERS001
 #pragma warning disable ASPIREAWSPUBLISHERS001
 
+using Amazon.CDK;
 using Amazon.CDK.AWS.BedrockAgentCore;
 using Amazon.CDK.AWS.Ecr.Assets;
+using Amazon.CDK.AWS.IAM;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.AWS.AgentCore;
 using Aspire.Hosting.AWS.Deployment.CDKDefaults;
@@ -61,17 +63,6 @@ internal class AgentCoreRuntimePublishTarget(ITarballContainerImageBuilder image
         var runtime = new CfnRuntime(environment.CDKStack, $"AgentRuntime-{projectResource.Name}", runtimeProps);
         publishAnnotation.Config.ConstructCfnRuntimeCallback?.Invoke(CreatePublishTargetContext(environment), runtime);
 
-        var endpointProps = new CfnRuntimeEndpointProps
-        {
-            AgentRuntimeId = runtime.AttrAgentRuntimeId,
-            Name = $"{projectResource.Name}-endpoint",
-            AgentRuntimeVersion = runtime.AttrAgentRuntimeVersion
-        };
-        publishAnnotation.Config.PropsCfnRuntimeEndpointCallback?.Invoke(CreatePublishTargetContext(environment), endpointProps);
-
-        var endpoint = new CfnRuntimeEndpoint(environment.CDKStack, $"AgentRuntimeEndpoint-{projectResource.Name}", endpointProps);
-        publishAnnotation.Config.ConstructCfnRuntimeEndpointCallback?.Invoke(CreatePublishTargetContext(environment), endpoint);
-
         ApplyAWSLinkedObjectsAnnotation(environment, projectResource, runtime, this);
     }
 
@@ -93,7 +84,44 @@ internal class AgentCoreRuntimePublishTarget(ITarballContainerImageBuilder image
 
     public override ReferenceConnectionInfo GetReferenceConnectionInfo(AWSLinkedObjectsAnnotation linkedAnnotation)
     {
-        return new ReferenceConnectionInfo();
+        var result = new ReferenceConnectionInfo();
+        if (linkedAnnotation.Construct is not CfnRuntime runtime)
+            return result;
+
+        // Expose the runtime ARN to referencing apps under the standard reference convention:
+        //   AWS:Resources:{agentName}:AgentRuntimeArn  ->  AWS_RESOURCES__{AGENT}__AGENTRUNTIMEARN
+        // AttrAgentRuntimeArn resolves to a CloudFormation Fn::GetAtt token during synthesis.
+        var prefix = $"{Constants.DefaultConfigSection}:{linkedAnnotation.Resource.Name}".ToEnvironmentVariables();
+        result.EnvironmentVariables = new Dictionary<string, string>
+        {
+            [$"{prefix}__{Constants.AgentRuntimeArnOutputName}"] = runtime.AttrAgentRuntimeArn
+        };
+        return result;
+    }
+
+    /// <inheritdoc/>
+    public override bool ReferenceRequiresTaskRolePolicy() => true;
+
+    /// <inheritdoc/>
+    public override void ApplyReferenceTaskRolePolicy(AWSLinkedObjectsAnnotation linkedAnnotation, IRole taskRole)
+    {
+        if (linkedAnnotation.Construct is not CfnRuntime runtime)
+            return;
+
+        // A resource referencing this agent invokes it at runtime via the AgentCore invoke APIs, so its
+        // task role needs permission to call them. The policy is scoped to this runtime and its child
+        // endpoints (named qualifiers) using the runtime ARN, which resolves to an Fn::GetAtt token.
+        var runtimeArn = runtime.AttrAgentRuntimeArn;
+        taskRole.AddToPrincipalPolicy(new PolicyStatement(new PolicyStatementProps
+        {
+            Effect = Effect.ALLOW,
+            Actions = new[] { "bedrock-agentcore:Invoke*" },
+            Resources = new[]
+            {
+                runtimeArn,
+                Fn.Join("", new[] { runtimeArn, "/*" })
+            }
+        }));
     }
 }
 

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateExpressServicePublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateExpressServicePublishTarget.cs
@@ -6,6 +6,7 @@ using Amazon.CDK;
 using Amazon.CDK.AWS.EC2;
 using Amazon.CDK.AWS.Ecr.Assets;
 using Amazon.CDK.AWS.ECS;
+using Amazon.CDK.AWS.IAM;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.AWS.Deployment.CDKDefaults;
 using Aspire.Hosting.AWS.Deployment.Services;
@@ -51,9 +52,20 @@ internal class ECSFargateExpressServicePublishTarget(ITarballContainerImageBuild
         publishAnnotation.Config.PropsCfnExpressGatewayServicePropsCallback?.Invoke(CreatePublishTargetContext(environment), fargateServiceProps);
         environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(fargateServiceProps);
 
+        // Assign a default task role when the user hasn't supplied one so the application's own AWS calls
+        // run under a controllable role. Only the integration-created role is exposed to reference hooks
+        // (via ReferenceTaskRole) so a user-supplied role is never mutated.
+        IRole? defaultTaskRole = null;
+        if (string.IsNullOrEmpty(fargateServiceProps.TaskRoleArn))
+        {
+            defaultTaskRole = environment.DefaultsProvider.CreateDefaultECSTaskRole(projectResource.Name);
+            fargateServiceProps.TaskRoleArn = defaultTaskRole.RoleArn;
+        }
+
         var referencePoints = new CfnExpressGatewayServicePropsConnectionPoints(
             fargateServiceProps,
-            environment.DefaultsProvider.GetDefaultECSClusterSecurityGroup());
+            environment.DefaultsProvider.GetDefaultECSClusterSecurityGroup(),
+            defaultTaskRole);
         ProcessRelationShips(referencePoints, projectResource, environment);
 
         var fargateService = new CfnExpressGatewayService(environment.CDKStack, $"Project-{projectResource.Name}", fargateServiceProps);
@@ -102,7 +114,7 @@ internal class ECSFargateExpressServicePublishTarget(ITarballContainerImageBuild
 }
 
 [Experimental(Constants.ASPIREAWSPUBLISHERS001)]
-internal class CfnExpressGatewayServicePropsConnectionPoints(CfnExpressGatewayServiceProps props, ISecurityGroup securityGroup) : AbstractCDKConstructConnectionPoints
+internal class CfnExpressGatewayServicePropsConnectionPoints(CfnExpressGatewayServiceProps props, ISecurityGroup securityGroup, IRole? taskRole = null) : AbstractCDKConstructConnectionPoints
 {
     public override IDictionary<string, string>? EnvironmentVariables
     {
@@ -142,5 +154,7 @@ internal class CfnExpressGatewayServicePropsConnectionPoints(CfnExpressGatewaySe
     }
 
     public override ISecurityGroup? ReferenceSecurityGroup => securityGroup;
+
+    public override IRole? ReferenceTaskRole => taskRole;
 }
 

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateServicePublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateServicePublishTarget.cs
@@ -4,6 +4,7 @@
 
 using Amazon.CDK.AWS.EC2;
 using Amazon.CDK.AWS.ECS;
+using Amazon.CDK.AWS.IAM;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.AWS.Deployment.CDKDefaults;
 using Aspire.Hosting.AWS.Deployment.Services;
@@ -34,6 +35,16 @@ internal class ECSFargateServicePublishTarget(ITarballContainerImageBuilder imag
         publishAnnotation.Config.PropsFargateTaskDefinitionCallback?.Invoke(CreatePublishTargetContext(environment), fargateTaskDefinitionProps);
         environment.DefaultsProvider.ApplyECSFargateServiceDefaults(fargateTaskDefinitionProps);
 
+        // Assign a default task role when the user hasn't supplied one so the application's own AWS calls
+        // run under a controllable role. Only the integration-created role is exposed to reference hooks
+        // (via ReferenceTaskRole) so a user-supplied role is never mutated.
+        IRole? defaultTaskRole = null;
+        if (fargateTaskDefinitionProps.TaskRole == null)
+        {
+            defaultTaskRole = environment.DefaultsProvider.CreateDefaultECSTaskRole(projectResource.Name);
+            fargateTaskDefinitionProps.TaskRole = defaultTaskRole;
+        }
+
         var taskDef = new FargateTaskDefinition(environment.CDKStack, $"TaskDefinition-{projectResource.Name}", fargateTaskDefinitionProps);
         publishAnnotation.Config.ConstructFargateTaskDefinitionCallback?.Invoke(CreatePublishTargetContext(environment), taskDef);
 
@@ -59,7 +70,8 @@ internal class ECSFargateServicePublishTarget(ITarballContainerImageBuilder imag
         publishAnnotation.Config.PropsFargateServiceCallback?.Invoke(CreatePublishTargetContext(environment), fargateServiceProps);
         environment.DefaultsProvider.ApplyECSFargateServiceDefaults(fargateServiceProps);
         ProcessRelationShips(new FargateServicePropsConnectionPoints(
-            () => CreateEmptyReferenceSecurityGroup(environment, projectResource, fargateServiceProps, x => x.SecurityGroups, (x, v) => x.SecurityGroups = v)),
+            () => CreateEmptyReferenceSecurityGroup(environment, projectResource, fargateServiceProps, x => x.SecurityGroups, (x, v) => x.SecurityGroups = v),
+            defaultTaskRole),
             resource, environment);
 
         var fargateService = new FargateService(environment.CDKStack, $"Project-{projectResource.Name}", fargateServiceProps);
@@ -100,7 +112,7 @@ internal class ContainerDefinitionPropsConnectionPoints(ContainerDefinitionProps
 }
 
 [Experimental(Constants.ASPIREAWSPUBLISHERS001)]
-internal class FargateServicePropsConnectionPoints(Func<ISecurityGroup> securityGroupFactory) : AbstractCDKConstructConnectionPoints
+internal class FargateServicePropsConnectionPoints(Func<ISecurityGroup> securityGroupFactory, IRole? taskRole = null) : AbstractCDKConstructConnectionPoints
 {
     ISecurityGroup? _referenceSecurityGroup;
 
@@ -112,4 +124,6 @@ internal class FargateServicePropsConnectionPoints(Func<ISecurityGroup> security
             return _referenceSecurityGroup;
         }
     }
+
+    public override IRole? ReferenceTaskRole => taskRole;
 }

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateServiceWithALBPublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateServiceWithALBPublishTarget.cs
@@ -7,6 +7,7 @@ using Amazon.CDK;
 using Amazon.CDK.AWS.EC2;
 using Amazon.CDK.AWS.ECS;
 using Amazon.CDK.AWS.ECS.Patterns;
+using Amazon.CDK.AWS.IAM;
 using Aspire.Hosting.ApplicationModel;
 using Aspire.Hosting.AWS.Deployment.CDKDefaults;
 using Aspire.Hosting.AWS.Deployment.Services;
@@ -49,9 +50,20 @@ internal class ECSFargateServiceWithALBPublishTarget(ITarballContainerImageBuild
         publishAnnotation.Config.PropsApplicationLoadBalancedFargateServiceCallback?.Invoke(CreatePublishTargetContext(environment), fargateServiceProps);
         environment.DefaultsProvider.ApplyECSFargateServiceWithALBDefaults(fargateServiceProps);
 
+        // Assign a default task role when the user hasn't supplied one so the application's own AWS calls
+        // run under a controllable role. Only the integration-created role is exposed to reference hooks
+        // (via ReferenceTaskRole) so a user-supplied role is never mutated.
+        IRole? defaultTaskRole = null;
+        if (taskImageOptions.TaskRole == null)
+        {
+            defaultTaskRole = environment.DefaultsProvider.CreateDefaultECSTaskRole(projectResource.Name);
+            taskImageOptions.TaskRole = defaultTaskRole;
+        }
+
         var referencePoints = new ApplicationLoadBalancedFargateServicePropsConnectionPoints(
             fargateServiceProps,
-                () => CreateEmptyReferenceSecurityGroup(environment, projectResource, fargateServiceProps, x => x.SecurityGroups, (x, v) => x.SecurityGroups = v));
+                () => CreateEmptyReferenceSecurityGroup(environment, projectResource, fargateServiceProps, x => x.SecurityGroups, (x, v) => x.SecurityGroups = v),
+                defaultTaskRole);
         ProcessRelationShips(referencePoints, projectResource, environment);
 
         var fargateService = new ApplicationLoadBalancedFargateService(environment.CDKStack, $"Project-{projectResource.Name}", fargateServiceProps);
@@ -99,7 +111,7 @@ internal class ECSFargateServiceWithALBPublishTarget(ITarballContainerImageBuild
 }
 
 [Experimental(Constants.ASPIREAWSPUBLISHERS001)]
-internal class ApplicationLoadBalancedFargateServicePropsConnectionPoints(ApplicationLoadBalancedFargateServiceProps props, Func<ISecurityGroup> securityGroupFactory) : AbstractCDKConstructConnectionPoints
+internal class ApplicationLoadBalancedFargateServicePropsConnectionPoints(ApplicationLoadBalancedFargateServiceProps props, Func<ISecurityGroup> securityGroupFactory, IRole? taskRole = null) : AbstractCDKConstructConnectionPoints
 {
     ISecurityGroup? _referenceSecurityGroup;
     public override IDictionary<string, string>? EnvironmentVariables
@@ -138,4 +150,6 @@ internal class ApplicationLoadBalancedFargateServicePropsConnectionPoints(Applic
             return _referenceSecurityGroup;
         }
     }
+
+    public override IRole? ReferenceTaskRole => taskRole;
 }

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/IAWSPublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/IAWSPublishTarget.cs
@@ -3,6 +3,7 @@
 using Aspire.Hosting.ApplicationModel;
 using System.Diagnostics.CodeAnalysis;
 using Amazon.CDK.AWS.EC2;
+using Amazon.CDK.AWS.IAM;
 using Aspire.Hosting.AWS.Deployment.CDKDefaults;
 
 namespace Aspire.Hosting.AWS.Deployment.CDKPublishTargets;
@@ -57,6 +58,21 @@ public interface IAWSPublishTarget
     /// <param name="linkedAnnotation">The container of the Aspire resource and CDK construct that where the ingress will be created</param>
     /// <param name="securityGroup">The security group that will be added as a ingress rule to the resource</param>
     void ApplyReferenceSecurityGroup(AWSLinkedObjectsAnnotation linkedAnnotation, ISecurityGroup securityGroup);
+
+    /// <summary>
+    /// Returns true if a resource referencing this resource needs permissions added to its task role.
+    /// For example a service referencing an AgentCore runtime needs its task role granted permission to call the AgentCore invoke APIs.
+    /// </summary>
+    /// <returns></returns>
+    bool ReferenceRequiresTaskRolePolicy();
+
+    /// <summary>
+    /// Attaches a scoped policy to the referencing resource's task role granting it the permissions needed to use this resource.
+    /// Only called when the referencing publish target created a default task role, so user-supplied roles are never mutated.
+    /// </summary>
+    /// <param name="linkedAnnotation">The container of this resource's Aspire resource and CDK construct being referenced</param>
+    /// <param name="taskRole">The task role of the referencing resource that the policy will be attached to</param>
+    void ApplyReferenceTaskRolePolicy(AWSLinkedObjectsAnnotation linkedAnnotation, IRole taskRole);
 
     /// <summary>
     /// For Aspire resources that do not have an explicit publish target added this method is called to see if the publish target is the best 

--- a/src/Aspire.Hosting.AWS/Deployment/PublishAgentCoreRuntimeAnnotation.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/PublishAgentCoreRuntimeAnnotation.cs
@@ -28,6 +28,21 @@ public class PublishAgentCoreRuntimeConfig
     /// Callback to modify the constructed AgentCore Runtime
     /// </summary>
     public PublishCallback<CfnRuntime>? ConstructCfnRuntimeCallback { get; set; }
+
+    /// <summary>
+    /// The subnet IDs to place the runtime in when it is attached to a VPC. A runtime is attached to a
+    /// VPC only when it references a resource that requires VPC access (for example an ElastiCache
+    /// cluster); otherwise the runtime uses public networking and this property is ignored.
+    /// <para>
+    /// When not set, the subnets of the default VPC are used. Bedrock AgentCore only supports a subset of
+    /// a region's availability zones, so the default VPC's subnets may include an availability zone that
+    /// AgentCore does not support, which causes deployment to fail with an error similar to
+    /// "The following subnets are in unsupported availability zones". Set this property to the subnet IDs
+    /// in AgentCore-supported availability zones to resolve such failures. The supported availability
+    /// zones are not known at synthesis time, so this selection cannot be made automatically.
+    /// </para>
+    /// </summary>
+    public string[]? VpcSubnetIds { get; set; }
 }
 
 #endif

--- a/src/Aspire.Hosting.AWS/Deployment/PublishAgentCoreRuntimeAnnotation.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/PublishAgentCoreRuntimeAnnotation.cs
@@ -28,16 +28,6 @@ public class PublishAgentCoreRuntimeConfig
     /// Callback to modify the constructed AgentCore Runtime
     /// </summary>
     public PublishCallback<CfnRuntime>? ConstructCfnRuntimeCallback { get; set; }
-
-    /// <summary>
-    /// Callback to modify the properties used to construct the AgentCore Runtime Endpoint
-    /// </summary>
-    public PublishCallback<CfnRuntimeEndpointProps>? PropsCfnRuntimeEndpointCallback { get; set; }
-
-    /// <summary>
-    /// Callback to modify the constructed AgentCore Runtime Endpoint
-    /// </summary>
-    public PublishCallback<CfnRuntimeEndpoint>? ConstructCfnRuntimeEndpointCallback { get; set; }
 }
 
 #endif

--- a/src/Aspire.Hosting.AWS/Deployment/PublishAgentCoreRuntimeAnnotation.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/PublishAgentCoreRuntimeAnnotation.cs
@@ -1,0 +1,43 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#if NET10_0_OR_GREATER
+
+using Amazon.CDK.AWS.BedrockAgentCore;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Aspire.Hosting.AWS.Deployment;
+
+[Experimental(Constants.ASPIREAWSPUBLISHERS001)]
+internal class PublishAgentCoreRuntimeAnnotation : IAWSPublishTargetAnnotation
+{
+    public PublishAgentCoreRuntimeConfig Config { get; set; } = new();
+}
+
+/// <summary>
+/// The config used for publishing a Bedrock AgentCore Runtime
+/// </summary>
+[Experimental(Constants.ASPIREAWSPUBLISHERS001)]
+public class PublishAgentCoreRuntimeConfig
+{
+    /// <summary>
+    /// Callback to modify the properties used to construct the AgentCore Runtime
+    /// </summary>
+    public PublishCallback<CfnRuntimeProps>? PropsCfnRuntimeCallback { get; set; }
+
+    /// <summary>
+    /// Callback to modify the constructed AgentCore Runtime
+    /// </summary>
+    public PublishCallback<CfnRuntime>? ConstructCfnRuntimeCallback { get; set; }
+
+    /// <summary>
+    /// Callback to modify the properties used to construct the AgentCore Runtime Endpoint
+    /// </summary>
+    public PublishCallback<CfnRuntimeEndpointProps>? PropsCfnRuntimeEndpointCallback { get; set; }
+
+    /// <summary>
+    /// Callback to modify the constructed AgentCore Runtime Endpoint
+    /// </summary>
+    public PublishCallback<CfnRuntimeEndpoint>? ConstructCfnRuntimeEndpointCallback { get; set; }
+}
+
+#endif

--- a/testapps/AgentCoreTestApps/AgentCoreTestApp.Agent/Properties/launchSettings.json
+++ b/testapps/AgentCoreTestApps/AgentCoreTestApp.Agent/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "AgentCoreTestApp.Agent": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:50481;http://localhost:50483"
+    }
+  }
+}

--- a/testapps/AgentCoreTestApps/AgentCoreTestApp.ChatUI/Program.cs
+++ b/testapps/AgentCoreTestApps/AgentCoreTestApp.ChatUI/Program.cs
@@ -9,6 +9,14 @@ var builder = WebApplication.CreateBuilder(args);
 // set by Aspire's WithReference() — no manual ServiceURL configuration needed.
 builder.Services.TryAddAWSService<IAmazonBedrockAgentCore>();
 
+// WithReference(agent) injects the agent's runtime ARN under this IConfiguration key. Locally it
+// resolves to the "local-agent" placeholder (the emulator ignores it); when deployed the generated
+// CDK stack sets it to the real AWS::BedrockAgentCore::Runtime ARN — same code path either way.
+var agentRuntimeArn = builder.Configuration["AWS:Resources:AgentCoreTestApp-Agent:AgentRuntimeArn"]
+    ?? throw new InvalidOperationException(
+        "Missing configuration 'AWS:Resources:AgentCoreTestApp-Agent:AgentRuntimeArn'. " +
+        "Ensure the ChatUI has WithReference(agent) in the AppHost.");
+
 var app = builder.Build();
 
 // Simple API to invoke the agent via the SDK
@@ -19,7 +27,7 @@ app.MapPost("/chat", async (ChatRequest request, IAmazonBedrockAgentCore client)
 
     var response = await client.InvokeAgentRuntimeAsync(new Amazon.BedrockAgentCore.Model.InvokeAgentRuntimeRequest
     {
-        AgentRuntimeArn = "local-agent",
+        AgentRuntimeArn = agentRuntimeArn,
         Payload = payloadStream
     });
 

--- a/testapps/AgentCoreTestApps/AgentCoreTestApp.StreamingAgent/Properties/launchSettings.json
+++ b/testapps/AgentCoreTestApps/AgentCoreTestApp.StreamingAgent/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+{
+  "profiles": {
+    "AgentCoreTestApp.StreamingAgent": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:50472;http://localhost:50473"
+    }
+  }
+}

--- a/testapps/DeploymentTestApps/DeploymentTestApp.AgentCoreAgent/DeploymentTestApp.AgentCoreAgent.csproj
+++ b/testapps/DeploymentTestApps/DeploymentTestApp.AgentCoreAgent/DeploymentTestApp.AgentCoreAgent.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+    <PropertyGroup>
+        <TargetFramework>$(DefaultTargetFramework)</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="AWS.AgentCore.Hosting" />
+    </ItemGroup>
+
+</Project>

--- a/testapps/DeploymentTestApps/DeploymentTestApp.AgentCoreAgent/Program.cs
+++ b/testapps/DeploymentTestApps/DeploymentTestApp.AgentCoreAgent/Program.cs
@@ -1,0 +1,3 @@
+var builder = WebApplication.CreateBuilder(args);
+var app = builder.Build();
+app.Run();

--- a/testapps/DeploymentTestApps/DeploymentTestApp.AppHost/DeploymentTestApp.AppHost.csproj
+++ b/testapps/DeploymentTestApps/DeploymentTestApp.AppHost/DeploymentTestApp.AppHost.csproj
@@ -22,6 +22,7 @@
 	  <ProjectReference Include="..\DeploymentTestApp.Service1\DeploymentTestApp.Service1.csproj" />
 	  <ProjectReference Include="..\DeploymentTestApps.WebApp1\DeploymentTestApps.WebApp1.csproj" />
 	  <ProjectReference Include="..\DeploymentTestApps.WebApp2\DeploymentTestApps.WebApp2.csproj" />
-	</ItemGroup>	
+	  <ProjectReference Include="..\DeploymentTestApp.AgentCoreAgent\DeploymentTestApp.AgentCoreAgent.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/testapps/DeploymentTestApps/DeploymentTestApp.AppHost/Scenarios.cs
+++ b/testapps/DeploymentTestApps/DeploymentTestApp.AppHost/Scenarios.cs
@@ -307,6 +307,23 @@ namespace DeploymentTestApp.AppHost
             await ExecuteApp(builder);
         }
 
+        public static async Task PublishAgentCoreRuntimeWithReference()
+        {
+            var builder = DistributedApplication.CreateBuilder(Environment.GetCommandLineArgs());
+
+            builder.AddAWSCDKEnvironment("aws", CDKDefaultsProviderFactory.Preview_V1, _defaultEnvironentResourceConfig, nameof(PublishAgentCoreRuntimeWithReference));
+
+            var agent = builder.AddAgentCoreRuntime<Projects.DeploymentTestApp_AgentCoreAgent>("AgentCoreAgent");
+
+            // A consumer that references the agent should receive its runtime ARN as an environment
+            // variable derived from the standard reference convention.
+            builder.AddProject<Projects.DeploymentTestApps_WebApp1>("WebApp1")
+                .WithReference(agent)
+                .WithExternalHttpEndpoints();
+
+            await ExecuteApp(builder);
+        }
+
         /// <summary>
         /// When running the IDistributedApplication through tests for publishing there are exceptions thrown
         /// when the IDistributedApplication is shutting down. This method catches and ignores those exceptions to allow for clean test runs.

--- a/testapps/DeploymentTestApps/DeploymentTestApp.AppHost/Scenarios.cs
+++ b/testapps/DeploymentTestApps/DeploymentTestApp.AppHost/Scenarios.cs
@@ -7,6 +7,7 @@ using Environment = System.Environment;
 #pragma warning disable ASPIREAWSPUBLISHERS001
 #pragma warning disable ASPIRECOMPUTE001
 #pragma warning disable ASPIREINTERACTION001
+#pragma warning disable ASPIREAWSAGENTCORE001
 
 namespace DeploymentTestApp.AppHost
 {
@@ -277,8 +278,37 @@ namespace DeploymentTestApp.AppHost
             await ExecuteApp(builder);
         }
 
+        public static async Task PublishAgentCoreRuntime()
+        {
+            var builder = DistributedApplication.CreateBuilder(Environment.GetCommandLineArgs());
+
+            builder.AddAWSCDKEnvironment("aws", CDKDefaultsProviderFactory.Preview_V1, _defaultEnvironentResourceConfig, nameof(PublishAgentCoreRuntime));
+
+            builder.AddAgentCoreRuntime<Projects.DeploymentTestApp_AgentCoreAgent>("AgentCoreAgent");
+
+            await ExecuteApp(builder);
+        }
+
+        public static async Task PublishAgentCoreRuntimeWithCustomization()
+        {
+            var builder = DistributedApplication.CreateBuilder(Environment.GetCommandLineArgs());
+
+            builder.AddAWSCDKEnvironment("aws", CDKDefaultsProviderFactory.Preview_V1, _defaultEnvironentResourceConfig, nameof(PublishAgentCoreRuntimeWithCustomization));
+
+            builder.AddAgentCoreRuntime<Projects.DeploymentTestApp_AgentCoreAgent>("AgentCoreAgent")
+                .PublishAsAgentCoreRuntime(new PublishAgentCoreRuntimeConfig
+                {
+                    PropsCfnRuntimeCallback = (ctx, props) =>
+                    {
+                        props.Description = "Custom agent description";
+                    }
+                });
+
+            await ExecuteApp(builder);
+        }
+
         /// <summary>
-        /// When running the IDistributedApplication through tests for publishing there are exceptions thrown 
+        /// When running the IDistributedApplication through tests for publishing there are exceptions thrown
         /// when the IDistributedApplication is shutting down. This method catches and ignores those exceptions to allow for clean test runs.
         /// </summary>
         /// <param name="builder"></param>

--- a/testapps/DeploymentTestApps/DeploymentTestApp.AppHost/Scenarios.cs
+++ b/testapps/DeploymentTestApps/DeploymentTestApp.AppHost/Scenarios.cs
@@ -324,6 +324,42 @@ namespace DeploymentTestApp.AppHost
             await ExecuteApp(builder);
         }
 
+        public static async Task PublishAgentCoreRuntimeWithVpcReference()
+        {
+            var builder = DistributedApplication.CreateBuilder(Environment.GetCommandLineArgs());
+
+            builder.AddAWSCDKEnvironment("aws", CDKDefaultsProviderFactory.Preview_V1, _defaultEnvironentResourceConfig, nameof(PublishAgentCoreRuntimeWithVpcReference));
+
+            var cache = builder.AddRedis("Cache");
+
+            // Referencing a VPC-requiring resource (ElastiCache) should switch the agent runtime's
+            // network configuration to VPC mode.
+            builder.AddAgentCoreRuntime<Projects.DeploymentTestApp_AgentCoreAgent>("AgentCoreAgent")
+                .WithReference(cache);
+
+            await ExecuteApp(builder);
+        }
+
+        public static async Task PublishAgentCoreRuntimeWithVpcReferenceAndSubnets()
+        {
+            var builder = DistributedApplication.CreateBuilder(Environment.GetCommandLineArgs());
+
+            builder.AddAWSCDKEnvironment("aws", CDKDefaultsProviderFactory.Preview_V1, _defaultEnvironentResourceConfig, nameof(PublishAgentCoreRuntimeWithVpcReferenceAndSubnets));
+
+            var cache = builder.AddRedis("Cache");
+
+            // The user pins explicit subnet IDs (e.g. to avoid AgentCore-unsupported availability zones).
+            // These should take precedence over the default VPC's subnets.
+            builder.AddAgentCoreRuntime<Projects.DeploymentTestApp_AgentCoreAgent>("AgentCoreAgent")
+                .WithReference(cache)
+                .PublishAsAgentCoreRuntime(new PublishAgentCoreRuntimeConfig
+                {
+                    VpcSubnetIds = new[] { "subnet-aaaa1111", "subnet-bbbb2222" }
+                });
+
+            await ExecuteApp(builder);
+        }
+
         /// <summary>
         /// When running the IDistributedApplication through tests for publishing there are exceptions thrown
         /// when the IDistributedApplication is shutting down. This method catches and ignores those exceptions to allow for clean test runs.

--- a/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
+++ b/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
@@ -66,10 +66,15 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             var vpcs = GetResourcesOfType(cfTemplateDoc, "AWS::EC2::VPC");
             Assert.Single(vpcs);
 
+            // 4 roles: shared Express execution + infrastructure roles, plus a per-service default task role for each of the 2 apps.
             var iamRoles = GetResourcesOfType(cfTemplateDoc, "AWS::IAM::Role");
-            Assert.Equal(2, iamRoles.Count);
+            Assert.Equal(4, iamRoles.Count);
 
-            var executionRole = iamRoles.FirstOrDefault(r => r.LogicalId.Contains("ExecutionRole"));            
+            // Each app gets its own default task role wired into the service's TaskRoleArn.
+            var taskRoles = iamRoles.Where(r => r.LogicalId.Contains("DefaultTaskRole")).ToList();
+            Assert.Equal(2, taskRoles.Count);
+
+            var executionRole = iamRoles.FirstOrDefault(r => r.LogicalId.Contains("ExecutionRole"));
             AssertJsonEquals("""
             {
              "Type": "AWS::IAM::Role",
@@ -408,9 +413,15 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             var ecsClusters = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::Cluster");
             Assert.Single(ecsClusters);
 
-            // Validate IAM Roles (4 total: 2 for Express, 2 for Service1)
+            // Validate IAM Roles (5 total: 2 shared Express roles (execution + infrastructure), a default task
+            // role for the Express WebApp1, plus the Fargate Service1's task role and execution role).
             var iamRoles = GetResourcesOfType(cfTemplateDoc, "AWS::IAM::Role");
-            Assert.Equal(4, iamRoles.Count);
+            Assert.Equal(5, iamRoles.Count);
+
+            // Both services get a default task role (the Express service's is named *-DefaultTaskRole;
+            // the Fargate Service1's task role is wired into its task definition).
+            var defaultTaskRoles = iamRoles.Where(r => r.LogicalId.Contains("DefaultTaskRole")).ToList();
+            Assert.Equal(2, defaultTaskRoles.Count);
 
             // Validate Security Groups
             var securityGroups = GetResourcesOfType(cfTemplateDoc, "AWS::EC2::SecurityGroup");
@@ -1715,27 +1726,113 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             Assert.Single(iamRoles);
             var agentCoreRole = iamRoles[0];
 
-            // Validate IAM Role has bedrock service principal
+            // Validate IAM Role has the Bedrock AgentCore service principal
             var assumeRolePrincipal = AssertElementExistsAtPath(agentCoreRole.Resource, "Properties/AssumeRolePolicyDocument/Statement/0/Principal/Service");
-            Assert.Equal("bedrock.amazonaws.com", assumeRolePrincipal.GetString());
+            Assert.Equal("bedrock-agentcore.amazonaws.com", assumeRolePrincipal.GetString());
 
             // Validate IAM Role has required managed policies
             var managedPolicyArns = AssertElementExistsAtPath(agentCoreRole.Resource, "Properties/ManagedPolicyArns");
             Assert.True(managedPolicyArns.GetArrayLength() >= 2);
 
-            // Validate AgentCore RuntimeEndpoint exists
-            var runtimeEndpoints = GetResourcesOfType(cfTemplateDoc, "AWS::BedrockAgentCore::RuntimeEndpoint");
-            Assert.Single(runtimeEndpoints);
-            var runtimeEndpoint = runtimeEndpoints[0];
+            // Validate the role has an inline policy granting the Bedrock model invocation actions, since
+            // the agent code running in the runtime invokes foundation models. The statement must cover both
+            // foundation-model and inference-profile ARNs (agents commonly invoke via inference profiles).
+            var policies = GetResourcesOfType(cfTemplateDoc, "AWS::IAM::Policy");
+            var invokeModelPolicy = policies.FirstOrDefault(p =>
+            {
+                var statements = GetElementAtPath(p.Resource, "Properties/PolicyDocument/Statement");
+                if (statements is not { ValueKind: JsonValueKind.Array } stmts)
+                    return false;
+                return stmts.EnumerateArray().Any(s =>
+                {
+                    var action = GetElementAtPath(s, "Action");
+                    if (action is not { ValueKind: JsonValueKind.String } a || a.GetString() != "bedrock:InvokeModel*")
+                        return false;
 
-            // Validate RuntimeEndpoint references the runtime
-            var endpointRuntimeId = AssertElementExistsAtPath(runtimeEndpoint.Resource, "Properties/AgentRuntimeId");
-            Assert.True(endpointRuntimeId.TryGetProperty("Fn::GetAtt", out _), "AgentRuntimeId should reference the runtime construct");
+                    var resource = GetElementAtPath(s, "Resource");
+                    if (resource is not { ValueKind: JsonValueKind.Array } resources)
+                        return false;
+                    // ARNs are built with the AWS::Partition token, so each resource renders as an Fn::Join
+                    // object rather than a plain string. Match against the raw JSON of each element.
+                    var resourceTexts = resources.EnumerateArray().Select(r => r.GetRawText()).ToList();
+                    return resourceTexts.Any(r => r.Contains("foundation-model/")) &&
+                           resourceTexts.Any(r => r.Contains("inference-profile/"));
+                });
+            });
+            Assert.False(string.IsNullOrEmpty(invokeModelPolicy.LogicalId), "The AgentCore runtime role should have an inline policy granting bedrock:InvokeModel* on foundation-model and inference-profile resources");
+
+            // Validate NO AgentCore RuntimeEndpoint is created. The runtime's auto-created DEFAULT
+            // endpoint is used for invocation; a named endpoint may be added as an opt-in in a future version.
+            var runtimeEndpoints = GetResourcesOfType(cfTemplateDoc, "AWS::BedrockAgentCore::RuntimeEndpoint");
+            Assert.Empty(runtimeEndpoints);
 
             return Task.CompletedTask;
         };
 
         await ExecutePublishAsync(nameof(Scenarios.PublishAgentCoreRuntime), cloudFormationValidation);
+    }
+
+    [Fact]
+    public async Task TestPublishAgentCoreRuntimeWithReference()
+    {
+        var cloudFormationValidation = (JsonDocument cfTemplateDoc) =>
+        {
+            // The agent runtime is created.
+            var agentRuntimes = GetResourcesOfType(cfTemplateDoc, "AWS::BedrockAgentCore::Runtime");
+            Assert.Single(agentRuntimes);
+            var agentRuntimeLogicalId = agentRuntimes[0].LogicalId;
+
+            // The referencing consumer (WebApp1) receives the runtime ARN as an environment variable
+            // keyed by the standard reference convention: AWS:Resources:AgentCoreAgent:AgentRuntimeArn
+            // which is delivered as AWS__Resources__AgentCoreAgent__AgentRuntimeArn.
+            var arnEnvVar = AssertElementExistsAtPath(cfTemplateDoc,
+                "Resources/ProjectWebApp1/Properties/PrimaryContainer/Environment/{Name=AWS__Resources__AgentCoreAgent__AgentRuntimeArn}/Value");
+
+            // The value is a Fn::GetAtt against the runtime's AgentRuntimeArn attribute.
+            var getAtt = AssertElementExistsAtPath(arnEnvVar, "Fn::GetAtt");
+            Assert.Equal(JsonValueKind.Array, getAtt.ValueKind);
+            Assert.Equal(agentRuntimeLogicalId, getAtt[0].GetString());
+            Assert.Equal("AgentRuntimeArn", getAtt[1].GetString());
+
+            // The consumer (WebApp1, an Express service) is assigned a default task role wired into TaskRoleArn.
+            var iamRoles = GetResourcesOfType(cfTemplateDoc, "AWS::IAM::Role");
+            var taskRole = iamRoles.FirstOrDefault(r => r.LogicalId.Contains("DefaultTaskRole"));
+            Assert.False(string.IsNullOrEmpty(taskRole.LogicalId), "A default task role should be created for the referencing service");
+
+            var taskRoleArn = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp1/Properties/TaskRoleArn");
+            var taskRoleArnGetAtt = AssertElementExistsAtPath(taskRoleArn, "Fn::GetAtt");
+            Assert.Equal(taskRole.LogicalId, taskRoleArnGetAtt[0].GetString());
+
+            // Because WebApp1 references the agent and was assigned the default task role, an inline policy
+            // granting the AgentCore invoke APIs (scoped to the runtime ARN and its child endpoints) is attached.
+            var policies = GetResourcesOfType(cfTemplateDoc, "AWS::IAM::Policy");
+            var invokePolicy = policies.FirstOrDefault(p =>
+            {
+                var statements = GetElementAtPath(p.Resource, "Properties/PolicyDocument/Statement");
+                if (statements is not { ValueKind: JsonValueKind.Array } stmts)
+                    return false;
+                return stmts.EnumerateArray().Any(s =>
+                {
+                    var action = GetElementAtPath(s, "Action");
+                    return action is { ValueKind: JsonValueKind.String } a && a.GetString() == "bedrock-agentcore:Invoke*";
+                });
+            });
+            Assert.False(string.IsNullOrEmpty(invokePolicy.LogicalId), "An inline policy granting bedrock-agentcore:Invoke* should be attached");
+
+            // The invoke policy is attached to the consumer's task role.
+            var policyRoles = AssertElementExistsAtPath(invokePolicy.Resource, "Properties/Roles");
+            Assert.Equal(JsonValueKind.Array, policyRoles.ValueKind);
+            var attachedToTaskRole = policyRoles.EnumerateArray().Any(r =>
+            {
+                var refEl = GetElementAtPath(r, "Ref");
+                return refEl is { ValueKind: JsonValueKind.String } refStr && refStr.GetString() == taskRole.LogicalId;
+            });
+            Assert.True(attachedToTaskRole, "The invoke policy should be attached to the service's default task role");
+
+            return Task.CompletedTask;
+        };
+
+        await ExecutePublishAsync(nameof(Scenarios.PublishAgentCoreRuntimeWithReference), cloudFormationValidation);
     }
 
     [Fact]
@@ -1752,9 +1849,9 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             var description = AssertElementExistsAtPath(agentRuntime.Resource, "Properties/Description");
             Assert.Equal("Custom agent description", description.GetString());
 
-            // Validate RuntimeEndpoint exists
+            // Validate NO RuntimeEndpoint is created (the runtime's auto-created DEFAULT endpoint is used).
             var runtimeEndpoints = GetResourcesOfType(cfTemplateDoc, "AWS::BedrockAgentCore::RuntimeEndpoint");
-            Assert.Single(runtimeEndpoints);
+            Assert.Empty(runtimeEndpoints);
 
             return Task.CompletedTask;
         };

--- a/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
+++ b/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
@@ -1707,7 +1707,7 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
 
             // Validate AgentRuntime name
             var runtimeName = AssertElementExistsAtPath(agentRuntime.Resource, "Properties/AgentRuntimeName");
-            Assert.Equal("AgentCoreAgent", runtimeName.GetString());
+            Assert.Equal("PublishAgentCoreRuntime_AgentCoreAgent", runtimeName.GetString());
 
             // Validate container configuration with image reference
             var containerConfig = AssertElementExistsAtPath(agentRuntime.Resource, "Properties/AgentRuntimeArtifact/ContainerConfiguration/ContainerUri");

--- a/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
+++ b/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
@@ -1668,6 +1668,100 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
         await ExecutePublishAsync(nameof(Scenarios.PublishWithEnvironmentAndReference), cloudFormationValidation);
     }
 
+    [Fact]
+    public async Task TestPublishAgentCoreRuntime()
+    {
+        var cloudFormationValidation = (JsonDocument cfTemplateDoc) =>
+        {
+            // Validate NO VPC resources are created
+            var vpcs = GetResourcesOfType(cfTemplateDoc, "AWS::EC2::VPC");
+            Assert.Empty(vpcs);
+
+            // Validate NO Subnet resources are created
+            var subnets = GetResourcesOfType(cfTemplateDoc, "AWS::EC2::Subnet");
+            Assert.Empty(subnets);
+
+            // Validate NO Security Groups are created (AgentCore uses PUBLIC network mode)
+            var securityGroups = GetResourcesOfType(cfTemplateDoc, "AWS::EC2::SecurityGroup");
+            Assert.Empty(securityGroups);
+
+            // Validate NO ECS resources are created
+            var ecsClusters = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::Cluster");
+            Assert.Empty(ecsClusters);
+
+            // Validate AgentCore Runtime exists
+            var agentRuntimes = GetResourcesOfType(cfTemplateDoc, "AWS::BedrockAgentCore::Runtime");
+            Assert.Single(agentRuntimes);
+            var agentRuntime = agentRuntimes[0];
+
+            // Validate AgentRuntime name
+            var runtimeName = AssertElementExistsAtPath(agentRuntime.Resource, "Properties/AgentRuntimeName");
+            Assert.Equal("AgentCoreAgent", runtimeName.GetString());
+
+            // Validate container configuration with image reference
+            var containerConfig = AssertElementExistsAtPath(agentRuntime.Resource, "Properties/AgentRuntimeArtifact/ContainerConfiguration/ContainerUri");
+            Assert.True(containerConfig.TryGetProperty("Fn::Sub", out _), "Container URI should be a Fn::Sub reference to ECR image");
+
+            // Validate network configuration is PUBLIC
+            var networkMode = AssertElementExistsAtPath(agentRuntime.Resource, "Properties/NetworkConfiguration/NetworkMode");
+            Assert.Equal("PUBLIC", networkMode.GetString());
+
+            // Validate role ARN references the default IAM role
+            var roleArn = AssertElementExistsAtPath(agentRuntime.Resource, "Properties/RoleArn");
+            Assert.True(roleArn.TryGetProperty("Fn::GetAtt", out _), "RoleArn should reference an IAM role construct");
+
+            // Validate IAM Role exists for AgentCore
+            var iamRoles = GetResourcesOfType(cfTemplateDoc, "AWS::IAM::Role");
+            Assert.Single(iamRoles);
+            var agentCoreRole = iamRoles[0];
+
+            // Validate IAM Role has bedrock service principal
+            var assumeRolePrincipal = AssertElementExistsAtPath(agentCoreRole.Resource, "Properties/AssumeRolePolicyDocument/Statement/0/Principal/Service");
+            Assert.Equal("bedrock.amazonaws.com", assumeRolePrincipal.GetString());
+
+            // Validate IAM Role has required managed policies
+            var managedPolicyArns = AssertElementExistsAtPath(agentCoreRole.Resource, "Properties/ManagedPolicyArns");
+            Assert.True(managedPolicyArns.GetArrayLength() >= 2);
+
+            // Validate AgentCore RuntimeEndpoint exists
+            var runtimeEndpoints = GetResourcesOfType(cfTemplateDoc, "AWS::BedrockAgentCore::RuntimeEndpoint");
+            Assert.Single(runtimeEndpoints);
+            var runtimeEndpoint = runtimeEndpoints[0];
+
+            // Validate RuntimeEndpoint references the runtime
+            var endpointRuntimeId = AssertElementExistsAtPath(runtimeEndpoint.Resource, "Properties/AgentRuntimeId");
+            Assert.True(endpointRuntimeId.TryGetProperty("Fn::GetAtt", out _), "AgentRuntimeId should reference the runtime construct");
+
+            return Task.CompletedTask;
+        };
+
+        await ExecutePublishAsync(nameof(Scenarios.PublishAgentCoreRuntime), cloudFormationValidation);
+    }
+
+    [Fact]
+    public async Task TestPublishAgentCoreRuntimeWithCustomization()
+    {
+        var cloudFormationValidation = (JsonDocument cfTemplateDoc) =>
+        {
+            // Validate AgentCore Runtime exists
+            var agentRuntimes = GetResourcesOfType(cfTemplateDoc, "AWS::BedrockAgentCore::Runtime");
+            Assert.Single(agentRuntimes);
+            var agentRuntime = agentRuntimes[0];
+
+            // Validate custom description was applied
+            var description = AssertElementExistsAtPath(agentRuntime.Resource, "Properties/Description");
+            Assert.Equal("Custom agent description", description.GetString());
+
+            // Validate RuntimeEndpoint exists
+            var runtimeEndpoints = GetResourcesOfType(cfTemplateDoc, "AWS::BedrockAgentCore::RuntimeEndpoint");
+            Assert.Single(runtimeEndpoints);
+
+            return Task.CompletedTask;
+        };
+
+        await ExecutePublishAsync(nameof(Scenarios.PublishAgentCoreRuntimeWithCustomization), cloudFormationValidation);
+    }
+
     private async Task ExecutePublishAsync(string scenario, Func<JsonDocument, Task> cfTemplateValidation)
     {
         var outputPath = GetTempOutputPath();

--- a/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
+++ b/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
@@ -1836,6 +1836,88 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task TestPublishAgentCoreRuntimeWithVpcReference()
+    {
+        var cloudFormationValidation = (JsonDocument cfTemplateDoc) =>
+        {
+            // The agent runtime is created.
+            var agentRuntimes = GetResourcesOfType(cfTemplateDoc, "AWS::BedrockAgentCore::Runtime");
+            Assert.Single(agentRuntimes);
+            var agentRuntime = agentRuntimes[0];
+
+            // Referencing a VPC-requiring resource (ElastiCache) switches the runtime to VPC network mode.
+            var networkMode = AssertElementExistsAtPath(agentRuntime.Resource, "Properties/NetworkConfiguration/NetworkMode");
+            Assert.Equal("VPC", networkMode.GetString());
+
+            // The VPC network config carries the default VPC's subnets.
+            var subnets = AssertElementExistsAtPath(agentRuntime.Resource, "Properties/NetworkConfiguration/NetworkModeConfig/Subnets");
+            Assert.Equal(JsonValueKind.Array, subnets.ValueKind);
+            Assert.True(subnets.GetArrayLength() >= 1, "VPC network config should include at least one subnet");
+
+            // The VPC network config references the runtime's reference security group (a *-Ref security group).
+            var sgIds = AssertElementExistsAtPath(agentRuntime.Resource, "Properties/NetworkConfiguration/NetworkModeConfig/SecurityGroups");
+            Assert.Equal(JsonValueKind.Array, sgIds.ValueKind);
+            Assert.True(sgIds.GetArrayLength() >= 1, "VPC network config should include the reference security group");
+
+            // A VPC is created for the runtime and cache to share.
+            var vpcs = GetResourcesOfType(cfTemplateDoc, "AWS::EC2::VPC");
+            Assert.Single(vpcs);
+
+            // The reference security group exists (named with the resource's "-Ref" suffix).
+            var securityGroups = GetResourcesOfType(cfTemplateDoc, "AWS::EC2::SecurityGroup");
+            var refSecurityGroup = securityGroups.FirstOrDefault(sg => sg.LogicalId.Contains("AgentCoreAgentRef"));
+            Assert.False(string.IsNullOrEmpty(refSecurityGroup.LogicalId), "A reference security group should be created for the agent runtime");
+
+            // ElastiCache grants ingress from the runtime's reference security group on the Redis port(s).
+            var serverlessCaches = GetResourcesOfType(cfTemplateDoc, "AWS::ElastiCache::ServerlessCache");
+            Assert.Single(serverlessCaches);
+
+            var ingressRules = GetResourcesOfType(cfTemplateDoc, "AWS::EC2::SecurityGroupIngress");
+            Assert.NotEmpty(ingressRules);
+            foreach (var ingress in ingressRules)
+            {
+                var fromPort = AssertElementExistsAtPath(ingress.Resource, "Properties/FromPort");
+                Assert.Contains(fromPort.GetInt32(), new[] { 6379, 6380 });
+            }
+            var ingressFromRefSg = ingressRules.Any(ingress =>
+            {
+                var src = GetElementAtPath(ingress.Resource, "Properties/SourceSecurityGroupId/Fn::GetAtt");
+                return src is { ValueKind: JsonValueKind.Array } arr && arr[0].GetString() == refSecurityGroup.LogicalId;
+            });
+            Assert.True(ingressFromRefSg, "ElastiCache should allow ingress from the agent runtime's reference security group");
+
+            return Task.CompletedTask;
+        };
+
+        await ExecutePublishAsync(nameof(Scenarios.PublishAgentCoreRuntimeWithVpcReference), cloudFormationValidation);
+    }
+
+    [Fact]
+    public async Task TestPublishAgentCoreRuntimeWithVpcReferenceAndSubnets()
+    {
+        var cloudFormationValidation = (JsonDocument cfTemplateDoc) =>
+        {
+            var agentRuntimes = GetResourcesOfType(cfTemplateDoc, "AWS::BedrockAgentCore::Runtime");
+            Assert.Single(agentRuntimes);
+            var agentRuntime = agentRuntimes[0];
+
+            // VPC mode is still enabled by the ElastiCache reference.
+            var networkMode = AssertElementExistsAtPath(agentRuntime.Resource, "Properties/NetworkConfiguration/NetworkMode");
+            Assert.Equal("VPC", networkMode.GetString());
+
+            // The explicitly configured subnet IDs take precedence over the default VPC's subnets.
+            var subnets = AssertElementExistsAtPath(agentRuntime.Resource, "Properties/NetworkConfiguration/NetworkModeConfig/Subnets");
+            Assert.Equal(JsonValueKind.Array, subnets.ValueKind);
+            var subnetValues = subnets.EnumerateArray().Select(s => s.GetString()).ToList();
+            Assert.Equal(new[] { "subnet-aaaa1111", "subnet-bbbb2222" }, subnetValues);
+
+            return Task.CompletedTask;
+        };
+
+        await ExecutePublishAsync(nameof(Scenarios.PublishAgentCoreRuntimeWithVpcReferenceAndSubnets), cloudFormationValidation);
+    }
+
+    [Fact]
     public async Task TestPublishAgentCoreRuntimeWithCustomization()
     {
         var cloudFormationValidation = (JsonDocument cfTemplateDoc) =>

--- a/tests/Aspire.Hosting.AWS.UnitTests/AgentCoreResourceBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/AgentCoreResourceBuilderExtensionsTests.cs
@@ -180,6 +180,11 @@ public class AgentCoreResourceBuilderExtensionsTests
         // Use Run-mode execution context so the env callback writes the var (it skips publish mode by design).
         var envVars = await EvaluateEnvironmentVariables(consumer.Resource, app.Services);
         Assert.Equal("http://localhost:12345", envVars["AWS_ENDPOINT_URL_BEDROCK_AGENTCORE"]);
+
+        // The hook also sets the runtime ARN under the standard reference convention so app code
+        // reads the same IConfiguration key locally and when deployed. Locally it's the placeholder
+        // "local-agent" (the emulator ignores it); deployment overrides it with the real ARN.
+        Assert.Equal("local-agent", envVars["AWS__Resources__my-agent__AgentRuntimeArn"]);
     }
 
     [Fact]


### PR DESCRIPTION
## Description

Adds support for deploying Aspire `ProjectResource`s registered with `AddAgentCoreRuntime<T>()` to **Amazon Bedrock AgentCore Runtime**, alongside the existing ECS/Lambda/ElastiCache publish targets. A project that runs as an AgentCore agent in local development is now deployed to a managed `AWS::BedrockAgentCore::Runtime` when the app is published through the AWS CDK environment.

### What's added

**AgentCore publish target**
- New `AgentCoreRuntimePublishTarget` that transforms an AgentCore `ProjectResource` into a CDK `CfnRuntime`. The container image is built and packaged as a tarball asset (`TarballImageAsset`) and referenced by the runtime.
- New `PublishAsAgentCoreRuntime()` extension method with a `PublishAgentCoreRuntimeConfig` exposing `PropsCfnRuntimeCallback` / `ConstructCfnRuntimeCallback` for customizing the runtime props/construct. Calling it is optional — any project registered via `AddAgentCoreRuntime<T>()` is auto-detected (via `AgentCoreRuntimeAnnotation`) and deployed to AgentCore by default.
- New `AgentCoreProjectResourcePublishTarget` enum + `DefaultAgentCoreProjectResourcePublishTarget` on the defaults provider, wired into `CDKDefaultsProviderPreviewV1`.

**Defaults and IAM**
- `CreateDefaultAgentCoreRuntimeRole()` creates the runtime execution role with:
  - Trust policy for the **`bedrock-agentcore.amazonaws.com`** service principal (the AgentCore control-plane principal — not `bedrock.amazonaws.com`), scoped with `aws:SourceAccount`/`aws:SourceArn` confused-deputy conditions.
  - Managed policies for ECR pull and CloudWatch Logs.
  - An inline policy granting **`bedrock:InvokeModel*`** on both `foundation-model/*` and `inference-profile/*` resources, since the agent code invokes Bedrock models (including cross-region inference profiles such as `global.anthropic.claude-sonnet-4-6`).
- `ApplyAgentCoreRuntimeDefaults()` defaults the network mode to `PUBLIC` and assigns the default role when one isn't supplied. A custom role can be provided via the new `[DefaultAgentCoreRuntimeRole]` attribute.
- Default network mode is `PUBLIC` (no VPC required).

**arm64 build**
- `AddAgentCoreRuntime<T>()` pins the agent project's container build platform to `linux/arm64` via Aspire's `WithContainerBuildOptions`, because Bedrock AgentCore only runs arm64 images. Applies at publish time only.

**Referencing an agent (`WithReference`)**
- `GetReferenceConnectionInfo` exposes the runtime ARN to consumers under the standard convention `AWS:Resources:{agentName}:AgentRuntimeArn` (env var `AWS_RESOURCES__{AGENT}__AGENTRUNTIMEARN`), resolving to a CloudFormation `Fn::GetAtt`. The same key is used in local dev (placeholder + emulator endpoint override), so application code reads one config key in both modes.

**Default ECS task roles + invoke permissions for consumers**
- All three ECS publish targets (`PublishAsECSFargateExpressService`, `PublishAsECSFargateService`, `PublishAsECSFargateServiceWithALB`) now assign a **default, per-service task role** (`{name}-DefaultTaskRole`) when the user hasn't supplied one, giving each service a controllable runtime identity.
- New reference hooks `ReferenceRequiresTaskRolePolicy()` / `ApplyReferenceTaskRolePolicy()` (mirroring the security-group hooks) plus `ReferenceTaskRole` on the connection-points base class. When a service `WithReference`s an agent **and** was assigned the default task role, the AgentCore target attaches a `bedrock-agentcore:Invoke*` policy scoped to the runtime ARN and its child endpoints. User-supplied task roles are never mutated.

Note: the publish target intentionally creates only the `CfnRuntime`; it does **not** create a named `CfnRuntimeEndpoint`. AgentCore auto-provisions a `DEFAULT` endpoint and consumers invoke via the runtime ARN. A named endpoint may be added as an opt-in in a future change.

### Docs
- `docs/deployment-design.md` updated with the AgentCore publish target, platform/IAM requirements (arm64, trust policy, model-invocation permissions), the runtime-ARN reference convention, and the new ECS task-role behavior and task-role reference hooks.

## Motivation and Context

The integration already deployed web/console projects, Lambda functions, and ElastiCache to AWS, and had local-development support for AgentCore agents. This PR closes the loop so an AgentCore agent developed and run locally with Aspire can be deployed to managed Bedrock AgentCore Runtime through the same publish pipeline, and so other resources (e.g. an ECS backend) can reference and invoke it with the correct IAM permissions wired automatically.

## Testing

- **Unit tests** — `AgentCoreResourceBuilderExtensionsTests` (local-dev wiring, reference hook) pass; full unit suite green.
- **Integration tests** (`PublishScenarioTests`) synthesize the CloudFormation template and assert on it:
  - `TestPublishAgentCoreRuntime` — runtime + `PUBLIC` network + execution role with the `bedrock-agentcore` trust principal and a `bedrock:InvokeModel*` policy covering foundation-model and inference-profile ARNs; no `RuntimeEndpoint`.
  - `TestPublishAgentCoreRuntimeWithReference` — consumer receives the runtime ARN env var, gets a default task role wired to `TaskRoleArn`, and an attached `bedrock-agentcore:Invoke*` policy.
  - `TestPublishAgentCoreRuntimeWithCustomization` — `PropsCfnRuntimeCallback` applies a custom description.
  - Updated existing ECS scenarios for the new per-service default task roles.
  - Backing scenarios added in `DeploymentTestApp.AppHost/Scenarios.cs` and a `DeploymentTestApp.AgentCoreAgent` test project.
- **Playground** — `Publishing` sample extended with a `Publishing.HoroscopeAgent` AgentCore project referenced by the backend, exercising end-to-end publish.
- Builds clean for `net8.0` and `net10.0`.

## Breaking Changes Assessment

No breaking changes to existing public APIs. All new public surface is additive and marked `[Experimental]` (publish-target callbacks, `PublishAsAgentCoreRuntime`, defaults enum).

Behavioral change worth noting: the ECS publish targets now emit a default per-service task role where previously the Express target emitted none and the L2 targets relied on CDK auto-creating one. This adds an `AWS::IAM::Role` (and, for agent-referencing services, an `AWS::IAM::Policy`) per service to generated templates. Existing tests that assert IAM-role counts were updated accordingly.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License
- [x] I confirm that this pull request can be released under the Apache 2 license

[issues]: https://github.com/aws/aws-sdk-net/issues
[license]: http://aws.amazon.com/apache2.0/
[cla]: http://en.wikipedia.org/wiki/Contributor_License_Agreement
