### PR TITLE
chore: rename preview method WithStreaming to WithAgentCoreStreaming

### DIFF
--- a/.autover/changes/ed8515cc-43f4-43b6-85a7-3b77f26a8ed3.json
+++ b/.autover/changes/ed8515cc-43f4-43b6-85a7-3b77f26a8ed3.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Minor",
+      "ChangelogMessages": [
+		"[Breaking Change] Rename the preview WithStreaming method to WithAgentCoreStreaming"
+      ]
+    }
+  ]
+}

--- a/playground/AgentCore/AgentCore.AppHost/Program.cs
+++ b/playground/AgentCore/AgentCore.AppHost/Program.cs
@@ -11,10 +11,10 @@ var agent = builder.AddAgentCoreRuntime<Projects.AgentCore_Agent>(
     .WithAgentCoreMemory();
 
 // Register a streaming agent.
-// WithStreaming tells the chat app to use SSE streaming mode.
+// WithAgentCoreStreaming tells the chat app to use SSE streaming mode.
 builder.AddAgentCoreRuntime<Projects.AgentCore_StreamingAgent>(
     "AgentCore-StreamingAgent", new() { IncludeEmulatorLogs = true })
-    .WithStreaming()
+    .WithAgentCoreStreaming()
     .WithAgentCoreMemory();
 
 // WithReference injects AWS_ENDPOINT_URL_BEDROCK_AGENTCORE into the ChatUI project

--- a/playground/Publishing/Publishing.HoroscopeAgent/Dockerfile
+++ b/playground/Publishing/Publishing.HoroscopeAgent/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+USER app
+WORKDIR /app
+EXPOSE 8080
+EXPOSE 8081
+
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+ARG TARGETARCH
+WORKDIR /src
+COPY . .
+RUN dotnet restore "playground/Publishing/Publishing.HoroscopeAgent/Publishing.HoroscopeAgent.csproj" -a $TARGETARCH
+WORKDIR "/src/playground/Publishing/Publishing.HoroscopeAgent"
+RUN dotnet build "Publishing.HoroscopeAgent.csproj" -c Release -o /app/build -a $TARGETARCH
+
+FROM build AS publish
+ARG TARGETARCH
+RUN dotnet publish "Publishing.HoroscopeAgent.csproj" -c Release -o /app/publish -a $TARGETARCH
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "Publishing.HoroscopeAgent.dll"]

--- a/src/Aspire.Hosting.AWS/AgentCore/AgentCoreResourceBuilderExtensions.cs
+++ b/src/Aspire.Hosting.AWS/AgentCore/AgentCoreResourceBuilderExtensions.cs
@@ -167,14 +167,14 @@ public static class AgentCoreResourceBuilderExtensions
     /// <param name="agentApp">The agent resource builder.</param>
     /// <returns>The resource builder for further chaining.</returns>
     [Experimental(Constants.ASPIREAWSAGENTCORE001)]
-    public static IResourceBuilder<ProjectResource> WithStreaming(
+    public static IResourceBuilder<ProjectResource> WithAgentCoreStreaming(
         this IResourceBuilder<ProjectResource> agentApp)
     {
         var annotation = agentApp.Resource.Annotations
             .OfType<AgentCoreRuntimeAnnotation>()
             .FirstOrDefault()
             ?? throw new InvalidOperationException(
-                "WithStreaming can only be called on an AgentCore runtime resource. " +
+                "WithAgentCoreStreaming can only be called on an AgentCore runtime resource. " +
                 "Use AddAgentCoreRuntime<T>() to create it.");
 
         annotation.IsStreaming = true;

--- a/src/Aspire.Hosting.AWS/README.md
+++ b/src/Aspire.Hosting.AWS/README.md
@@ -492,7 +492,7 @@ var agent = builder.AddAgentCoreRuntime<Projects.MyAgent>("my-agent")
 
 // Register a streaming agent
 builder.AddAgentCoreRuntime<Projects.MyStreamingAgent>("my-streaming-agent")
-    .WithStreaming()
+    .WithAgentCoreStreaming()
     .WithAgentCoreMemory();
 
 // Wire a consumer project — AWS_ENDPOINT_URL_BEDROCK_AGENTCORE is injected automatically
@@ -507,7 +507,7 @@ builder.Build().Run();
 | Method | Description |
 |--------|-------------|
 | `AddAgentCoreRuntime<TProject>()` | Registers an agent with embedded runtime and chat emulators |
-| `.WithStreaming()` | Enables SSE streaming mode for the chat app |
+| `.WithAgentCoreStreaming()` | Enables SSE streaming mode for the chat app |
 | `.WithAgentCoreMemory()` | Enables AgentCore memory: a short-term memory emulator locally, and a provisioned AgentCore Memory resource on deployment |
 | `.WithReference(agent)` | Injects the runtime emulator endpoint into a consumer project via `AWS_ENDPOINT_URL_BEDROCK_AGENTCORE` |
 

--- a/testapps/AgentCoreTestApps/AgentCoreTestApp.AppHost/Program.cs
+++ b/testapps/AgentCoreTestApps/AgentCoreTestApp.AppHost/Program.cs
@@ -6,7 +6,7 @@ var agent = builder.AddAgentCoreRuntime<Projects.AgentCoreTestApp_Agent>("AgentC
 
 // Streaming agent
 builder.AddAgentCoreRuntime<Projects.AgentCoreTestApp_StreamingAgent>("AgentCoreTestApp-StreamingAgent")
-    .WithStreaming()
+    .WithAgentCoreStreaming()
     .WithAgentCoreMemory();
 
 // Chat UI that invokes the agent via the AWS SDK

--- a/tests/Aspire.Hosting.AWS.UnitTests/AgentCoreResourceBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/AgentCoreResourceBuilderExtensionsTests.cs
@@ -78,12 +78,12 @@ public class AgentCoreResourceBuilderExtensionsTests
     }
 
     [Fact]
-    public void WithStreaming_SetsStreamingFlag()
+    public void WithAgentCoreStreaming_SetsStreamingFlag()
     {
         var builder = DistributedApplication.CreateBuilder();
 
         var agent = builder.AddAgentCoreRuntime<FakeAgent>("my-agent")
-            .WithStreaming();
+            .WithAgentCoreStreaming();
 
         var annotation = agent.Resource.Annotations
             .OfType<AgentCoreRuntimeAnnotation>()
@@ -93,13 +93,13 @@ public class AgentCoreResourceBuilderExtensionsTests
     }
 
     [Fact]
-    public void WithStreaming_ThrowsOnNonAgentCoreResource()
+    public void WithAgentCoreStreaming_ThrowsOnNonAgentCoreResource()
     {
         var builder = DistributedApplication.CreateBuilder();
 
         var project = builder.AddProject<FakeAgent>("plain-project", o => o.ExcludeLaunchProfile = true);
 
-        Assert.Throws<InvalidOperationException>(() => project.WithStreaming());
+        Assert.Throws<InvalidOperationException>(() => project.WithAgentCoreStreaming());
     }
 
     [Fact]
@@ -270,12 +270,12 @@ public class AgentCoreResourceBuilderExtensionsTests
     }
 
     [Fact]
-    public void WithStreaming_CanBeChainedWithWithAgentCoreMemory()
+    public void WithAgentCoreStreaming_CanBeChainedWithWithAgentCoreMemory()
     {
         var builder = DistributedApplication.CreateBuilder();
 
         var agent = builder.AddAgentCoreRuntime<FakeAgent>("my-agent")
-            .WithStreaming()
+            .WithAgentCoreStreaming()
             .WithAgentCoreMemory();
 
         var annotation = agent.Resource.Annotations


### PR DESCRIPTION
## ⚠️ Breaking change — `WithStreaming` renamed to `WithAgentCoreStreaming`

The experimental extension method **`WithStreaming()` has been renamed to `WithAgentCoreStreaming()`**. Because it is exposed on the generic `IResourceBuilder<ProjectResource>` (shared with non-agent projects), the new name makes it clear the method configures AgentCore streaming support. Behavior for local development is unchanged. This is an experimental (`ASPIREAWSAGENTCORE001`) API, so it was renamed outright rather than kept as an alias — update any `.WithStreaming()` calls to `.WithAgentCoreStreaming()`.