### PR TITLE
Add AgentCore memory support when deploying

### DIFF
--- a/.autover/changes/ed8515cc-43f4-43b6-85a7-3b77f26a8ed3.json
+++ b/.autover/changes/ed8515cc-43f4-43b6-85a7-3b77f26a8ed3.json
@@ -1,0 +1,12 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "When deploying to AgentCore support provisioning AgentCore memory",
+		"[Breaking Change] Rename the preview WithInMemory method to WithAgentCoreMemory"
+      ]
+    }
+  ]
+}

--- a/.autover/changes/ed8515cc-43f4-43b6-85a7-3b77f26a8ed3.json
+++ b/.autover/changes/ed8515cc-43f4-43b6-85a7-3b77f26a8ed3.json
@@ -2,7 +2,7 @@
   "Projects": [
     {
       "Name": "Aspire.Hosting.AWS",
-      "Type": "Patch",
+      "Type": "Minor",
       "ChangelogMessages": [
         "When deploying to AgentCore support provisioning AgentCore memory",
 		"[Breaking Change] Rename the preview WithInMemory method to WithAgentCoreMemory"

--- a/playground/AgentCore/AgentCore.AppHost/Program.cs
+++ b/playground/AgentCore/AgentCore.AppHost/Program.cs
@@ -8,14 +8,14 @@ var builder = DistributedApplication.CreateBuilder(args);
 // AddAgentCoreRuntime starts embedded runtime + chat emulators — no Docker needed.
 var agent = builder.AddAgentCoreRuntime<Projects.AgentCore_Agent>(
     "AgentCore-Agent", new() { IncludeEmulatorLogs = true })
-    .WithInMemory();
+    .WithAgentCoreMemory();
 
 // Register a streaming agent.
 // WithStreaming tells the chat app to use SSE streaming mode.
 builder.AddAgentCoreRuntime<Projects.AgentCore_StreamingAgent>(
     "AgentCore-StreamingAgent", new() { IncludeEmulatorLogs = true })
     .WithStreaming()
-    .WithInMemory();
+    .WithAgentCoreMemory();
 
 // WithReference injects AWS_ENDPOINT_URL_BEDROCK_AGENTCORE into the ChatUI project
 // so the AWS SDK routes requests to the local runtime emulator automatically.

--- a/playground/Publishing/Publishing.AppHost/Program.cs
+++ b/playground/Publishing/Publishing.AppHost/Program.cs
@@ -37,7 +37,8 @@ builder.Configuration["Parameters:db-connection"] = "Server=localhost;Database=m
 var apiKey = builder.AddParameter("api-key");
 var dbConnection = builder.AddParameter("db-connection", secret: true);
 
-var horoscopeAgent = builder.AddAgentCoreRuntime<Projects.Publishing_HoroscopeAgent>("HoroscopeAgent");
+var horoscopeAgent = builder.AddAgentCoreRuntime<Projects.Publishing_HoroscopeAgent>("HoroscopeAgent")
+            .WithAgentCoreMemory();
 
 var frontend = builder.AddProject<Projects.Frontend>("Frontend")
         .WithEnvironment("ENV_LAMBDA_1", "LambdaValue1")

--- a/playground/Publishing/Publishing.HoroscopeAgent/HoroscopeAgent.cs
+++ b/playground/Publishing/Publishing.HoroscopeAgent/HoroscopeAgent.cs
@@ -3,7 +3,6 @@
 using AWS.AgentCore.Hosting;
 using Microsoft.Agents.AI;
 using Publishing.HoroscopeAgent.Models;
-using StackExchange.Redis;
 using System.ComponentModel;
 
 namespace Publishing.HoroscopeAgent;
@@ -12,12 +11,10 @@ public class HoroscopeAgent
 {
     private ChatClientAgent _chatAgent;
     private ILogger<HoroscopeAgent> _logger;
-    private IDatabase _database;
 
-    public HoroscopeAgent(ChatClientAgent chatAgent, IConnectionMultiplexer mp, ILogger<HoroscopeAgent> logger)
+    public HoroscopeAgent(ChatClientAgent chatAgent, ILogger<HoroscopeAgent> logger)
     {
         _chatAgent = chatAgent;
-        _database = mp.GetDatabase();
         _logger = logger;
     }
 
@@ -34,18 +31,10 @@ public class HoroscopeAgent
 
         var prompt = request.Prompt ?? "Give me a general horoscope for today.";
 
-        if(_database.StringGet(prompt) is var cachedResponse && cachedResponse.HasValue)
-        {
-            _logger.LogInformation("Returning cached response for prompt: {Prompt}", prompt);
-            return cachedResponse.ToString();
-        }
-
         var response = await _chatAgent.RunAsync(
             prompt,
             session: session,
             cancellationToken: cancellationToken);
-
-        _database.StringSet(prompt, response.ToString(), TimeSpan.FromMinutes(10));
 
         return response.ToString();
     }

--- a/playground/Publishing/Publishing.HoroscopeAgent/Publishing.HoroscopeAgent.csproj
+++ b/playground/Publishing/Publishing.HoroscopeAgent/Publishing.HoroscopeAgent.csproj
@@ -8,7 +8,6 @@
 
     <ItemGroup>
         <PackageReference Include="AWS.AgentCore.Hosting" />
-		<PackageReference Include="Aspire.StackExchange.Redis" />
 	</ItemGroup>
 
     <ItemGroup>

--- a/playground/Publishing/Publishing.HoroscopeAgent/Startup.cs
+++ b/playground/Publishing/Publishing.HoroscopeAgent/Startup.cs
@@ -12,7 +12,6 @@ public class Startup
     public void ConfigureServices(WebApplicationBuilder builder)
     {
         builder.AddServiceDefaults();
-        builder.AddRedisClient("cache");
 
         builder.AddAgentCore(options =>
         {

--- a/src/Aspire.Hosting.AWS/AgentCore/AgentCoreResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.AWS/AgentCore/AgentCoreResourceBuilderExtensions.cs
@@ -187,9 +187,8 @@ public static class AgentCoreResourceBuilderExtensions
     /// <para>
     /// During local development this adds an embedded memory emulator and sets the
     /// <c>AWS_AGENTCORE_MEMORY_ID</c> and <c>AWS_AGENTCORE_SERVICE_ENDPOINT</c> environment variables on
-    /// the agent resource. During deployment an <c>AWS::BedrockAgentCore::Memory</c> resource is
     /// provisioned and <c>AWS_AGENTCORE_MEMORY_ID</c> is pointed at it. Deployment memory creation can be
-    /// overridden with <see cref="Deployment.PublishAgentCoreRuntimeConfig.CreateMemory"/>.
+    /// overridden with <see cref="Aspire.Hosting.AWS.Deployment.PublishAgentCoreRuntimeConfig.CreateMemory"/>.
     /// </para>
     /// </summary>
     /// <param name="agentApp">The agent resource builder.</param>

--- a/src/Aspire.Hosting.AWS/AgentCore/AgentCoreResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.AWS/AgentCore/AgentCoreResourceBuilderExtensions.cs
@@ -183,26 +183,31 @@ public static class AgentCoreResourceBuilderExtensions
     }
 
     /// <summary>
-    /// Adds an embedded memory emulator and wires it to the agent application.
-    /// Sets the <c>AWS_AGENTCORE_MEMORY_ID</c> and <c>AWS_AGENTCORE_SERVICE_ENDPOINT</c>
-    /// environment variables on the agent resource.
+    /// Enables AgentCore memory for the agent application.
+    /// <para>
+    /// During local development this adds an embedded memory emulator and sets the
+    /// <c>AWS_AGENTCORE_MEMORY_ID</c> and <c>AWS_AGENTCORE_SERVICE_ENDPOINT</c> environment variables on
+    /// the agent resource. During deployment an <c>AWS::BedrockAgentCore::Memory</c> resource is
+    /// provisioned and <c>AWS_AGENTCORE_MEMORY_ID</c> is pointed at it. Deployment memory creation can be
+    /// overridden with <see cref="Deployment.PublishAgentCoreRuntimeConfig.CreateMemory"/>.
+    /// </para>
     /// </summary>
     /// <param name="agentApp">The agent resource builder.</param>
     /// <returns>The resource builder for further chaining.</returns>
     [Experimental(Constants.ASPIREAWSAGENTCORE001)]
-    public static IResourceBuilder<ProjectResource> WithInMemory(
+    public static IResourceBuilder<ProjectResource> WithAgentCoreMemory(
         this IResourceBuilder<ProjectResource> agentApp)
     {
         var annotation = agentApp.Resource.Annotations
             .OfType<AgentCoreRuntimeAnnotation>()
             .FirstOrDefault()
             ?? throw new InvalidOperationException(
-                "WithInMemory can only be called on an AgentCore runtime resource. " +
+                "WithAgentCoreMemory can only be called on an AgentCore runtime resource. " +
                 "Use AddAgentCoreRuntime<T>() to create it.");
 
         annotation.HasMemory = true;
 
-        agentApp.WithEnvironment("AWS_AGENTCORE_MEMORY_ID", "localdev-memory");
+        agentApp.WithEnvironment(Constants.AgentCoreMemoryIdEnvironmentVariable, "localdev-memory");
 
         agentApp.WithEnvironment(async context =>
         {

--- a/src/Aspire.Hosting.AWS/Constants.cs
+++ b/src/Aspire.Hosting.AWS/Constants.cs
@@ -31,6 +31,12 @@ internal static class Constants
     /// </summary>
     internal const string AgentRuntimeArnOutputName = "AgentRuntimeArn";
 
+    /// <summary>
+    /// The environment variable the agent reads to discover its AgentCore memory id. Shared between the
+    /// local development emulator wiring and the deployment publish target so the name can never drift.
+    /// </summary>
+    internal const string AgentCoreMemoryIdEnvironmentVariable = "AWS_AGENTCORE_MEMORY_ID";
+
     internal const string IsAspireHostedEnvVariable = "ASPIRE_HOSTED";
     
     /// <summary>

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.AgentCoreRuntime.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.AgentCoreRuntime.cs
@@ -19,6 +19,7 @@ public partial class CDKDefaultsProvider
     public virtual string AgentCoreRuntimeNetworkMode => "PUBLIC";
 
     private IRole? _defaultAgentCoreRuntimeRole;
+    private bool _defaultAgentCoreRuntimeRoleCreatedByIntegration;
 
     /// <summary>
     /// Gets the default IAM role for AgentCore runtimes. The role is shared across all AgentCore runtimes in the stack.
@@ -32,10 +33,12 @@ public partial class CDKDefaultsProvider
             if (definedDefault != null)
             {
                 _defaultAgentCoreRuntimeRole = definedDefault;
+                _defaultAgentCoreRuntimeRoleCreatedByIntegration = false;
             }
             else
             {
                 _defaultAgentCoreRuntimeRole = CreateDefaultAgentCoreRuntimeRole();
+                _defaultAgentCoreRuntimeRoleCreatedByIntegration = true;
             }
         }
 
@@ -113,6 +116,71 @@ public partial class CDKDefaultsProvider
         {
             props.RoleArn = GetDefaultAgentCoreRuntimeRole().RoleArn;
         }
+    }
+
+    /// <summary>
+    /// Gets the default event expiry duration, in days, applied to an AgentCore memory when the user has
+    /// not specified one.
+    /// </summary>
+    public virtual double AgentCoreMemoryEventExpiryDurationDays => 90;
+
+    /// <summary>
+    /// Applies default configuration values to the specified AgentCore memory properties if they are not already set.
+    /// </summary>
+    /// <param name="props">The AgentCore memory properties to which default values will be applied.</param>
+    protected internal virtual void ApplyAgentCoreMemoryDefaults(CfnMemoryProps props)
+    {
+        // A short-term (event) memory only requires a name and an event expiry duration. The name is set
+        // by the publish target (it knows the stack and resource name), so only default the expiry here.
+        // Long-term memory strategies and a memory execution role are left to the user via the memory
+        // props callback.
+        // EventExpiryDuration is a non-nullable double on CfnMemoryProps; treat the default 0 as unset.
+        if (props.EventExpiryDuration == 0)
+        {
+            props.EventExpiryDuration = AgentCoreMemoryEventExpiryDurationDays;
+        }
+    }
+
+    /// <summary>
+    /// Grants the default AgentCore runtime role permission to use the data-plane APIs of the AgentCore
+    /// memory identified by <paramref name="memoryArn"/>. The agent code running in the runtime reads and
+    /// writes memory events and records, so its role needs these permissions, scoped to the memory and its
+    /// child resources.
+    /// <para>
+    /// When the runtime role was supplied by the user (rather than created by the integration) the role is
+    /// left untouched, mirroring how user-supplied roles are never mutated elsewhere.
+    /// </para>
+    /// </summary>
+    /// <param name="memoryArn">The ARN of the AgentCore memory to grant access to.</param>
+    internal void GrantAgentCoreRuntimeMemoryAccess(string memoryArn)
+    {
+        var role = GetDefaultAgentCoreRuntimeRole();
+        if (!_defaultAgentCoreRuntimeRoleCreatedByIntegration)
+        {
+            return;
+        }
+
+        role.AddToPrincipalPolicy(new PolicyStatement(new PolicyStatementProps
+        {
+            Effect = Effect.ALLOW,
+            Actions = new[]
+            {
+                "bedrock-agentcore:CreateEvent",
+                "bedrock-agentcore:GetEvent",
+                "bedrock-agentcore:ListEvents",
+                "bedrock-agentcore:DeleteEvent",
+                "bedrock-agentcore:ListActors",
+                "bedrock-agentcore:ListSessions",
+                "bedrock-agentcore:RetrieveMemoryRecords",
+                "bedrock-agentcore:GetMemoryRecord",
+                "bedrock-agentcore:ListMemoryRecords"
+            },
+            Resources = new[]
+            {
+                memoryArn,
+                Fn.Join("", new[] { memoryArn, "/*" })
+            }
+        }));
     }
 }
 

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.AgentCoreRuntime.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.AgentCoreRuntime.cs
@@ -142,10 +142,33 @@ public partial class CDKDefaultsProvider
     }
 
     /// <summary>
+    /// The AgentCore memory data-plane actions granted to the runtime role. The agent code running in the
+    /// runtime reads and writes memory events and records, so its role needs these permissions.
+    /// </summary>
+    private static readonly string[] AgentCoreMemoryDataPlaneActions =
+    {
+        "bedrock-agentcore:CreateEvent",
+        "bedrock-agentcore:GetEvent",
+        "bedrock-agentcore:ListEvents",
+        "bedrock-agentcore:DeleteEvent",
+        "bedrock-agentcore:ListActors",
+        "bedrock-agentcore:ListSessions",
+        "bedrock-agentcore:RetrieveMemoryRecords",
+        "bedrock-agentcore:GetMemoryRecord",
+        "bedrock-agentcore:ListMemoryRecords"
+    };
+
+    private PolicyStatement? _agentCoreRuntimeMemoryPolicyStatement;
+
+    /// <summary>
     /// Grants the default AgentCore runtime role permission to use the data-plane APIs of the AgentCore
-    /// memory identified by <paramref name="memoryArn"/>. The agent code running in the runtime reads and
-    /// writes memory events and records, so its role needs these permissions, scoped to the memory and its
-    /// child resources.
+    /// memory identified by <paramref name="memoryArn"/>, scoped to the memory and its child resources.
+    /// <para>
+    /// All memories share a single policy statement: the first call creates the statement (with the memory
+    /// actions) and attaches it to the role; subsequent calls append the additional memory ARNs to that
+    /// same statement's resource list rather than adding a new statement. This keeps the IAM policy compact
+    /// when multiple agents each provision a memory.
+    /// </para>
     /// <para>
     /// When the runtime role was supplied by the user (rather than created by the integration) the role is
     /// left untouched, mirroring how user-supplied roles are never mutated elsewhere.
@@ -160,27 +183,26 @@ public partial class CDKDefaultsProvider
             return;
         }
 
-        role.AddToPrincipalPolicy(new PolicyStatement(new PolicyStatementProps
+        var memoryChildArn = Fn.Join("", new[] { memoryArn, "/*" });
+
+        if (_agentCoreRuntimeMemoryPolicyStatement == null)
         {
-            Effect = Effect.ALLOW,
-            Actions = new[]
+            _agentCoreRuntimeMemoryPolicyStatement = new PolicyStatement(new PolicyStatementProps
             {
-                "bedrock-agentcore:CreateEvent",
-                "bedrock-agentcore:GetEvent",
-                "bedrock-agentcore:ListEvents",
-                "bedrock-agentcore:DeleteEvent",
-                "bedrock-agentcore:ListActors",
-                "bedrock-agentcore:ListSessions",
-                "bedrock-agentcore:RetrieveMemoryRecords",
-                "bedrock-agentcore:GetMemoryRecord",
-                "bedrock-agentcore:ListMemoryRecords"
-            },
-            Resources = new[]
-            {
-                memoryArn,
-                Fn.Join("", new[] { memoryArn, "/*" })
-            }
-        }));
+                Effect = Effect.ALLOW,
+                Actions = AgentCoreMemoryDataPlaneActions,
+                Resources = new[] { memoryArn, memoryChildArn }
+            });
+
+            // AddToPrincipalPolicy attaches the statement object by reference; CDK renders it at synth
+            // time, so resources appended to the cached instance on later calls are reflected in the
+            // final template.
+            role.AddToPrincipalPolicy(_agentCoreRuntimeMemoryPolicyStatement);
+        }
+        else
+        {
+            _agentCoreRuntimeMemoryPolicyStatement.AddResources(memoryArn, memoryChildArn);
+        }
     }
 }
 

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AgentCoreRuntimePublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/AgentCoreRuntimePublishTarget.cs
@@ -44,7 +44,7 @@ internal class AgentCoreRuntimePublishTarget(ITarballContainerImageBuilder image
 
         var runtimeProps = new CfnRuntimeProps
         {
-            AgentRuntimeName = $"{environment.CDKStack.StackName}_{projectResource.Name}",
+            AgentRuntimeName = SanitizeName($"{environment.CDKStack.StackName}_{projectResource.Name}"),
             AgentRuntimeArtifact = new CfnRuntime.AgentRuntimeArtifactProperty
             {
                 ContainerConfiguration = new CfnRuntime.ContainerConfigurationProperty
@@ -52,10 +52,15 @@ internal class AgentCoreRuntimePublishTarget(ITarballContainerImageBuilder image
                     ContainerUri = asset.ImageUri
                 }
             },
-            EnvironmentVariables = new Dictionary<string, string>(),            
+            EnvironmentVariables = new Dictionary<string, string>(),
         };
 
         publishAnnotation.Config.PropsCfnRuntimeCallback?.Invoke(CreatePublishTargetContext(environment), runtimeProps);
+
+        // Capture whether the user supplied the runtime role before defaults fill in the integration's
+        // default role, so memory permissions are only added to a role the integration owns.
+        var userSuppliedRoleArn = !string.IsNullOrEmpty(runtimeProps.RoleArn);
+
         environment.DefaultsProvider.ApplyAgentCoreRuntimeDefaults(runtimeProps);
 
         var referencePoints = new AgentCoreRuntimeConnectionPoints(
@@ -67,10 +72,74 @@ internal class AgentCoreRuntimePublishTarget(ITarballContainerImageBuilder image
             logger);
         ProcessRelationShips(referencePoints, projectResource, environment);
 
+        // Memory creation follows WithAgentCoreMemory() (HasMemory) unless the user explicitly overrode it via the
+        // publish config. It is resolved here (rather than from the annotation directly) so the opt-out
+        // works regardless of the order WithAgentCoreMemory() and PublishAsAgentCoreRuntime() were called in.
+        var runtimeAnnotation = projectResource.Annotations.OfType<AgentCoreRuntimeAnnotation>().FirstOrDefault();
+        var createMemory = publishAnnotation.Config.CreateMemory ?? (runtimeAnnotation?.HasMemory ?? false);
+
+        CfnMemory? memory = null;
+        if (createMemory)
+        {
+            var memoryProps = new CfnMemoryProps
+            {
+                Name = SanitizeName($"{environment.CDKStack.StackName}_{projectResource.Name}")
+            };
+
+            publishAnnotation.Config.PropsCfnMemoryCallback?.Invoke(CreatePublishTargetContext(environment), memoryProps);
+            environment.DefaultsProvider.ApplyAgentCoreMemoryDefaults(memoryProps);
+
+            memory = new CfnMemory(environment.CDKStack, $"AgentMemory-{projectResource.Name}", memoryProps);
+            publishAnnotation.Config.ConstructCfnMemoryCallback?.Invoke(CreatePublishTargetContext(environment), memory);
+
+            // Point the deployed agent at the real memory id. WithAgentCoreMemory() seeds AWS_AGENTCORE_MEMORY_ID
+            // with the local "localdev-memory" placeholder, which ProcessRelationShips copied into the
+            // runtime environment above; overwrite it with the created memory's id token.
+            runtimeProps.EnvironmentVariables = WithMemoryIdEnvironmentVariable(runtimeProps.EnvironmentVariables, memory.AttrMemoryId);
+
+            // The agent code reads and writes memory at runtime, so grant its role memory data-plane
+            // access. Only do so when the integration created the role (a user-supplied role is untouched).
+            if (!userSuppliedRoleArn)
+            {
+                environment.DefaultsProvider.GrantAgentCoreRuntimeMemoryAccess(memory.AttrMemoryArn);
+            }
+        }
+
         var runtime = new CfnRuntime(environment.CDKStack, $"AgentRuntime-{projectResource.Name}", runtimeProps);
         publishAnnotation.Config.ConstructCfnRuntimeCallback?.Invoke(CreatePublishTargetContext(environment), runtime);
 
+        // Ensure the memory is provisioned before the runtime that depends on its id.
+        if (memory != null)
+        {
+            runtime.Node.AddDependency(memory);
+        }
+
         ApplyAWSLinkedObjectsAnnotation(environment, projectResource, runtime, this);
+    }
+
+    /// <summary>
+    /// Sets the <c>AWS_AGENTCORE_MEMORY_ID</c> environment variable to the given value on the runtime's
+    /// environment variable collection, preserving any other variables already present.
+    /// </summary>
+    private static IDictionary<string, string> WithMemoryIdEnvironmentVariable(object? existing, string memoryId)
+    {
+        var env = existing as IDictionary<string, string> ?? new Dictionary<string, string>();
+        env[Constants.AgentCoreMemoryIdEnvironmentVariable] = memoryId;
+        return env;
+    }
+
+    /// <summary>
+    /// Sanitizes a candidate name to the allowed charset. Names must start with a
+    /// letter and contain only letters, digits and underscores.
+    /// </summary>
+    private static string SanitizeName(string candidate)
+    {
+        var sanitized = new string(candidate.Select(c => char.IsLetterOrDigit(c) || c == '_' ? c : '_').ToArray());
+        if (sanitized.Length == 0 || !char.IsLetter(sanitized[0]))
+        {
+            sanitized = "m" + sanitized;
+        }
+        return sanitized;
     }
 
     public override IsDefaultPublishTargetMatchResult IsDefaultPublishTargetMatch(CDKDefaultsProvider cdkDefaultsProvider, IResource resource)

--- a/src/Aspire.Hosting.AWS/Deployment/PublishAgentCoreRuntimeAnnotation.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/PublishAgentCoreRuntimeAnnotation.cs
@@ -30,6 +30,30 @@ public class PublishAgentCoreRuntimeConfig
     public PublishCallback<CfnRuntime>? ConstructCfnRuntimeCallback { get; set; }
 
     /// <summary>
+    /// Callback to modify the properties used to construct the AgentCore Memory. Only invoked when an
+    /// AgentCore Memory resource is created for the runtime (see <see cref="CreateMemory"/>).
+    /// </summary>
+    public PublishCallback<CfnMemoryProps>? PropsCfnMemoryCallback { get; set; }
+
+    /// <summary>
+    /// Callback to modify the constructed AgentCore Memory. Only invoked when an AgentCore Memory resource
+    /// is created for the runtime (see <see cref="CreateMemory"/>).
+    /// </summary>
+    public PublishCallback<CfnMemory>? ConstructCfnMemoryCallback { get; set; }
+
+    /// <summary>
+    /// Controls whether an <c>AWS::BedrockAgentCore::Memory</c> resource is provisioned for the runtime
+    /// during deployment.
+    /// <para>
+    /// When <c>null</c> (the default) memory creation follows whether <c>WithAgentCoreMemory()</c> was called on
+    /// the agent. Set to <c>true</c> or <c>false</c> to force or suppress memory creation during
+    /// deployment independently of local testing — for example call <c>WithAgentCoreMemory()</c> to use the memory
+    /// emulator locally while setting this to <c>false</c> to skip provisioning memory when deployed.
+    /// </para>
+    /// </summary>
+    public bool? CreateMemory { get; set; }
+
+    /// <summary>
     /// The subnet IDs to place the runtime in when it is attached to a VPC. A runtime is attached to a
     /// VPC only when it references a resource that requires VPC access (for example an ElastiCache
     /// cluster); otherwise the runtime uses public networking and this property is ignored.

--- a/src/Aspire.Hosting.AWS/README.md
+++ b/src/Aspire.Hosting.AWS/README.md
@@ -488,12 +488,12 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 // Register a non-streaming agent with short-term memory
 var agent = builder.AddAgentCoreRuntime<Projects.MyAgent>("my-agent")
-    .WithInMemory();
+    .WithAgentCoreMemory();
 
 // Register a streaming agent
 builder.AddAgentCoreRuntime<Projects.MyStreamingAgent>("my-streaming-agent")
     .WithStreaming()
-    .WithInMemory();
+    .WithAgentCoreMemory();
 
 // Wire a consumer project — AWS_ENDPOINT_URL_BEDROCK_AGENTCORE is injected automatically
 builder.AddProject<Projects.MyChatUI>("ChatUI")
@@ -508,7 +508,7 @@ builder.Build().Run();
 |--------|-------------|
 | `AddAgentCoreRuntime<TProject>()` | Registers an agent with embedded runtime and chat emulators |
 | `.WithStreaming()` | Enables SSE streaming mode for the chat app |
-| `.WithInMemory()` | Adds a short-term memory emulator |
+| `.WithAgentCoreMemory()` | Enables AgentCore memory: a short-term memory emulator locally, and a provisioned AgentCore Memory resource on deployment |
 | `.WithReference(agent)` | Injects the runtime emulator endpoint into a consumer project via `AWS_ENDPOINT_URL_BEDROCK_AGENTCORE` |
 
 ### Options

--- a/testapps/AgentCoreTestApps/AgentCoreTestApp.AppHost/Program.cs
+++ b/testapps/AgentCoreTestApps/AgentCoreTestApp.AppHost/Program.cs
@@ -2,12 +2,12 @@ var builder = DistributedApplication.CreateBuilder(args);
 
 // Non-streaming agent with memory
 var agent = builder.AddAgentCoreRuntime<Projects.AgentCoreTestApp_Agent>("AgentCoreTestApp-Agent")
-    .WithInMemory();
+    .WithAgentCoreMemory();
 
 // Streaming agent
 builder.AddAgentCoreRuntime<Projects.AgentCoreTestApp_StreamingAgent>("AgentCoreTestApp-StreamingAgent")
     .WithStreaming()
-    .WithInMemory();
+    .WithAgentCoreMemory();
 
 // Chat UI that invokes the agent via the AWS SDK
 // WithReference injects AWS_ENDPOINT_URL_BEDROCK_AGENTCORE so the SDK routes to the emulator

--- a/testapps/DeploymentTestApps/DeploymentTestApp.AppHost/Scenarios.cs
+++ b/testapps/DeploymentTestApps/DeploymentTestApp.AppHost/Scenarios.cs
@@ -289,6 +289,38 @@ namespace DeploymentTestApp.AppHost
             await ExecuteApp(builder);
         }
 
+        public static async Task PublishAgentCoreRuntimeWithMemory()
+        {
+            var builder = DistributedApplication.CreateBuilder(Environment.GetCommandLineArgs());
+
+            builder.AddAWSCDKEnvironment("aws", CDKDefaultsProviderFactory.Preview_V1, _defaultEnvironentResourceConfig, nameof(PublishAgentCoreRuntimeWithMemory));
+
+            // WithAgentCoreMemory() requests AgentCore memory, which should provision an AgentCore Memory resource,
+            // point the agent's AWS_AGENTCORE_MEMORY_ID at it, and grant the runtime role memory access.
+            builder.AddAgentCoreRuntime<Projects.DeploymentTestApp_AgentCoreAgent>("AgentCoreAgent")
+                .WithAgentCoreMemory();
+
+            await ExecuteApp(builder);
+        }
+
+        public static async Task PublishAgentCoreRuntimeWithMemoryDisabled()
+        {
+            var builder = DistributedApplication.CreateBuilder(Environment.GetCommandLineArgs());
+
+            builder.AddAWSCDKEnvironment("aws", CDKDefaultsProviderFactory.Preview_V1, _defaultEnvironentResourceConfig, nameof(PublishAgentCoreRuntimeWithMemoryDisabled));
+
+            // WithAgentCoreMemory() is used for local testing, but CreateMemory = false suppresses provisioning the
+            // memory resource during deployment.
+            builder.AddAgentCoreRuntime<Projects.DeploymentTestApp_AgentCoreAgent>("AgentCoreAgent")
+                .WithAgentCoreMemory()
+                .PublishAsAgentCoreRuntime(new PublishAgentCoreRuntimeConfig
+                {
+                    CreateMemory = false
+                });
+
+            await ExecuteApp(builder);
+        }
+
         public static async Task PublishAgentCoreRuntimeWithCustomization()
         {
             var builder = DistributedApplication.CreateBuilder(Environment.GetCommandLineArgs());

--- a/testapps/DeploymentTestApps/DeploymentTestApp.AppHost/Scenarios.cs
+++ b/testapps/DeploymentTestApps/DeploymentTestApp.AppHost/Scenarios.cs
@@ -303,6 +303,24 @@ namespace DeploymentTestApp.AppHost
             await ExecuteApp(builder);
         }
 
+        public static async Task PublishAgentCoreRuntimeWithMultipleMemories()
+        {
+            var builder = DistributedApplication.CreateBuilder(Environment.GetCommandLineArgs());
+
+            builder.AddAWSCDKEnvironment("aws", CDKDefaultsProviderFactory.Preview_V1, _defaultEnvironentResourceConfig, nameof(PublishAgentCoreRuntimeWithMultipleMemories));
+
+            // Two agents each provision their own memory but share the default runtime role. The role
+            // should receive a single bedrock-agentcore memory statement listing both memory ARNs, rather
+            // than one statement per memory.
+            builder.AddAgentCoreRuntime<Projects.DeploymentTestApp_AgentCoreAgent>("AgentCoreAgent1")
+                .WithAgentCoreMemory();
+
+            builder.AddAgentCoreRuntime<Projects.DeploymentTestApp_AgentCoreAgent>("AgentCoreAgent2")
+                .WithAgentCoreMemory();
+
+            await ExecuteApp(builder);
+        }
+
         public static async Task PublishAgentCoreRuntimeWithMemoryDisabled()
         {
             var builder = DistributedApplication.CreateBuilder(Environment.GetCommandLineArgs());

--- a/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
+++ b/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
@@ -1840,6 +1840,64 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task TestPublishAgentCoreRuntimeWithMultipleMemories()
+    {
+        var cloudFormationValidation = (JsonDocument cfTemplateDoc) =>
+        {
+            // Both agents are created, each with its own memory resource.
+            var agentRuntimes = GetResourcesOfType(cfTemplateDoc, "AWS::BedrockAgentCore::Runtime");
+            Assert.Equal(2, agentRuntimes.Count);
+
+            var memories = GetResourcesOfType(cfTemplateDoc, "AWS::BedrockAgentCore::Memory");
+            Assert.Equal(2, memories.Count);
+
+            // Both agents share the single default runtime role, and the memory data-plane actions are
+            // granted through a single policy statement listing both memory ARNs — not one statement per
+            // memory. Find every statement that carries the memory actions across all IAM policies.
+            var policies = GetResourcesOfType(cfTemplateDoc, "AWS::IAM::Policy");
+            var memoryStatements = policies
+                .SelectMany(p =>
+                {
+                    var statements = GetElementAtPath(p.Resource, "Properties/PolicyDocument/Statement");
+                    if (statements is not { ValueKind: JsonValueKind.Array } stmts)
+                        return Enumerable.Empty<JsonElement>();
+                    return stmts.EnumerateArray().Where(s =>
+                    {
+                        var action = GetElementAtPath(s, "Action");
+                        if (action is not { ValueKind: JsonValueKind.Array } actions)
+                            return false;
+                        var actionTexts = actions.EnumerateArray()
+                            .Where(a => a.ValueKind == JsonValueKind.String)
+                            .Select(a => a.GetString())
+                            .ToList();
+                        return actionTexts.Contains("bedrock-agentcore:CreateEvent") &&
+                               actionTexts.Contains("bedrock-agentcore:RetrieveMemoryRecords");
+                    });
+                })
+                .ToList();
+
+            // Exactly one statement grants the memory actions (no duplicated action list per memory).
+            Assert.Single(memoryStatements);
+
+            // That single statement's Resource list references both memories' ARNs.
+            var resource = GetElementAtPath(memoryStatements[0], "Resource");
+            Assert.True(resource is { ValueKind: JsonValueKind.Array }, "The memory statement should scope access to an array of memory ARNs");
+            var resources = resource!.Value.EnumerateArray().ToList();
+
+            // Each memory contributes a base MemoryArn entry plus a "/*" child entry (Fn::Join wrapping
+            // the Fn::GetAtt MemoryArn), so both memory logical ids should appear in the resource list.
+            foreach (var memory in memories)
+            {
+                Assert.Contains(resources, r => r.GetRawText().Contains(memory.LogicalId));
+            }
+
+            return Task.CompletedTask;
+        };
+
+        await ExecutePublishAsync(nameof(Scenarios.PublishAgentCoreRuntimeWithMultipleMemories), cloudFormationValidation);
+    }
+
+    [Fact]
     public async Task TestPublishAgentCoreRuntimeWithMemoryDisabled()
     {
         var cloudFormationValidation = (JsonDocument cfTemplateDoc) =>

--- a/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
+++ b/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
@@ -1773,6 +1773,102 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public async Task TestPublishAgentCoreRuntimeWithMemory()
+    {
+        var cloudFormationValidation = (JsonDocument cfTemplateDoc) =>
+        {
+            // The agent runtime is created.
+            var agentRuntimes = GetResourcesOfType(cfTemplateDoc, "AWS::BedrockAgentCore::Runtime");
+            Assert.Single(agentRuntimes);
+            var agentRuntime = agentRuntimes[0];
+
+            // Exactly one AgentCore Memory resource is provisioned because the agent called WithAgentCoreMemory().
+            var memories = GetResourcesOfType(cfTemplateDoc, "AWS::BedrockAgentCore::Memory");
+            Assert.Single(memories);
+            var memory = memories[0];
+
+            // The memory has the defaulted event expiry duration and a sanitized name.
+            var expiry = AssertElementExistsAtPath(memory.Resource, "Properties/EventExpiryDuration");
+            Assert.Equal(90, expiry.GetInt32());
+            var memoryName = AssertElementExistsAtPath(memory.Resource, "Properties/Name");
+            Assert.Equal("PublishAgentCoreRuntimeWithMemory_AgentCoreAgent", memoryName.GetString());
+
+            // The runtime's AWS_AGENTCORE_MEMORY_ID env var resolves to the created memory's id via
+            // Fn::GetAtt, not the local "localdev-memory" placeholder seeded by WithAgentCoreMemory().
+            var memoryIdEnv = AssertElementExistsAtPath(agentRuntime.Resource,
+                "Properties/EnvironmentVariables/AWS_AGENTCORE_MEMORY_ID");
+            Assert.NotEqual("localdev-memory", memoryIdEnv.GetRawText().Trim('"'));
+            var memoryIdGetAtt = AssertElementExistsAtPath(memoryIdEnv, "Fn::GetAtt");
+            Assert.Equal(JsonValueKind.Array, memoryIdGetAtt.ValueKind);
+            Assert.Equal(memory.LogicalId, memoryIdGetAtt[0].GetString());
+            Assert.Equal("MemoryId", memoryIdGetAtt[1].GetString());
+
+            // The agent's default runtime role is granted the AgentCore memory data-plane actions, scoped
+            // to the created memory's ARN (and its child resources).
+            var policies = GetResourcesOfType(cfTemplateDoc, "AWS::IAM::Policy");
+            var memoryPolicy = policies.FirstOrDefault(p =>
+            {
+                var statements = GetElementAtPath(p.Resource, "Properties/PolicyDocument/Statement");
+                if (statements is not { ValueKind: JsonValueKind.Array } stmts)
+                    return false;
+                return stmts.EnumerateArray().Any(s =>
+                {
+                    var action = GetElementAtPath(s, "Action");
+                    if (action is not { ValueKind: JsonValueKind.Array } actions)
+                        return false;
+                    var actionTexts = actions.EnumerateArray()
+                        .Where(a => a.ValueKind == JsonValueKind.String)
+                        .Select(a => a.GetString())
+                        .ToList();
+                    if (!actionTexts.Contains("bedrock-agentcore:CreateEvent") ||
+                        !actionTexts.Contains("bedrock-agentcore:RetrieveMemoryRecords"))
+                        return false;
+
+                    // The resources are scoped to the memory ARN via Fn::GetAtt MemoryArn.
+                    var resource = GetElementAtPath(s, "Resource");
+                    if (resource is not { ValueKind: JsonValueKind.Array } resources)
+                        return false;
+                    return resources.EnumerateArray().Any(r => r.GetRawText().Contains("MemoryArn"));
+                });
+            });
+            Assert.False(string.IsNullOrEmpty(memoryPolicy.LogicalId), "The AgentCore runtime role should have an inline policy granting bedrock-agentcore memory data-plane actions scoped to the memory ARN");
+
+            return Task.CompletedTask;
+        };
+
+        await ExecutePublishAsync(nameof(Scenarios.PublishAgentCoreRuntimeWithMemory), cloudFormationValidation);
+    }
+
+    [Fact]
+    public async Task TestPublishAgentCoreRuntimeWithMemoryDisabled()
+    {
+        var cloudFormationValidation = (JsonDocument cfTemplateDoc) =>
+        {
+            // The agent runtime is created.
+            var agentRuntimes = GetResourcesOfType(cfTemplateDoc, "AWS::BedrockAgentCore::Runtime");
+            Assert.Single(agentRuntimes);
+
+            // CreateMemory = false suppresses provisioning the memory resource even though WithAgentCoreMemory()
+            // was called (for local testing).
+            var memories = GetResourcesOfType(cfTemplateDoc, "AWS::BedrockAgentCore::Memory");
+            Assert.Empty(memories);
+
+            // The AWS_AGENTCORE_MEMORY_ID env var, if present, is not a memory Fn::GetAtt (it keeps the
+            // local placeholder copied from WithAgentCoreMemory()).
+            var memoryIdEnv = GetElementAtPath(cfTemplateDoc,
+                $"Resources/{agentRuntimes[0].LogicalId}/Properties/EnvironmentVariables/AWS_AGENTCORE_MEMORY_ID");
+            if (memoryIdEnv is { } env)
+            {
+                Assert.NotEqual(JsonValueKind.Object, env.ValueKind);
+            }
+
+            return Task.CompletedTask;
+        };
+
+        await ExecutePublishAsync(nameof(Scenarios.PublishAgentCoreRuntimeWithMemoryDisabled), cloudFormationValidation);
+    }
+
+    [Fact]
     public async Task TestPublishAgentCoreRuntimeWithReference()
     {
         var cloudFormationValidation = (JsonDocument cfTemplateDoc) =>

--- a/tests/Aspire.Hosting.AWS.UnitTests/AgentCoreResourceBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/AgentCoreResourceBuilderExtensionsTests.cs
@@ -103,12 +103,12 @@ public class AgentCoreResourceBuilderExtensionsTests
     }
 
     [Fact]
-    public void WithInMemory_SetsMemoryFlag()
+    public void WithAgentCoreMemory_SetsMemoryFlag()
     {
         var builder = DistributedApplication.CreateBuilder();
 
         var agent = builder.AddAgentCoreRuntime<FakeAgent>("my-agent")
-            .WithInMemory();
+            .WithAgentCoreMemory();
 
         var annotation = agent.Resource.Annotations
             .OfType<AgentCoreRuntimeAnnotation>()
@@ -118,13 +118,13 @@ public class AgentCoreResourceBuilderExtensionsTests
     }
 
     [Fact]
-    public void WithInMemory_ThrowsOnNonAgentCoreResource()
+    public void WithAgentCoreMemory_ThrowsOnNonAgentCoreResource()
     {
         var builder = DistributedApplication.CreateBuilder();
 
         var project = builder.AddProject<FakeAgent>("plain-project", o => o.ExcludeLaunchProfile = true);
 
-        Assert.Throws<InvalidOperationException>(() => project.WithInMemory());
+        Assert.Throws<InvalidOperationException>(() => project.WithAgentCoreMemory());
     }
 
     [Fact]
@@ -270,13 +270,13 @@ public class AgentCoreResourceBuilderExtensionsTests
     }
 
     [Fact]
-    public void WithStreaming_CanBeChainedWithWithInMemory()
+    public void WithStreaming_CanBeChainedWithWithAgentCoreMemory()
     {
         var builder = DistributedApplication.CreateBuilder();
 
         var agent = builder.AddAgentCoreRuntime<FakeAgent>("my-agent")
             .WithStreaming()
-            .WithInMemory();
+            .WithAgentCoreMemory();
 
         var annotation = agent.Resource.Annotations
             .OfType<AgentCoreRuntimeAnnotation>()


### PR DESCRIPTION
## Summary

Adds provisioning of AWS Bedrock **AgentCore Memory** during deployment. Previously `WithInMemory()` only stood up a local memory emulator; none of that translated to deployed infrastructure. Now, when memory is requested on an agent, deployment creates an `AWS::BedrockAgentCore::Memory` resource, points the agent at it, and grants the agent's IAM role access to it.

## ⚠️ Breaking change — `WithInMemory` renamed to `WithAgentCoreMemory`

The experimental extension method **`WithInMemory()` has been renamed to `WithAgentCoreMemory()`**. Because it is exposed on the generic `IResourceBuilder<ProjectResource>` (shared with non-agent projects), the new name makes it clear the method configures AgentCore memory. Behavior for local development is unchanged. This is an experimental (`ASPIREAWSAGENTCORE001`) API, so it was renamed outright rather than kept as an alias — update any `.WithInMemory()` calls to `.WithAgentCoreMemory()`.

## What's included

**Deployment: create the memory resource**
- When `WithAgentCoreMemory()` was called (`AgentCoreRuntimeAnnotation.HasMemory`), `AgentCoreRuntimePublishTarget` now creates a `CfnMemory` (`AWS::BedrockAgentCore::Memory`) construct following the existing publish-target conventions.
- A short-term (event) memory is created — matching what the local emulator provides. It defaults an `EventExpiryDuration` (90 days) and derives a sanitized memory name from the stack + resource name. Long-term memory strategies / a memory execution role are intentionally left to the user via the new props callback.

**Agent wiring**
- The agent's `AWS_AGENTCORE_MEMORY_ID` environment variable is pointed at the created memory's id (`Fn::GetAtt … MemoryId`), replacing the local `localdev-memory` placeholder during publish.
- A dependency is added so the memory is provisioned before the runtime.

**IAM**
- When the agent's runtime role was created by the integration (not user-supplied), it is granted the AgentCore memory **data-plane** permissions (`CreateEvent`, `GetEvent`, `ListEvents`, `DeleteEvent`, `ListActors`, `ListSessions`, `RetrieveMemoryRecords`, `GetMemoryRecord`, `ListMemoryRecords`), scoped to the created memory's ARN and its child resources. User-supplied roles are never mutated.

**Customization (follows the publishing-target callback pattern)**
- `PublishAgentCoreRuntimeConfig.PropsCfnMemoryCallback` — customize the memory props before construction.
- `PublishAgentCoreRuntimeConfig.ConstructCfnMemoryCallback` — customize the constructed memory.
- `PublishAgentCoreRuntimeConfig.CreateMemory` (`bool?`) — opt-out/override. Defaults to following `WithAgentCoreMemory()`; set `false` to use the emulator locally while skipping memory provisioning on deploy (resolved as `CreateMemory ?? HasMemory`, so it works regardless of call order).

## Tests

- New deployment scenarios `PublishAgentCoreRuntimeWithMemory` and `PublishAgentCoreRuntimeWithMemoryDisabled`.
- New CloudFormation assertion tests:
  - `TestPublishAgentCoreRuntimeWithMemory` — asserts a single `AWS::BedrockAgentCore::Memory` is emitted, `AWS_AGENTCORE_MEMORY_ID` resolves via `Fn::GetAtt` to the memory (not `localdev-memory`), and the runtime role has the memory data-plane policy scoped to the memory ARN.
  - `TestPublishAgentCoreRuntimeWithMemoryDisabled` — asserts no memory resource is emitted when `CreateMemory = false`.
- Updated existing AgentCore unit tests for the rename.

## Playground

- `WithInMemory()` → `WithAgentCoreMemory()` in the AgentCore and AgentCoreTestApp app hosts.
- The Publishing playground's HoroscopeAgent now uses AgentCore memory (`WithAgentCoreMemory()`) in place of the Redis cache.

## Notes

- All new CDK/deployment code is under `#if NET10_0_OR_GREATER`, matching the rest of the AgentCore publish target.
- `CfnMemoryProps.EventExpiryDuration` is a non-nullable `double`, so `0` is treated as "unset" when applying the default.
