### PR TITLE
[Breaking Change] Switch ECS Express to use TaskDefinition Instead of PrimaryContainer

### DIFF
--- a/.autover/changes/33e6a70d-c7af-4a97-baaf-86fe9dc5daee.json
+++ b/.autover/changes/33e6a70d-c7af-4a97-baaf-86fe9dc5daee.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "[Breaking Change] ECS Fargate Express Service deployment now uses a TaskDefinition construct instead of the PrimaryContainer construct when generating the CDK stack. This change is required for future work of adding OpenTelemetry support where the side car container will need to be added to the TaskDefinition."
+      ]
+    }
+  ]
+}

--- a/.autover/changes/33e6a70d-c7af-4a97-baaf-86fe9dc5daee.json
+++ b/.autover/changes/33e6a70d-c7af-4a97-baaf-86fe9dc5daee.json
@@ -4,7 +4,8 @@
       "Name": "Aspire.Hosting.AWS",
       "Type": "Patch",
       "ChangelogMessages": [
-        "[Breaking Change] ECS Fargate Express Service deployment now uses a TaskDefinition construct instead of the PrimaryContainer construct when generating the CDK stack. This change is required for future work of adding OpenTelemetry support where the side car container will need to be added to the TaskDefinition."
+        "[Breaking Change] ECS Fargate Express Service deployment now uses a TaskDefinition construct instead of the PrimaryContainer construct when generating the CDK stack. This change is required for future work of adding OpenTelemetry support where the side car container will need to be added to the TaskDefinition.",
+		"Updated Amazon.CDK.Lib dependency from 2.235.0 to 2.262.0"
       ]
     }
   ]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,7 +46,7 @@
     <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="3.0.0" />
     <PackageVersion Include="Amazon.AspNetCore.DataProtection.SSM" Version="4.0.1" />
     <!-- AWS CDK dependencies -->
-    <PackageVersion Include="Amazon.CDK.Lib" Version="2.236.0" />
+    <PackageVersion Include="Amazon.CDK.Lib" Version="2.262.0" />
     <!-- Open Telemetry -->
     <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -5,7 +5,7 @@ phases:
     runtime-versions:
       nodejs: 22
     commands:
-      - npm install -g aws-cdk@2.1106.0
+      - npm install -g aws-cdk@2.1133.0
       - cdk --version   
       - find / -type f -name 'global.json' -delete
       - curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 8.0

--- a/docs/deployment-design.md
+++ b/docs/deployment-design.md
@@ -468,7 +468,7 @@ An ECS task definition has two distinct IAM roles:
 - **Execution role** — used by the ECS/Fargate platform to pull the image, write logs, and resolve secrets. The integration assigns a shared default for this (e.g. `DefaultECSExpressExecutionRole`).
 - **Task role** — the role the application's *own* code assumes at runtime to call AWS APIs (S3, DynamoDB, Bedrock AgentCore, etc.).
 
-All three ECS publish targets — `PublishAsECSFargateExpressService` (`CfnExpressGatewayService.TaskRoleArn`), `PublishAsECSFargateService` (`FargateTaskDefinition.TaskRole`), and `PublishAsECSFargateServiceWithALB` (`ApplicationLoadBalancedTaskImageOptions.TaskRole`) — assign a **default task role when the user has not supplied one**. This gives every service a consistent, controllable identity and a place for references to attach scoped permissions.
+All three ECS publish targets — `PublishAsECSFargateExpressService` (`FargateTaskDefinition.TaskRole`), `PublishAsECSFargateService` (`FargateTaskDefinition.TaskRole`), and `PublishAsECSFargateServiceWithALB` (`ApplicationLoadBalancedTaskImageOptions.TaskRole`) — assign a **default task role when the user has not supplied one**. This gives every service a consistent, controllable identity and a place for references to attach scoped permissions.
 
 ### Per-service, created empty
 
@@ -488,10 +488,10 @@ Each publish target creates the role only when the relevant prop is unset (after
 
 ```csharp
 IRole? defaultTaskRole = null;
-if (string.IsNullOrEmpty(fargateServiceProps.TaskRoleArn))   // L2 targets check the IRole TaskRole prop instead
+if (fargateTaskDefinitionProps.TaskRole == null)   // all three ECS targets now check an IRole prop on the task definition
 {
     defaultTaskRole = environment.DefaultsProvider.CreateDefaultECSTaskRole(projectResource.Name);
-    fargateServiceProps.TaskRoleArn = defaultTaskRole.RoleArn;
+    fargateTaskDefinitionProps.TaskRole = defaultTaskRole;
 }
 // defaultTaskRole is passed to the connection-points object; ReferenceTaskRole returns it (else null)
 ```
@@ -499,6 +499,23 @@ if (string.IsNullOrEmpty(fargateServiceProps.TaskRoleArn))   // L2 targets check
 ### Interaction with references
 
 Because only the integration-created role is exposed through `ReferenceTaskRole`, the task-role policy hooks (see [Task Role Policies](#4-task-role-policies)) run **only** when the default role was used. If the user supplies their own task role — via a props callback on the publish target — the integration never mutates it, and the user owns granting any permissions their references need. The concrete payoff: a service that `WithReference`s an AgentCore agent automatically gets `bedrock-agentcore:Invoke*` on its default task role.
+
+---
+
+## ECS Fargate Express Task Definition Requirements
+
+`PublishAsECSFargateExpressService` runs the project on a `FargateTaskDefinition` that the
+`CfnExpressGatewayService` points at via its `TaskDefinitionArn` property (rather than the inline
+`PrimaryContainer` property). Amazon ECS Express imposes two requirements on that task definition's
+primary container that the publish target satisfies automatically:
+
+- **The primary container must be named `Main`.** The publish target sets `ContainerDefinitionProps.ContainerName = "Main"`. (The CDK construct id remains `Container-{resourceName}`, but the container *name* emitted to CloudFormation is `Main`.) Deploying with any other name fails with `Task definition must have a Main container`.
+- **The `Main` container must expose a named TCP port mapping.** The default port mapping sets `ContainerPort` (8080), `Name` (`http`, via `ECSFargateExpressContainerPortName`), and `Protocol = Protocol.TCP`. Omitting the port name or protocol fails at deploy time with `Task definition must have a port mapping with TCP protocol, a container port, and a port name on the Main container`.
+
+The `Main` name is set when the container props are created. The default port mapping is applied by
+`ApplyCfnExpressGatewayServiceContainerDefinitionDefaults` **after** the user's
+`PropsContainerDefinitionCallback` runs, and only when no port mapping was supplied — so a user who
+supplies their own port mapping is responsible for keeping it a named TCP mapping.
 
 ---
 
@@ -570,16 +587,38 @@ public virtual void ApplyLambdaFunctionDefaults(FunctionProps props, LambdaProje
     props.Architecture ??= Architecture.X86_64;
 }
 
-// Example: ECS Express service defaults
+// Example: ECS Express service defaults.
+// The Express service runs a FargateTaskDefinition (referenced via TaskDefinitionArn), so the
+// container-hosting settings are split across three Apply* methods, mirroring the ECS Fargate target.
+public virtual void ApplyCfnExpressGatewayServiceTaskDefinitionDefaults(FargateTaskDefinitionProps props)
+{
+    props.Cpu ??= ECSFargateExpressCpu;                        // e.g. 1024
+    props.MemoryLimitMiB ??= ECSFargateExpressMiB;             // e.g. 2048
+    props.ExecutionRole ??= GetDefaultECSExpressExecutionRole();
+}
+
+public virtual void ApplyCfnExpressGatewayServiceContainerDefinitionDefaults(string projectName, ContainerDefinitionProps props)
+{
+    props.Logging ??= CreateECSFargateServiceLogDriver(projectName);   // awslogs driver
+    // ECS Fargate Express requires the primary container's port mapping to be a *named* TCP port.
+    if (props.PortMappings is null || props.PortMappings.Length == 0)
+        props.PortMappings = new[]
+        {
+            new PortMapping
+            {
+                ContainerPort = ECSFargateExpressContainerPort ?? 8080,
+                Name = ECSFargateExpressContainerPortName,   // e.g. "http"
+                Protocol = Protocol.TCP
+            }
+        };
+}
+
 public virtual void ApplyCfnExpressGatewayServiceDefaults(CfnExpressGatewayServiceProps props)
 {
-    props.ExecutionRole ??= GetDefaultECSExpressExecutionRole().RoleArn;
-    props.InfrastructureRole ??= GetDefaultECSExpressInfrastructureRole().RoleArn;
-    
-    if (props.PrimaryContainer is ExpressGatewayContainerProperty container)
-    {
-        container.Port ??= 8080;  // Default container port
-    }
+    // The service itself only needs the infrastructure role and network configuration; the container,
+    // CPU/memory, execution role, and task role live on the task definition it points at.
+    props.InfrastructureRoleArn ??= GetDefaultECSExpressInfrastructureRole().RoleArn;
+    // props.NetworkConfiguration ??= ... (security groups + public subnets)
 }
 
 // Example: AgentCore runtime defaults

--- a/docs/deployment-design.md
+++ b/docs/deployment-design.md
@@ -510,12 +510,15 @@ Because only the integration-created role is exposed through `ReferenceTaskRole`
 primary container that the publish target satisfies automatically:
 
 - **The primary container must be named `Main`.** The publish target sets `ContainerDefinitionProps.ContainerName = "Main"`. (The CDK construct id remains `Container-{resourceName}`, but the container *name* emitted to CloudFormation is `Main`.) Deploying with any other name fails with `Task definition must have a Main container`.
-- **The `Main` container must expose a named TCP port mapping.** The default port mapping sets `ContainerPort` (8080), `Name` (`http`, via `ECSFargateExpressContainerPortName`), and `Protocol = Protocol.TCP`. Omitting the port name or protocol fails at deploy time with `Task definition must have a port mapping with TCP protocol, a container port, and a port name on the Main container`.
+- **The `Main` container must expose a named TCP port mapping.** The default port mapping sets `ContainerPort` (8080), `Name` (`http`, via `ECSFargateExpressContainerPortName`), and `Protocol = Protocol.TCP`. Without a named TCP port, ECS rejects the deployment with `Task definition must have a port mapping with TCP protocol, a container port, and a port name on the Main container`.
 
 The `Main` name is set when the container props are created. The default port mapping is applied by
 `ApplyCfnExpressGatewayServiceContainerDefinitionDefaults` **after** the user's
-`PropsContainerDefinitionCallback` runs, and only when no port mapping was supplied — so a user who
-supplies their own port mapping is responsible for keeping it a named TCP mapping.
+`PropsContainerDefinitionCallback` runs, and only when no port mapping was supplied. If the user
+supplies their own port mappings, `ValidateExpressPortMappings` checks that at least one is a named TCP
+mapping (a null protocol counts as TCP, matching the ECS/CDK default) and throws at synth time
+otherwise — so a misconfiguration fails fast rather than at deploy. The named TCP mapping need not be
+first in the list; any compliant entry satisfies the requirement.
 
 ---
 

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.ECSFargateExpressService.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.ECSFargateExpressService.cs
@@ -31,35 +31,65 @@ public partial class CDKDefaultsProvider
     public virtual double? ECSFargateExpressContainerPort => 8080;
 
     /// <summary>
+    /// Gets the name given to the default container port mapping. ECS Fargate Express requires the primary
+    /// ("Main") container to have a named TCP port mapping.
+    /// </summary>
+    /// <remarks>
+    /// Default is "http".
+    /// </remarks>
+    public virtual string ECSFargateExpressContainerPortName => "http";
+
+    /// <summary>
+    /// Applies default values to the Fargate task definition used by an ECS Express Gateway service, if they
+    /// are not already set. The Express service points at this task definition via its TaskDefinitionArn
+    /// property, so container-hosting settings such as CPU, memory, and the execution role live here.
+    /// </summary>
+    /// <param name="props">The Fargate task definition properties to which default values will be applied.</param>
+    protected internal virtual void ApplyCfnExpressGatewayServiceTaskDefinitionDefaults(FargateTaskDefinitionProps props)
+    {
+        if (props.Cpu == null)
+            props.Cpu = ECSFargateExpressCpu;
+        if (props.MemoryLimitMiB == null)
+            props.MemoryLimitMiB = ECSFargateExpressMiB;
+        if (props.ExecutionRole == null)
+            props.ExecutionRole = GetDefaultECSExpressExecutionRole();
+    }
+
+    /// <summary>
+    /// Applies default values to the container definition run by an ECS Express Gateway service's task
+    /// definition, if they are not already set. This adds awslogs logging and the default container port.
+    /// </summary>
+    /// <param name="projectName">The name of the project, used to create the log stream prefix.</param>
+    /// <param name="props">The container definition properties to which default values will be applied.</param>
+    protected internal virtual void ApplyCfnExpressGatewayServiceContainerDefinitionDefaults(string projectName, ContainerDefinitionProps props)
+    {
+        if (props.Logging == null)
+            props.Logging = CreateECSFargateServiceLogDriver(projectName);
+
+        if (props.PortMappings == null || props.PortMappings.Length == 0)
+        {
+            // ECS Fargate Express requires the Main container to expose a named TCP port mapping.
+            props.PortMappings = new[]
+            {
+                new PortMapping
+                {
+                    ContainerPort = ECSFargateExpressContainerPort ?? 8080,
+                    Name = ECSFargateExpressContainerPortName,
+                    Protocol = Protocol.TCP
+                }
+            };
+        }
+    }
+
+    /// <summary>
     /// Applies default values to the specified properties for configuring an AWS CloudFormation Express Gateway
-    /// service, if they are not already set.
+    /// service, if they are not already set. Container-hosting settings (CPU, memory, image, execution role,
+    /// container port) live on the task definition; this method only sets the service-level defaults.
     /// </summary>
     /// <param name="props">The properties object to which default values will be applied. Properties that are null or empty will be set to
     /// recommended defaults for an Express Gateway service.</param>
-    /// <exception cref="InvalidDataException">Thrown if the <paramref name="props"/>.PrimaryContainer property is not set or is not of type <see
-    /// cref="CfnExpressGatewayService.ExpressGatewayContainerProperty"/>.</exception>
     protected internal virtual void ApplyCfnExpressGatewayServiceDefaults(CfnExpressGatewayServiceProps props)
     {
-        if (props.Cluster == null)
-            props.Cluster = GetDefaultECSCluster().ClusterName;
-        if (string.IsNullOrEmpty(props.Cpu))
-            props.Cpu = ECSFargateExpressCpu.ToString();
-        if (string.IsNullOrEmpty(props.Memory))
-            props.Memory = ECSFargateExpressMiB.ToString();
-
-        var primaryContainer = props.PrimaryContainer as CfnExpressGatewayService.ExpressGatewayContainerProperty;
-        if (primaryContainer == null)
-            throw new InvalidDataException("PrimaryContainer must be set and of type ExpressGatewayContainerProperty.");
-
-        if (!primaryContainer.ContainerPort.HasValue)
-            primaryContainer.ContainerPort = ECSFargateExpressContainerPort;
-
-        if (string.IsNullOrEmpty(props.ExecutionRoleArn))
-        {
-            var role = GetDefaultECSExpressExecutionRole();
-            props.ExecutionRoleArn = role.RoleArn;
-        }
-
         if (string.IsNullOrEmpty(props.InfrastructureRoleArn))
         {
             var role = GetDefaultECSExpressInfrastructureRole();
@@ -79,5 +109,5 @@ public partial class CDKDefaultsProvider
                 Subnets = GetDefaultVpc().PublicSubnets.Select(s => s.SubnetId).ToArray()
             };
         }
-    }    
+    }
 }

--- a/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.ECSFargateExpressService.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKDefaults/CDKDefaultsProvider.ECSFargateExpressService.cs
@@ -90,6 +90,9 @@ public partial class CDKDefaultsProvider
     /// recommended defaults for an Express Gateway service.</param>
     protected internal virtual void ApplyCfnExpressGatewayServiceDefaults(CfnExpressGatewayServiceProps props)
     {
+        if (string.IsNullOrEmpty(props.Cluster))
+            props.Cluster = GetDefaultECSCluster().ClusterName;
+
         if (string.IsNullOrEmpty(props.InfrastructureRoleArn))
         {
             var role = GetDefaultECSExpressInfrastructureRole();

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateExpressServicePublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateExpressServicePublishTarget.cs
@@ -68,6 +68,10 @@ internal class ECSFargateExpressServicePublishTarget(ITarballContainerImageBuild
             projectResource, environment);
 
         publishAnnotation.Config.PropsContainerDefinitionCallback?.Invoke(CreatePublishTargetContext(environment), containerDefinitionProps);
+
+        if (containerDefinitionProps.ContainerName != "Main")
+            throw new InvalidOperationException("ECS Fargate Express requires the application container to be named \"Main\".");
+
         environment.DefaultsProvider.ApplyCfnExpressGatewayServiceContainerDefinitionDefaults(projectResource.Name, containerDefinitionProps);
 
         var containerDefinition = taskDef.AddContainer($"Container-{projectResource.Name}", containerDefinitionProps);

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateExpressServicePublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateExpressServicePublishTarget.cs
@@ -4,7 +4,6 @@
 #pragma warning disable ASPIREAWSPUBLISHERS001
 using Amazon.CDK;
 using Amazon.CDK.AWS.EC2;
-using Amazon.CDK.AWS.Ecr.Assets;
 using Amazon.CDK.AWS.ECS;
 using Amazon.CDK.AWS.IAM;
 using Aspire.Hosting.ApplicationModel;
@@ -12,7 +11,6 @@ using Aspire.Hosting.AWS.Deployment.CDKDefaults;
 using Aspire.Hosting.AWS.Deployment.Services;
 using Microsoft.Extensions.Logging;
 using System.Diagnostics.CodeAnalysis;
-using static Amazon.CDK.AWS.ECS.CfnExpressGatewayService;
 using IResource = Aspire.Hosting.ApplicationModel.IResource;
 
 namespace Aspire.Hosting.AWS.Deployment.CDKPublishTargets;
@@ -34,39 +32,55 @@ internal class ECSFargateExpressServicePublishTarget(ITarballContainerImageBuild
 
         var imageTarballPath = await imageBuilder.CreateTarballImageAsync(projectResource, cancellationToken);
 
-        var asset = new TarballImageAsset(environment.CDKStack, $"ContainerTarBall-{projectResource.Name}", new TarballImageAssetProps
-        {
-            TarballFile = imageTarballPath
-        });
-
-        var primaryContainer = new ExpressGatewayContainerProperty
-        {
-            Image = asset.ImageUri
-        };
-
-        var fargateServiceProps = new CfnExpressGatewayServiceProps
-        {
-            PrimaryContainer = primaryContainer,
-            ServiceName = projectResource.Name
-        };
-        publishAnnotation.Config.PropsCfnExpressGatewayServicePropsCallback?.Invoke(CreatePublishTargetContext(environment), fargateServiceProps);
-        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(fargateServiceProps);
+        // Create the task definition that describes the container(s) run by the Express service. The
+        // Express service points at this task definition via its TaskDefinitionArn property (rather than
+        // the inline PrimaryContainer property), giving parity with the other ECS Fargate publish targets.
+        var fargateTaskDefinitionProps = new FargateTaskDefinitionProps();
+        publishAnnotation.Config.PropsFargateTaskDefinitionCallback?.Invoke(CreatePublishTargetContext(environment), fargateTaskDefinitionProps);
+        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceTaskDefinitionDefaults(fargateTaskDefinitionProps);
 
         // Assign a default task role when the user hasn't supplied one so the application's own AWS calls
         // run under a controllable role. Only the integration-created role is exposed to reference hooks
         // (via ReferenceTaskRole) so a user-supplied role is never mutated.
         IRole? defaultTaskRole = null;
-        if (string.IsNullOrEmpty(fargateServiceProps.TaskRoleArn))
+        if (fargateTaskDefinitionProps.TaskRole == null)
         {
             defaultTaskRole = environment.DefaultsProvider.CreateDefaultECSTaskRole(projectResource.Name);
-            fargateServiceProps.TaskRoleArn = defaultTaskRole.RoleArn;
+            fargateTaskDefinitionProps.TaskRole = defaultTaskRole;
         }
 
-        var referencePoints = new CfnExpressGatewayServicePropsConnectionPoints(
-            fargateServiceProps,
-            environment.DefaultsProvider.GetDefaultECSClusterSecurityGroup(),
-            defaultTaskRole);
-        ProcessRelationShips(referencePoints, projectResource, environment);
+        var taskDef = new FargateTaskDefinition(environment.CDKStack, $"TaskDefinition-{projectResource.Name}", fargateTaskDefinitionProps);
+        publishAnnotation.Config.ConstructFargateTaskDefinitionCallback?.Invoke(CreatePublishTargetContext(environment), taskDef);
+
+        // Create the container definition. Environment variables from Aspire references are wired onto the
+        // container, and the shared cluster security group / default task role are exposed to the reference
+        // hooks via the connection points.
+        var containerDefinitionProps = new ContainerDefinitionProps
+        {
+            ContainerName = "Main", // The application container is required to be named "Main" for ECS Fargate Express Service.
+            Image = ContainerImage.FromTarball(imageTarballPath),
+            Environment = new Dictionary<string, string>()
+        };
+        ProcessRelationShips(new ExpressServiceContainerConnectionPoints(
+                containerDefinitionProps,
+                environment.DefaultsProvider.GetDefaultECSClusterSecurityGroup(),
+                defaultTaskRole),
+            projectResource, environment);
+
+        publishAnnotation.Config.PropsContainerDefinitionCallback?.Invoke(CreatePublishTargetContext(environment), containerDefinitionProps);
+        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceContainerDefinitionDefaults(projectResource.Name, containerDefinitionProps);
+
+        var containerDefinition = taskDef.AddContainer($"Container-{projectResource.Name}", containerDefinitionProps);
+        publishAnnotation.Config.ConstructContainerDefinitionCallback?.Invoke(CreatePublishTargetContext(environment), containerDefinition);
+
+        // Create the Express Gateway service pointing at the task definition.
+        var fargateServiceProps = new CfnExpressGatewayServiceProps
+        {
+            TaskDefinitionArn = taskDef.TaskDefinitionArn,
+            ServiceName = projectResource.Name
+        };
+        publishAnnotation.Config.PropsCfnExpressGatewayServicePropsCallback?.Invoke(CreatePublishTargetContext(environment), fargateServiceProps);
+        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(fargateServiceProps);
 
         var fargateService = new CfnExpressGatewayService(environment.CDKStack, $"Project-{projectResource.Name}", fargateServiceProps);
         publishAnnotation.Config.ConstructCfnExpressGatewayServiceCallback?.Invoke(CreatePublishTargetContext(environment), fargateService);
@@ -114,43 +128,12 @@ internal class ECSFargateExpressServicePublishTarget(ITarballContainerImageBuild
 }
 
 [Experimental(Constants.ASPIREAWSPUBLISHERS001)]
-internal class CfnExpressGatewayServicePropsConnectionPoints(CfnExpressGatewayServiceProps props, ISecurityGroup securityGroup, IRole? taskRole = null) : AbstractCDKConstructConnectionPoints
+internal class ExpressServiceContainerConnectionPoints(ContainerDefinitionProps props, ISecurityGroup securityGroup, IRole? taskRole = null) : AbstractCDKConstructConnectionPoints
 {
     public override IDictionary<string, string>? EnvironmentVariables
     {
-        get
-        {
-            var primaryContainer = props.PrimaryContainer as ExpressGatewayContainerProperty;
-            if (primaryContainer == null)
-                throw new InvalidDataException("PrimaryContainer must be set in CfnExpressGatewayServiceProps and of type ExpressGatewayContainerProperty");
-
-            var existingKvp = primaryContainer.Environment as IKeyValuePairProperty[] ?? [];
-
-            var environmentVariables = new Dictionary<string, string>();
-            foreach (var kvp in existingKvp)
-            {
-                environmentVariables[kvp.Name] = kvp.Value;
-            }
-
-            return environmentVariables;
-        }
-        set
-        {
-            var primaryContainer = props.PrimaryContainer as ExpressGatewayContainerProperty;
-            if (primaryContainer == null)
-                throw new InvalidDataException("PrimaryContainer must be set in CfnExpressGatewayServiceProps and of type ExpressGatewayContainerProperty");
-
-            var list = new List<IKeyValuePairProperty>();
-            if (value != null)
-            {
-                foreach (var kvp in value)
-                {
-                    list.Add(new KeyValuePairProperty { Name = kvp.Key, Value = kvp.Value });
-                }
-            }
-
-            primaryContainer.Environment = list.ToArray();
-        }
+        get => props.Environment ?? new Dictionary<string, string>();
+        set => props.Environment = value ?? new Dictionary<string, string>();
     }
 
     public override ISecurityGroup? ReferenceSecurityGroup => securityGroup;

--- a/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateExpressServicePublishTarget.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/CDKPublishTargets/ECSFargateExpressServicePublishTarget.cs
@@ -72,6 +72,11 @@ internal class ECSFargateExpressServicePublishTarget(ITarballContainerImageBuild
         if (containerDefinitionProps.ContainerName != "Main")
             throw new InvalidOperationException("ECS Fargate Express requires the application container to be named \"Main\".");
 
+        // ECS Fargate Express requires the "Main" container to expose at least one named TCP port mapping.
+        // The defaults below add one when the user supplied none; when the user supplied their own mappings
+        // via the callback, validate the requirement so we fail at synth time rather than at deploy time.
+        ValidateExpressPortMappings(containerDefinitionProps.PortMappings);
+
         environment.DefaultsProvider.ApplyCfnExpressGatewayServiceContainerDefinitionDefaults(projectResource.Name, containerDefinitionProps);
 
         var containerDefinition = taskDef.AddContainer($"Container-{projectResource.Name}", containerDefinitionProps);
@@ -95,6 +100,31 @@ internal class ECSFargateExpressServicePublishTarget(ITarballContainerImageBuild
             Description = "Endpoint for the ECS Express Gateway Service",
             Value = Fn.Join("", ["https://", Fn.GetAtt(fargateService.LogicalId, "Endpoint").ToString(), "/"])
         });
+    }
+
+    /// <summary>
+    /// Validates that a user-supplied set of port mappings satisfies the ECS Fargate Express requirement that
+    /// the "Main" container expose at least one named TCP port mapping. No validation is performed when
+    /// <paramref name="portMappings"/> is null or empty, since the defaults provider adds a compliant mapping
+    /// in that case. A null protocol is treated as TCP, matching the ECS/CDK default.
+    /// </summary>
+    /// <param name="portMappings">The container's port mappings after the user's props callback has run.</param>
+    /// <exception cref="InvalidOperationException">Thrown when mappings are supplied but none is a named TCP port.</exception>
+    internal static void ValidateExpressPortMappings(IPortMapping[]? portMappings)
+    {
+        if (portMappings is not { Length: > 0 })
+            return;
+
+        var hasNamedTcpPort = portMappings.Any(pm =>
+            !string.IsNullOrEmpty(pm.Name) &&
+            pm.ContainerPort > 0 &&
+            (pm.Protocol == null || pm.Protocol == Amazon.CDK.AWS.ECS.Protocol.TCP));
+
+        if (!hasNamedTcpPort)
+        {
+            throw new InvalidOperationException(
+                "ECS Fargate Express requires the \"Main\" container to have at least one named port mapping using the TCP protocol.");
+        }
     }
 
     public override IsDefaultPublishTargetMatchResult IsDefaultPublishTargetMatch(CDKDefaultsProvider cdkDefaultsProvider, IResource resource)

--- a/src/Aspire.Hosting.AWS/Deployment/PublishECSFargateServiceExpressAnnotation.cs
+++ b/src/Aspire.Hosting.AWS/Deployment/PublishECSFargateServiceExpressAnnotation.cs
@@ -18,6 +18,26 @@ internal class PublishECSFargateServiceExpressAnnotation : IAWSPublishTargetAnno
 public class PublishECSFargateExpressServiceConfig
 {
     /// <summary>
+    /// Callback to modify the properties used to construct the Fargate Task Definition
+    /// </summary>
+    public PublishCallback<FargateTaskDefinitionProps>? PropsFargateTaskDefinitionCallback { get; set; }
+
+    /// <summary>
+    /// Callback to modify the constructed Fargate Task Definition
+    /// </summary>
+    public PublishCallback<FargateTaskDefinition>? ConstructFargateTaskDefinitionCallback { get; set; }
+
+    /// <summary>
+    /// Callback to modify the properties used to construct the Container Definition
+    /// </summary>
+    public PublishCallback<ContainerDefinitionProps>? PropsContainerDefinitionCallback { get; set; }
+
+    /// <summary>
+    /// Callback to modify the constructed Container Definition
+    /// </summary>
+    public PublishCallback<ContainerDefinition>? ConstructContainerDefinitionCallback { get; set; }
+
+    /// <summary>
     /// Callback to modify the properties used to construct the CfnExpressGatewayService
     /// </summary>
     public PublishCallback<CfnExpressGatewayServiceProps>? PropsCfnExpressGatewayServicePropsCallback { get; set; }

--- a/testapps/DeploymentTestApps/DeploymentTestApp.AppHost/Scenarios.cs
+++ b/testapps/DeploymentTestApps/DeploymentTestApp.AppHost/Scenarios.cs
@@ -28,9 +28,9 @@ namespace DeploymentTestApp.AppHost
             var webApp1 = builder.AddProject<Projects.DeploymentTestApps_WebApp1>("WebApp1")
                 .PublishAsECSFargateExpressService(new PublishECSFargateExpressServiceConfig
                 {
-                    PropsCfnExpressGatewayServicePropsCallback = (context, props) =>
+                    PropsFargateTaskDefinitionCallback = (context, props) =>
                     {
-                        props.Memory = "4096";
+                        props.MemoryLimitMiB = 4096;
                     }
                 })
                 .WithExternalHttpEndpoints();

--- a/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
+++ b/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
@@ -40,7 +40,17 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             ]
             """, webApp1OutputFnJoin);
 
-            var webApp2EnvFnJoin = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp2/Properties/PrimaryContainer/Environment/{Name=services__WebApp1__https__0}/Value/Fn::Join");
+            // The container image, environment variables, and memory now live on a per-service task
+            // definition; the Express service points at it via TaskDefinitionArn.
+            var taskDefinitions = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::TaskDefinition");
+            Assert.Equal(2, taskDefinitions.Count);
+
+            var webApp1TaskDef = taskDefinitions.FirstOrDefault(td => td.LogicalId.Contains("WebApp1"));
+            Assert.NotNull(webApp1TaskDef.LogicalId);
+            var webApp2TaskDef = taskDefinitions.FirstOrDefault(td => td.LogicalId.Contains("WebApp2"));
+            Assert.NotNull(webApp2TaskDef.LogicalId);
+
+            var webApp2EnvFnJoin = AssertElementExistsAtPath(cfTemplateDoc, $"Resources/{webApp2TaskDef.LogicalId}/Properties/ContainerDefinitions/{{Name=Main}}/Environment/{{Name=services__WebApp1__https__0}}/Value/Fn::Join");
             AssertJsonEquals("""
             [
              "",
@@ -57,10 +67,10 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             ]
             """, webApp2EnvFnJoin);
 
-            var webApp1Memory = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp1/Properties/Memory");
+            var webApp1Memory = AssertElementExistsAtPath(webApp1TaskDef.Resource, "Properties/Memory");
             Assert.Equal("4096", webApp1Memory.GetString());
 
-            var webApp2Memory = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp2/Properties/Memory");
+            var webApp2Memory = AssertElementExistsAtPath(webApp2TaskDef.Resource, "Properties/Memory");
             Assert.Equal("2048", webApp2Memory.GetString());
 
             var vpcs = GetResourcesOfType(cfTemplateDoc, "AWS::EC2::VPC");
@@ -124,7 +134,8 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             }
             """, executionRole.Resource);
 
-            var executionRoleAssignment = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp1/Properties/ExecutionRoleArn");
+            // The execution role is now assigned to the task definition rather than the Express service.
+            var executionRoleAssignment = AssertElementExistsAtPath(webApp1TaskDef.Resource, "Properties/ExecutionRoleArn");
             AssertJsonEquals("""
             {
              "Fn::GetAtt": [
@@ -200,8 +211,12 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             var subnetAssignment = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp1/Properties/NetworkConfiguration/Subnets");
             Assert.Equal(2, subnetAssignment.GetArrayLength());
 
-            var imageAssignment = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp1/Properties/PrimaryContainer/Image");
+            var imageAssignment = AssertElementExistsAtPath(webApp1TaskDef.Resource, "Properties/ContainerDefinitions/{Name=Main}/Image");
             Assert.True(imageAssignment.TryGetProperty("Fn::Sub", out var _));
+
+            // The container port is now a port mapping on the task definition's container.
+            var webApp1ContainerPort = AssertElementExistsAtPath(webApp1TaskDef.Resource, "Properties/ContainerDefinitions/{Name=Main}/PortMappings/0/ContainerPort");
+            Assert.Equal(8080, webApp1ContainerPort.GetInt32());
 
             return Task.CompletedTask;
         };
@@ -427,10 +442,10 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             var securityGroups = GetResourcesOfType(cfTemplateDoc, "AWS::EC2::SecurityGroup");
             Assert.Single(securityGroups);
 
-            // Validate ECS TaskDefinition for Service1
+            // Validate ECS TaskDefinitions: one for WebApp1 (Express) and one for Service1 (Fargate).
             var taskDefinitions = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::TaskDefinition");
-            Assert.Single(taskDefinitions);
-            var service1TaskDef = taskDefinitions[0];
+            Assert.Equal(2, taskDefinitions.Count);
+            var service1TaskDef = taskDefinitions.First(td => td.LogicalId.Contains("Service1"));
 
             // Validate Service1 TaskDefinition properties
             var service1Cpu = AssertElementExistsAtPath(service1TaskDef.Resource, "Properties/Cpu");
@@ -495,13 +510,14 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             var dependsOnArray = service1DependsOn.EnumerateArray().Select(e => e.GetString()).ToList();
             Assert.Contains("ProjectWebApp1", dependsOnArray);
 
-            // Validate Log Group exists
+            // Validate Log Groups: one for the WebApp1 Express container, one for Service1.
             var logGroups = GetResourcesOfType(cfTemplateDoc, "AWS::Logs::LogGroup");
-            Assert.Single(logGroups);
+            Assert.Equal(2, logGroups.Count);
 
-            // Validate IAM Policy for Service1 Execution Role
+            // Validate IAM Policies: the shared Express execution role's default policy (ECR pull + log
+            // writes for the WebApp1 task definition) and Service1's execution role default policy.
             var iamPolicies = GetResourcesOfType(cfTemplateDoc, "AWS::IAM::Policy");
-            Assert.Single(iamPolicies);
+            Assert.Equal(2, iamPolicies.Count);
 
             return Task.CompletedTask;
         };
@@ -899,8 +915,9 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             var expressGatewayServices = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::ExpressGatewayService");
             Assert.Single(expressGatewayServices);
 
-            // Validate WebApp1 has ConnectionStrings__Cache environment variable
-            var webApp1EnvFnJoin = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp1/Properties/PrimaryContainer/Environment/{Name=ConnectionStrings__Cache}/Value/Fn::Join");
+            // WebApp1's container now lives on its own task definition; its environment variables are set there.
+            var webApp1TaskDef = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::TaskDefinition").First(td => td.LogicalId.Contains("WebApp1"));
+            var webApp1EnvFnJoin = AssertElementExistsAtPath(webApp1TaskDef.Resource, "Properties/ContainerDefinitions/{Name=Main}/Environment/{Name=ConnectionStrings__Cache}/Value/Fn::Join");
             var webApp1EnvParts = webApp1EnvFnJoin.EnumerateArray().ToList();
             Assert.Equal(2, webApp1EnvParts.Count);
             Assert.Equal("", webApp1EnvParts[0].GetString());
@@ -919,10 +936,10 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             var webApp1DependsOnArray = webApp1DependsOn.EnumerateArray().Select(e => e.GetString()).ToList();
             Assert.Contains(elastiCache.LogicalId, webApp1DependsOnArray);
 
-            // Validate ECS TaskDefinition for Service1
+            // Validate ECS TaskDefinitions: one for WebApp1 (Express) and one for Service1 (Fargate).
             var taskDefinitions = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::TaskDefinition");
-            Assert.Single(taskDefinitions);
-            var service1TaskDef = taskDefinitions[0];
+            Assert.Equal(2, taskDefinitions.Count);
+            var service1TaskDef = taskDefinitions.First(td => td.LogicalId.Contains("Service1"));
 
             // Validate Service1 TaskDefinition has ConnectionStrings__Cache environment variable
             var service1EnvFnJoin = AssertElementExistsAtPath(cfTemplateDoc, $"Resources/{service1TaskDef.LogicalId}/Properties/ContainerDefinitions/{{Name=Container-Service1}}/Environment/{{Name=ConnectionStrings__Cache}}/Value/Fn::Join");
@@ -1103,8 +1120,9 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             var expressGatewayServices = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::ExpressGatewayService");
             Assert.Single(expressGatewayServices);
 
-            // Validate WebApp1 has ConnectionStrings__Cache environment variable
-            var webApp1EnvFnJoin = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp1/Properties/PrimaryContainer/Environment/{Name=ConnectionStrings__Cache}/Value/Fn::Join");
+            // WebApp1's container now lives on its own task definition; its environment variables are set there.
+            var webApp1TaskDef = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::TaskDefinition").First(td => td.LogicalId.Contains("WebApp1"));
+            var webApp1EnvFnJoin = AssertElementExistsAtPath(webApp1TaskDef.Resource, "Properties/ContainerDefinitions/{Name=Main}/Environment/{Name=ConnectionStrings__Cache}/Value/Fn::Join");
             var webApp1EnvParts = webApp1EnvFnJoin.EnumerateArray().ToList();
             Assert.Equal(2, webApp1EnvParts.Count);
             Assert.Equal("", webApp1EnvParts[0].GetString());
@@ -1123,10 +1141,10 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             var webApp1DependsOnArray = webApp1DependsOn.EnumerateArray().Select(e => e.GetString()).ToList();
             Assert.Contains(elastiCache.LogicalId, webApp1DependsOnArray);
 
-            // Validate ECS TaskDefinition for Service1
+            // Validate ECS TaskDefinitions: one for WebApp1 (Express) and one for Service1 (Fargate).
             var taskDefinitions = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::TaskDefinition");
-            Assert.Single(taskDefinitions);
-            var service1TaskDef = taskDefinitions[0];
+            Assert.Equal(2, taskDefinitions.Count);
+            var service1TaskDef = taskDefinitions.First(td => td.LogicalId.Contains("Service1"));
 
             // Validate Service1 TaskDefinition has ConnectionStrings__Cache environment variable
             var service1EnvFnJoin = AssertElementExistsAtPath(cfTemplateDoc, $"Resources/{service1TaskDef.LogicalId}/Properties/ContainerDefinitions/{{Name=Container-Service1}}/Environment/{{Name=ConnectionStrings__Cache}}/Value/Fn::Join");
@@ -1275,8 +1293,9 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             var expressGatewayServices = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::ExpressGatewayService");
             Assert.Single(expressGatewayServices);
 
-            // Validate WebApp1 has ConnectionStrings__Cache environment variable
-            var webApp1EnvFnJoin = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp1/Properties/PrimaryContainer/Environment/{Name=ConnectionStrings__Cache}/Value/Fn::Join");
+            // WebApp1's container now lives on its own task definition; its environment variables are set there.
+            var webApp1TaskDef = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::TaskDefinition").First(td => td.LogicalId.Contains("WebApp1"));
+            var webApp1EnvFnJoin = AssertElementExistsAtPath(webApp1TaskDef.Resource, "Properties/ContainerDefinitions/{Name=Main}/Environment/{Name=ConnectionStrings__Cache}/Value/Fn::Join");
             var webApp1EnvParts = webApp1EnvFnJoin.EnumerateArray().ToList();
             Assert.Equal(2, webApp1EnvParts.Count);
             Assert.Equal("", webApp1EnvParts[0].GetString());
@@ -1295,10 +1314,10 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             var webApp1DependsOnArray = webApp1DependsOn.EnumerateArray().Select(e => e.GetString()).ToList();
             Assert.Contains(elastiCache.LogicalId, webApp1DependsOnArray);
 
-            // Validate ECS TaskDefinition for Service1
+            // Validate ECS TaskDefinitions: one for WebApp1 (Express) and one for Service1 (Fargate).
             var taskDefinitions = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::TaskDefinition");
-            Assert.Single(taskDefinitions);
-            var service1TaskDef = taskDefinitions[0];
+            Assert.Equal(2, taskDefinitions.Count);
+            var service1TaskDef = taskDefinitions.First(td => td.LogicalId.Contains("Service1"));
 
             // Validate Service1 TaskDefinition has ConnectionStrings__Cache environment variable
             var service1EnvFnJoin = AssertElementExistsAtPath(cfTemplateDoc, $"Resources/{service1TaskDef.LogicalId}/Properties/ContainerDefinitions/{{Name=Container-Service1}}/Environment/{{Name=ConnectionStrings__Cache}}/Value/Fn::Join");
@@ -1479,8 +1498,9 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             var expressGatewayServices = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::ExpressGatewayService");
             Assert.Single(expressGatewayServices);
 
-            // Validate WebApp1 has ConnectionStrings__Cache environment variable
-            var webApp1EnvFnJoin = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp1/Properties/PrimaryContainer/Environment/{Name=ConnectionStrings__Cache}/Value/Fn::Join");
+            // WebApp1's container now lives on its own task definition; its environment variables are set there.
+            var webApp1TaskDef = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::TaskDefinition").First(td => td.LogicalId.Contains("WebApp1"));
+            var webApp1EnvFnJoin = AssertElementExistsAtPath(webApp1TaskDef.Resource, "Properties/ContainerDefinitions/{Name=Main}/Environment/{Name=ConnectionStrings__Cache}/Value/Fn::Join");
             var webApp1EnvParts = webApp1EnvFnJoin.EnumerateArray().ToList();
             Assert.Equal(2, webApp1EnvParts.Count);
             Assert.Equal("", webApp1EnvParts[0].GetString());
@@ -1499,10 +1519,10 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             var webApp1DependsOnArray = webApp1DependsOn.EnumerateArray().Select(e => e.GetString()).ToList();
             Assert.Contains(elastiCache.LogicalId, webApp1DependsOnArray);
 
-            // Validate ECS TaskDefinition for Service1
+            // Validate ECS TaskDefinitions: one for WebApp1 (Express) and one for Service1 (Fargate).
             var taskDefinitions = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::TaskDefinition");
-            Assert.Single(taskDefinitions);
-            var service1TaskDef = taskDefinitions[0];
+            Assert.Equal(2, taskDefinitions.Count);
+            var service1TaskDef = taskDefinitions.First(td => td.LogicalId.Contains("Service1"));
 
             // Validate Service1 TaskDefinition has ConnectionStrings__Cache environment variable
             var service1EnvFnJoin = AssertElementExistsAtPath(cfTemplateDoc, $"Resources/{service1TaskDef.LogicalId}/Properties/ContainerDefinitions/{{Name=Container-Service1}}/Environment/{{Name=ConnectionStrings__Cache}}/Value/Fn::Join");
@@ -1596,10 +1616,13 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
         {
             AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp1");
 
-            var myStaticVar = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp1/Properties/PrimaryContainer/Environment/{Name=MY_STATIC_VAR}/Value");
+            // Environment variables are now set on the container in WebApp1's task definition.
+            var webApp1TaskDef = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::TaskDefinition").First(td => td.LogicalId.Contains("WebApp1"));
+
+            var myStaticVar = AssertElementExistsAtPath(webApp1TaskDef.Resource, "Properties/ContainerDefinitions/{Name=Main}/Environment/{Name=MY_STATIC_VAR}/Value");
             Assert.Equal("static-value", myStaticVar.GetString());
 
-            var anotherVar = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp1/Properties/PrimaryContainer/Environment/{Name=ANOTHER_VAR}/Value");
+            var anotherVar = AssertElementExistsAtPath(webApp1TaskDef.Resource, "Properties/ContainerDefinitions/{Name=Main}/Environment/{Name=ANOTHER_VAR}/Value");
             Assert.Equal("another-value", anotherVar.GetString());
 
             return Task.CompletedTask;
@@ -1651,12 +1674,15 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
         {
             AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp2");
 
+            // Environment variables are now set on the container in WebApp2's task definition.
+            var webApp2TaskDef = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::TaskDefinition").First(td => td.LogicalId.Contains("WebApp2"));
+
             // Validate the explicit WithEnvironment var is present
-            var customVar = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp2/Properties/PrimaryContainer/Environment/{Name=MY_CUSTOM_VAR}/Value");
+            var customVar = AssertElementExistsAtPath(webApp2TaskDef.Resource, "Properties/ContainerDefinitions/{Name=Main}/Environment/{Name=MY_CUSTOM_VAR}/Value");
             Assert.Equal("custom-value", customVar.GetString());
 
             // Validate the WithReference-derived env var is also present
-            var webApp1Ref = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp2/Properties/PrimaryContainer/Environment/{Name=services__WebApp1__https__0}/Value/Fn::Join");
+            var webApp1Ref = AssertElementExistsAtPath(webApp2TaskDef.Resource, "Properties/ContainerDefinitions/{Name=Main}/Environment/{Name=services__WebApp1__https__0}/Value/Fn::Join");
             AssertJsonEquals("""
             [
              "",
@@ -1936,11 +1962,12 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             Assert.Single(agentRuntimes);
             var agentRuntimeLogicalId = agentRuntimes[0].LogicalId;
 
-            // The referencing consumer (WebApp1) receives the runtime ARN as an environment variable
-            // keyed by the standard reference convention: AWS:Resources:AgentCoreAgent:AgentRuntimeArn
-            // which is delivered as AWS__Resources__AgentCoreAgent__AgentRuntimeArn.
-            var arnEnvVar = AssertElementExistsAtPath(cfTemplateDoc,
-                "Resources/ProjectWebApp1/Properties/PrimaryContainer/Environment/{Name=AWS__Resources__AgentCoreAgent__AgentRuntimeArn}/Value");
+            // The referencing consumer (WebApp1) receives the runtime ARN as an environment variable on its
+            // task definition container, keyed by the standard reference convention:
+            // AWS:Resources:AgentCoreAgent:AgentRuntimeArn delivered as AWS__Resources__AgentCoreAgent__AgentRuntimeArn.
+            var webApp1TaskDef = GetResourcesOfType(cfTemplateDoc, "AWS::ECS::TaskDefinition").First(td => td.LogicalId.Contains("WebApp1"));
+            var arnEnvVar = AssertElementExistsAtPath(webApp1TaskDef.Resource,
+                "Properties/ContainerDefinitions/{Name=Main}/Environment/{Name=AWS__Resources__AgentCoreAgent__AgentRuntimeArn}/Value");
 
             // The value is a Fn::GetAtt against the runtime's AgentRuntimeArn attribute.
             var getAtt = AssertElementExistsAtPath(arnEnvVar, "Fn::GetAtt");
@@ -1948,12 +1975,13 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             Assert.Equal(agentRuntimeLogicalId, getAtt[0].GetString());
             Assert.Equal("AgentRuntimeArn", getAtt[1].GetString());
 
-            // The consumer (WebApp1, an Express service) is assigned a default task role wired into TaskRoleArn.
+            // The consumer (WebApp1, an Express service) is assigned a default task role wired into the task
+            // definition's TaskRoleArn.
             var iamRoles = GetResourcesOfType(cfTemplateDoc, "AWS::IAM::Role");
             var taskRole = iamRoles.FirstOrDefault(r => r.LogicalId.Contains("DefaultTaskRole"));
             Assert.False(string.IsNullOrEmpty(taskRole.LogicalId), "A default task role should be created for the referencing service");
 
-            var taskRoleArn = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp1/Properties/TaskRoleArn");
+            var taskRoleArn = AssertElementExistsAtPath(webApp1TaskDef.Resource, "Properties/TaskRoleArn");
             var taskRoleArnGetAtt = AssertElementExistsAtPath(taskRoleArn, "Fn::GetAtt");
             Assert.Equal(taskRole.LogicalId, taskRoleArnGetAtt[0].GetString());
 

--- a/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
+++ b/tests/Aspire.Hosting.AWS.Integ.Tests/Deployment/PublishScenarioTests.cs
@@ -566,6 +566,16 @@ public class PublishScenarioTests(ITestOutputHelper testOutputHelper)
             // Validate WebApp1 configuration
             AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp1");
 
+            // Validate the Express service is pinned to the default ECS cluster. The default cluster's
+            // ClusterName resolves to a Ref to the created ECS Cluster resource.
+            var ecsCluster = Assert.Single(GetResourcesOfType(cfTemplateDoc, "AWS::ECS::Cluster"));
+            var clusterAssignment = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp1/Properties/Cluster");
+            AssertJsonEquals($$"""
+            {
+             "Ref": "{{ecsCluster.LogicalId}}"
+            }
+            """, clusterAssignment);
+
             // Validate WebApp1 network configuration references subnets
             var subnetAssignment = AssertElementExistsAtPath(cfTemplateDoc, "Resources/ProjectWebApp1/Properties/NetworkConfiguration/Subnets");
             Assert.Equal(JsonValueKind.Array, subnetAssignment.ValueKind);

--- a/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ApplyDefaultsTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ApplyDefaultsTests.cs
@@ -12,7 +12,6 @@ using Amazon.CDK.AWS.Lambda;
 using Aspire.Hosting.AWS.Deployment;
 using Aspire.Hosting.AWS.Lambda;
 using Xunit;
-using static Amazon.CDK.AWS.ECS.CfnExpressGatewayService;
 
 namespace Aspire.Hosting.AWS.UnitTests.Deployment;
 
@@ -20,37 +19,116 @@ namespace Aspire.Hosting.AWS.UnitTests.Deployment;
 public class ApplyDefaultsTests
 {
     [Fact]
+    public void ApplyCfnExpressGatewayServiceTaskDefinitionDefaults_AppliesAllDefaults()
+    {
+        // Arrange
+        var environment = CreateProviderAndEnvironment();
+        var props = new FargateTaskDefinitionProps();
+
+        // Act
+        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceTaskDefinitionDefaults(props);
+
+        // Assert
+        Assert.Equal(1024, props.Cpu);
+        Assert.Equal(2048, props.MemoryLimitMiB);
+        Assert.NotNull(props.ExecutionRole);
+        Assert.Equal(environment.DefaultsProvider.GetDefaultECSExpressExecutionRole(), props.ExecutionRole);
+    }
+
+    [Fact]
+    public void ApplyCfnExpressGatewayServiceTaskDefinitionDefaults_OverrideDefaults()
+    {
+        // Arrange
+        var environment = CreateProviderAndEnvironment();
+        var existingExecutionRole = environment.DefaultsProvider.CreateDefaultECSTaskRole("my-execution-role");
+        var props = new FargateTaskDefinitionProps
+        {
+            Cpu = 512,
+            MemoryLimitMiB = 1024,
+            ExecutionRole = existingExecutionRole
+        };
+
+        // Act
+        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceTaskDefinitionDefaults(props);
+
+        // Assert
+        Assert.Equal(512, props.Cpu);
+        Assert.Equal(1024, props.MemoryLimitMiB);
+        Assert.Equal(existingExecutionRole, props.ExecutionRole);
+    }
+
+    [Fact]
+    public void ApplyCfnExpressGatewayServiceContainerDefinitionDefaults_AppliesAllDefaults()
+    {
+        // Arrange
+        var environment = CreateProviderAndEnvironment();
+        var props = new ContainerDefinitionProps
+        {
+            Image = ContainerImage.FromRegistry("nginx")
+        };
+
+        // Act
+        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceContainerDefinitionDefaults("test-project", props);
+
+        // Assert
+        Assert.NotNull(props.Logging);
+        Assert.NotNull(props.PortMappings);
+        Assert.Single(props.PortMappings);
+        Assert.Equal(8080, props.PortMappings[0].ContainerPort);
+        // ECS Fargate Express requires the Main container's port mapping to be a named TCP port.
+        Assert.Equal("http", props.PortMappings[0].Name);
+        Assert.Equal(Protocol.TCP, props.PortMappings[0].Protocol);
+    }
+
+    [Fact]
+    public void ApplyCfnExpressGatewayServiceContainerDefinitionDefaults_OverrideDefaults()
+    {
+        // Arrange
+        var environment = CreateProviderAndEnvironment();
+        var customLogging = LogDrivers.AwsLogs(new AwsLogDriverProps
+        {
+            StreamPrefix = "custom-prefix"
+        });
+        var props = new ContainerDefinitionProps
+        {
+            Image = ContainerImage.FromRegistry("nginx"),
+            Logging = customLogging,
+            PortMappings = new[] { new PortMapping { ContainerPort = 3000 } }
+        };
+
+        // Act
+        environment.DefaultsProvider.ApplyCfnExpressGatewayServiceContainerDefinitionDefaults("test-project", props);
+
+        // Assert
+        Assert.Equal(customLogging, props.Logging);
+        Assert.Single(props.PortMappings);
+        Assert.Equal(3000, props.PortMappings[0].ContainerPort);
+    }
+
+    [Fact]
     public void ApplyCfnExpressGatewayServiceDefaults_AppliesAllDefaults()
     {
         // Arrange
         var environment = CreateProviderAndEnvironment();
         var props = new CfnExpressGatewayServiceProps
         {
-            PrimaryContainer = new ExpressGatewayContainerProperty()
+            TaskDefinitionArn = "arn:aws:ecs:us-west-2:123456789012:task-definition/my-task:1"
         };
 
         // Act
         environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(props);
 
         // Assert
-        Assert.NotNull(props.Cluster);
-        Assert.Equal("1024", props.Cpu);
-        Assert.Equal("2048", props.Memory);
-        Assert.NotNull(props.ExecutionRoleArn);
         Assert.NotNull(props.InfrastructureRoleArn);
-
-        var primaryContainer = props.PrimaryContainer as ExpressGatewayContainerProperty;
-        Assert.NotNull(primaryContainer);
-        Assert.Equal(8080, primaryContainer.ContainerPort);
-
-        var expectedClusterName = environment.DefaultsProvider.GetDefaultECSCluster().ClusterName;
-        Assert.Equal(expectedClusterName, props.Cluster);
-
-        var expectedExecutionRoleArn = environment.DefaultsProvider.GetDefaultECSExpressExecutionRole().RoleArn;
-        Assert.Equal(expectedExecutionRoleArn, props.ExecutionRoleArn);
-
         var expectedInfrastructureRoleArn = environment.DefaultsProvider.GetDefaultECSExpressInfrastructureRole().RoleArn;
         Assert.Equal(expectedInfrastructureRoleArn, props.InfrastructureRoleArn);
+
+        var networkConfiguration = props.NetworkConfiguration as CfnExpressGatewayService.ExpressGatewayServiceNetworkConfigurationProperty;
+        Assert.NotNull(networkConfiguration);
+        Assert.NotNull(networkConfiguration.SecurityGroups);
+        Assert.NotEmpty((string[])networkConfiguration.SecurityGroups);
+        Assert.NotNull(networkConfiguration.Subnets);
+        Assert.NotEmpty((string[])networkConfiguration.Subnets);
     }
 
     [Fact]
@@ -58,38 +136,26 @@ public class ApplyDefaultsTests
     {
         // Arrange
         var environment = CreateProviderAndEnvironment();
-        var existingCluster = "my-existing-cluster";
-        var existingCpu = "512";
-        var existingMemory = "1024";
-        var existingPort = 3000;
-        var existingExecutionRoleArn = "arn:aws:iam::123456789012:role/my-execution-role";
         var existingInfrastructureRoleArn = "arn:aws:iam::123456789012:role/my-infrastructure-role";
-
-        var primaryContainer = new ExpressGatewayContainerProperty
+        var existingNetworkConfiguration = new CfnExpressGatewayService.ExpressGatewayServiceNetworkConfigurationProperty
         {
-            ContainerPort = existingPort
+            SecurityGroups = new[] { "sg-12345" },
+            Subnets = new[] { "subnet-12345" }
         };
 
         var props = new CfnExpressGatewayServiceProps
         {
-            Memory = existingMemory,
-            Cpu = existingCpu,
-            Cluster = existingCluster,
-            PrimaryContainer = primaryContainer,
-            ExecutionRoleArn = existingExecutionRoleArn,
+            TaskDefinitionArn = "arn:aws:ecs:us-west-2:123456789012:task-definition/my-task:1",
             InfrastructureRoleArn = existingInfrastructureRoleArn,
+            NetworkConfiguration = existingNetworkConfiguration
         };
 
         // Act
         environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(props);
 
         // Assert
-        Assert.Equal(existingCluster, props.Cluster);
-        Assert.Equal(existingCpu, props.Cpu);
-        Assert.Equal(existingMemory, props.Memory);
-        Assert.Equal(existingPort, primaryContainer!.ContainerPort);
-        Assert.Equal(existingExecutionRoleArn, props.ExecutionRoleArn);
         Assert.Equal(existingInfrastructureRoleArn, props.InfrastructureRoleArn);
+        Assert.Equal(existingNetworkConfiguration, props.NetworkConfiguration);
     }
 
 

--- a/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ApplyDefaultsTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ApplyDefaultsTests.cs
@@ -93,7 +93,7 @@ public class ApplyDefaultsTests
         {
             Image = ContainerImage.FromRegistry("nginx"),
             Logging = customLogging,
-            PortMappings = new[] { new PortMapping { ContainerPort = 3000 } }
+            PortMappings = new[] { new PortMapping { ContainerPort = 3000, Name = "custom-http", Protocol = Protocol.TCP } }
         };
 
         // Act
@@ -103,7 +103,8 @@ public class ApplyDefaultsTests
         Assert.Equal(customLogging, props.Logging);
         Assert.Single(props.PortMappings);
         Assert.Equal(3000, props.PortMappings[0].ContainerPort);
-    }
+        Assert.Equal("custom-http", props.PortMappings[0].Name);
+        Assert.Equal(Protocol.TCP, props.PortMappings[0].Protocol);
 
     [Fact]
     public void ApplyCfnExpressGatewayServiceDefaults_AppliesAllDefaults()

--- a/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ApplyDefaultsTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ApplyDefaultsTests.cs
@@ -170,6 +170,8 @@ public class ApplyDefaultsTests
         environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(props);
 
         // Assert
+        Assert.Equal(environment.DefaultsProvider.GetDefaultECSCluster().ClusterName, props.Cluster);
+
         Assert.NotNull(props.InfrastructureRoleArn);
         var expectedInfrastructureRoleArn = environment.DefaultsProvider.GetDefaultECSExpressInfrastructureRole().RoleArn;
         Assert.Equal(expectedInfrastructureRoleArn, props.InfrastructureRoleArn);
@@ -194,9 +196,12 @@ public class ApplyDefaultsTests
             Subnets = new[] { "subnet-12345" }
         };
 
+        var existingCluster = "my-existing-cluster";
+
         var props = new CfnExpressGatewayServiceProps
         {
             TaskDefinitionArn = "arn:aws:ecs:us-west-2:123456789012:task-definition/my-task:1",
+            Cluster = existingCluster,
             InfrastructureRoleArn = existingInfrastructureRoleArn,
             NetworkConfiguration = existingNetworkConfiguration
         };
@@ -205,6 +210,7 @@ public class ApplyDefaultsTests
         environment.DefaultsProvider.ApplyCfnExpressGatewayServiceDefaults(props);
 
         // Assert
+        Assert.Equal(existingCluster, props.Cluster);
         Assert.Equal(existingInfrastructureRoleArn, props.InfrastructureRoleArn);
         Assert.Equal(existingNetworkConfiguration, props.NetworkConfiguration);
     }

--- a/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ApplyDefaultsTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/Deployment/ApplyDefaultsTests.cs
@@ -10,6 +10,7 @@ using Amazon.CDK.AWS.ECS.Patterns;
 using Amazon.CDK.AWS.ElastiCache;
 using Amazon.CDK.AWS.Lambda;
 using Aspire.Hosting.AWS.Deployment;
+using Aspire.Hosting.AWS.Deployment.CDKPublishTargets;
 using Aspire.Hosting.AWS.Lambda;
 using Xunit;
 
@@ -105,6 +106,55 @@ public class ApplyDefaultsTests
         Assert.Equal(3000, props.PortMappings[0].ContainerPort);
         Assert.Equal("custom-http", props.PortMappings[0].Name);
         Assert.Equal(Protocol.TCP, props.PortMappings[0].Protocol);
+    }
+
+    [Fact]
+    public void ValidateExpressPortMappings_NullOrEmpty_DoesNotThrow()
+    {
+        // The defaults provider supplies a compliant mapping when the user provides none, so nothing to validate.
+        ECSFargateExpressServicePublishTarget.ValidateExpressPortMappings(null);
+        ECSFargateExpressServicePublishTarget.ValidateExpressPortMappings(Array.Empty<IPortMapping>());
+    }
+
+    [Fact]
+    public void ValidateExpressPortMappings_NamedTcpPortPresent_DoesNotThrow()
+    {
+        // A named TCP mapping need not be the first entry; any compliant mapping in the list satisfies ECS Express.
+        var mappings = new IPortMapping[]
+        {
+            new PortMapping { ContainerPort = 9090 },                                          // unnamed metrics port
+            new PortMapping { ContainerPort = 8080, Name = "http", Protocol = Protocol.TCP }    // compliant
+        };
+
+        ECSFargateExpressServicePublishTarget.ValidateExpressPortMappings(mappings);
+    }
+
+    [Fact]
+    public void ValidateExpressPortMappings_NullProtocolTreatedAsTcp_DoesNotThrow()
+    {
+        // ECS/CDK default an omitted protocol to TCP, so a named mapping without an explicit protocol is valid.
+        var mappings = new IPortMapping[] { new PortMapping { ContainerPort = 8080, Name = "http" } };
+
+        ECSFargateExpressServicePublishTarget.ValidateExpressPortMappings(mappings);
+    }
+
+    [Fact]
+    public void ValidateExpressPortMappings_UnnamedPort_Throws()
+    {
+        var mappings = new IPortMapping[] { new PortMapping { ContainerPort = 8080, Protocol = Protocol.TCP } };
+
+        Assert.Throws<InvalidOperationException>(() =>
+            ECSFargateExpressServicePublishTarget.ValidateExpressPortMappings(mappings));
+    }
+
+    [Fact]
+    public void ValidateExpressPortMappings_NonTcpProtocol_Throws()
+    {
+        var mappings = new IPortMapping[] { new PortMapping { ContainerPort = 8080, Name = "udp", Protocol = Protocol.UDP } };
+
+        Assert.Throws<InvalidOperationException>(() =>
+            ECSFargateExpressServicePublishTarget.ValidateExpressPortMappings(mappings));
+    }
 
     [Fact]
     public void ApplyCfnExpressGatewayServiceDefaults_AppliesAllDefaults()


### PR DESCRIPTION
## Summary

Reworks the **ECS Fargate Express Service** deployment target so it runs the project on a real ECS **`FargateTaskDefinition`** and points the `CfnExpressGatewayService` at it via the new `TaskDefinitionArn` property — instead of describing the container inline through the `PrimaryContainer` property.

This brings the Express target in line with the other ECS Fargate publish targets (which already use a `FargateTaskDefinition`) and, critically, unblocks future work: **adding an OpenTelemetry side-car container**, which must be added to a task definition alongside the application container. The inline `PrimaryContainer` model has no place to attach a second container.

## ⚠️ Breaking Change

This is a **known, intentional breaking change** to the generated CloudFormation for web projects deployed via `PublishAsECSFargateExpressService` (the default for web `ProjectResource`s):

- Aspire deployment is currently **marked as preview** requiring users to opt-in to allow for breaking changes like this.
- The Express service no longer carries an inline `PrimaryContainer`. Instead a new `AWS::ECS::TaskDefinition` resource is emitted per Express service and referenced by the service's `TaskDefinitionArn`.
- Container-hosting settings move from the Express service props onto the task definition / its container: **image, environment variables, container port, CPU, memory, execution role, and task role**.
- Because a task definition is now created (with an awslogs log driver), each Express service also emits a **log group** and the execution role gains a **default policy** (ECR pull + log writes).

Redeploying an existing stack will replace the Express service's container wiring. This is required for the OpenTelemetry side-car work noted above and is captured in the changelog as a breaking change. 

## Changes

- **`ECSFargateExpressServicePublishTarget`** — `GenerateConstructAsync` now creates a `FargateTaskDefinition`, adds the application container via `ContainerImage.FromTarball(...)`, and sets `CfnExpressGatewayServiceProps.TaskDefinitionArn = taskDef.TaskDefinitionArn`. The reference/connection-points logic (env vars, security group, task role) now targets the container definition. Replaced `CfnExpressGatewayServicePropsConnectionPoints` with `ExpressServiceContainerConnectionPoints` (wraps `ContainerDefinitionProps`).
- **ECS Express requirements** — the application container is named **`Main`** and its port mapping is a **named TCP port** (`ContainerPort` 8080, `Name` `http`, `Protocol` TCP). ECS Fargate Express rejects the task definition without both.
- **`CDKDefaultsProvider.ECSFargateExpressService`** — split the single `ApplyCfnExpressGatewayServiceDefaults` into three: task-definition defaults (CPU / memory / execution role), container defaults (awslogs log driver + named TCP port mapping), and slimmed service defaults (infrastructure role + network configuration). Added the `ECSFargateExpressContainerPortName` virtual (default `"http"`); reused the existing `ECSFargateExpressCpu` / `ECSFargateExpressMiB` / `ECSFargateExpressContainerPort` virtuals and the shared `CreateECSFargateServiceLogDriver`.
- **`PublishECSFargateExpressServiceConfig`** — added `FargateTaskDefinition` and `ContainerDefinition` props/construct callbacks (full parity with `PublishAsECSFargateService`), keeping the existing Express-service callbacks. Additive and non-breaking to the config surface.
- **`Amazon.CDK.Lib`** bumped `2.236.0` → `2.262.0` (the `TaskDefinitionArn` property on `CfnExpressGatewayServiceProps` was introduced in 2.261.0).
- **Tests** — updated `ApplyDefaultsTests` (split into the three new methods; asserts named TCP port) and `PublishScenarioTests` (relocated container/CPU/memory/execution-role/task-role assertions to the new task-definition resource; container name lookups use `Main`; task-def / log-group / policy counts updated). The `PublishWebApp2ReferenceOnWebApp1` scenario now sets memory via the new `PropsFargateTaskDefinitionCallback`.
- **`docs/deployment-design.md`** — updated the ECS task-role and defaults sections, and added an "ECS Fargate Express Task Definition Requirements" section documenting the `Main` container name and named-TCP-port requirements.

## Tooling note

CDK lib 2.262.0 emits cloud-assembly schema 54, which requires a CDK **CLI** newer than 2.1106.0 (max schema 52). The CLI must be at 2.1108.0+ (2.1133.0 verified) for the publish/deploy context-generation step; otherwise VPC/AZ lookups fall back to placeholders.

## Testing

- Unit tests: `ApplyDefaultsTests` pass (20/20).
- Integration tests (CDK synthesis): all Express scenarios pass — WebApp2Reference, Service1Reference, WithEnvironment(+Reference), AgentCoreRuntimeWithReference, Serverless/Provisioned Redis & Valkey, WebApp1UsingDefaultVpc.
- Verified end-to-end deploy: the synthesized task definition has the `Main` container with a named TCP port mapping and the Express service references it via `TaskDefinitionArn`.
