### PR TITLE
Rename instances of ".NET Aspire" to "Aspire"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-## Integrations with .NET Aspire for AWS
+## Integrations with Aspire for AWS
 
-This repositry contains the integrations with [.NET Aspire](https://github.com/dotnet/aspire) for AWS. The AWS integrations focus on provisioning and working with AWS application resources in development environment. Making the dev inner loop of iterating over application code with AWS resource seamless without having to leave the development environment.
+This repositry contains the integrations with [Aspire](https://github.com/dotnet/aspire) for AWS. The AWS integrations focus on provisioning and working with AWS application resources in development environment. Making the dev inner loop of iterating over application code with AWS resource seamless without having to leave the development environment.
 
-For introduction on using AWS and Aspire checkout the [Building .NET Applications Across Clouds with .NET Aspire](https://www.youtube.com/watch?v=yVgr6cRYOPk) talk as part of .NET Conf 2024.
+For introduction on using AWS and Aspire checkout the [Building .NET Applications Across Clouds with Aspire](https://www.youtube.com/watch?v=yVgr6cRYOPk) talk as part of .NET Conf 2024.
 
 [![image](./resources/dotnetconf-2024-session.jpg)](https://www.youtube.com/watch?v=yVgr6cRYOPk)
 
 ## Integrations
 
-The following are the list of AWS integrations currently supported for .NET Aspire.
+The following are the list of AWS integrations currently supported for Aspire.
 
 ### Aspire.Hosting.AWS
 
@@ -30,7 +30,7 @@ Check out the package's [README](./src/Aspire.Hosting.AWS/README.md) for a deepe
 
 > **Note**: This feature is currently in preview and subject to change based on feedback. We encourage you to try it out and share your feedback!
 
-The AWS deployment feature for .NET Aspire enables you to deploy your Aspire applications directly to AWS. The deployment system transforms your Aspire AppHost resources into AWS CDK constructs, which are then synthesized into CloudFormation templates and deployed to your AWS account. This provides a seamless path from local development to cloud deployment.
+The AWS deployment feature for Aspire enables you to deploy your Aspire applications directly to AWS. The deployment system transforms your Aspire AppHost resources into AWS CDK constructs, which are then synthesized into CloudFormation templates and deployed to your AWS account. This provides a seamless path from local development to cloud deployment.
 
 For comprehensive documentation including advanced scenarios, implementation details, and architectural guidance, see the [Deployment Design Document](./docs/deployment-design.md).
 
@@ -158,7 +158,7 @@ When resources are connected with `WithReference()`, the system automatically:
 * Attaches resources to the same VPC when required (e.g., for ElastiCache)
 * Sets up security groups to allow network access between resources
 
-Your application code can access the referenced resource using the standard .NET Aspire configuration patterns - no AWS-specific code required.
+Your application code can access the referenced resource using the standard Aspire configuration patterns - no AWS-specific code required.
 
 ### Advanced Scenarios
 

--- a/docs/deployment-design.md
+++ b/docs/deployment-design.md
@@ -1,8 +1,8 @@
-# AWS Deployment Design for .NET Aspire
+# AWS Deployment Design for Aspire
 
 ## Overview
 
-The AWS deployment system for .NET Aspire transforms Aspire AppHost resources into AWS CDK constructs, which are then synthesized into CloudFormation templates and deployed to AWS. This document describes the architecture and design patterns used in the deployment system.
+The AWS deployment system for Aspire transforms Aspire AppHost resources into AWS CDK constructs, which are then synthesized into CloudFormation templates and deployed to AWS. This document describes the architecture and design patterns used in the deployment system.
 
 ## Table of Contents
 
@@ -1457,7 +1457,7 @@ CDKDefaultsProvider and then override the defaults property using the new defaul
 
 ## Summary
 
-The AWS deployment system for .NET Aspire provides a flexible, extensible architecture for transforming Aspire resources into AWS infrastructure:
+The AWS deployment system for Aspire provides a flexible, extensible architecture for transforming Aspire resources into AWS infrastructure:
 
 1. **Environment Setup**: Use `AddAWSCDKEnvironment()` to configure deployment with versioned defaults
 2. **Custom Stacks**: Provide your own CDK Stack to define custom infrastructure

--- a/playground/CloudFormationProvisioning/AWS.ServiceDefaults/Extensions.cs
+++ b/playground/CloudFormationProvisioning/AWS.ServiceDefaults/Extensions.cs
@@ -9,7 +9,7 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting;
 
-// Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+// Adds common Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
 // This project should be referenced by each service project in your solution.
 // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
 public static class Extensions

--- a/playground/Lambda/Lambda.ServiceDefaults/Extensions.cs
+++ b/playground/Lambda/Lambda.ServiceDefaults/Extensions.cs
@@ -11,7 +11,7 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting
 {
-    // Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+    // Adds common Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
     // This project should be referenced by each service project in your solution.
     // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
     public static class Extensions

--- a/playground/Publishing/Publishing.ServiceDefaults/Extensions.cs
+++ b/playground/Publishing/Publishing.ServiceDefaults/Extensions.cs
@@ -10,7 +10,7 @@ using OpenTelemetry.Trace;
 
 namespace Microsoft.Extensions.Hosting
 {
-    // Adds common .NET Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
+    // Adds common Aspire services: service discovery, resilience, health checks, and OpenTelemetry.
     // This project should be referenced by each service project in your solution.
     // To learn more about using this project, see https://aka.ms/dotnet/aspire/service-defaults
     public static class Extensions

--- a/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/DynamoDBStreamsEventSourceExtensions.cs
@@ -20,7 +20,7 @@ public static class DynamoDBStreamsEventSourceExtensions
 
     /// <summary>
     /// Add a DynamoDB Streams event source to a Lambda function. This feature emulates adding a DynamoDB Streams event source to a Lambda function when deployed to AWS.
-    /// A separate sub resource will be added to the .NET Aspire application that polls the DynamoDB stream. As records
+    /// A separate sub resource will be added to the Aspire application that polls the DynamoDB stream. As records
     /// are received from the stream the Lambda function will be invoked with the records.
     /// </summary>
     /// <param name="lambdaFunction">The Lambda function to add the event source to.</param>
@@ -34,7 +34,7 @@ public static class DynamoDBStreamsEventSourceExtensions
 
     /// <summary>
     /// Add a DynamoDB Streams event source to a Lambda function. This feature emulates adding a DynamoDB Streams event source to a Lambda function when deployed to AWS.
-    /// A separate sub resource will be added to the .NET Aspire application that polls the DynamoDB stream. As records
+    /// A separate sub resource will be added to the Aspire application that polls the DynamoDB stream. As records
     /// are received from the stream the Lambda function will be invoked with the records.
     /// </summary>
     /// <param name="lambdaFunction">The Lambda function to add the event source to.</param>
@@ -60,7 +60,7 @@ public static class DynamoDBStreamsEventSourceExtensions
 
     /// <summary>
     /// Add a DynamoDB Streams event source to a Lambda function. This feature emulates adding a DynamoDB Streams event source to a Lambda function when deployed to AWS.
-    /// A separate sub resource will be added to the .NET Aspire application that polls the DynamoDB stream. As records
+    /// A separate sub resource will be added to the Aspire application that polls the DynamoDB stream. As records
     /// are received from the stream the Lambda function will be invoked with the records.
     /// </summary>
     /// <param name="lambdaFunction">The Lambda function to add the event source to.</param>

--- a/src/Aspire.Hosting.AWS/Lambda/SQSEventSourceExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/SQSEventSourceExtensions.cs
@@ -24,7 +24,7 @@ public static class SQSEventSourceExtensions
 
     /// <summary>
     /// Add an SQS event source to a Lambda function. This feature emulates adding an SQS event source to a Lambda function when deployed to AWS. 
-    /// A separate sub resource will be added to the .NET Aspire application that polls the SQS queue. As messages 
+    /// A separate sub resource will be added to the Aspire application that polls the SQS queue. As messages 
     /// are received from the queue the Lambda function will be invoked with the messages.
     /// </summary>
     /// <param name="lambdaFunction">The Lambda function to add the event source to.</param>
@@ -39,7 +39,7 @@ public static class SQSEventSourceExtensions
 
     /// <summary>
     /// Add an SQS event source to a Lambda function. This feature emulates adding an SQS event source to a Lambda function when deployed to AWS. 
-    /// A separate sub resource will be added to the .NET Aspire application that polls the SQS queue. As messages 
+    /// A separate sub resource will be added to the Aspire application that polls the SQS queue. As messages 
     /// are received from the queue the Lambda function will be invoked with the messages.
     /// </summary>
     /// <param name="lambdaFunction">The Lambda function to add the event source to.</param>
@@ -71,7 +71,7 @@ public static class SQSEventSourceExtensions
 
     /// <summary>
     /// Add an SQS event source to a Lambda function. This feature emulates adding an SQS event source to a Lambda function when deployed to AWS. 
-    /// A separate sub resource will be added to the .NET Aspire application that polls the SQS queue. As messages 
+    /// A separate sub resource will be added to the Aspire application that polls the SQS queue. As messages 
     /// are received from the queue the Lambda function will be invoked with the messages.
     /// </summary>
     /// <param name="lambdaFunction">The Lambda function to add the event source to.</param>

--- a/src/Aspire.Hosting.AWS/README.md
+++ b/src/Aspire.Hosting.AWS/README.md
@@ -1,6 +1,6 @@
 # Aspire.Hosting.AWS library
 
-Provides extension methods and resources definition for a .NET Aspire AppHost to configure the AWS SDK for .NET and AWS application resources.
+Provides extension methods and resources definition for a Aspire AppHost to configure the AWS SDK for .NET and AWS application resources.
 
 ## Features
 
@@ -180,11 +180,11 @@ builder.AddProject<Projects.Frontend>("Frontend")
 
 ## Integrating AWS Lambda Local Development
 
-You can develop and test AWS Lambda functions locally within your .NET Aspire application. This enables testing Lambda functions alongside other application resources during development.
+You can develop and test AWS Lambda functions locally within your Aspire application. This enables testing Lambda functions alongside other application resources during development.
 
 ### Adding Lambda Functions
 
-To add a Lambda function to your .NET Aspire AppHost, use the `AddAWSLambdaFunction` method. The method supports both executable Lambda functions and class library Lambda functions:
+To add a Lambda function to your Aspire AppHost, use the `AddAWSLambdaFunction` method. The method supports both executable Lambda functions and class library Lambda functions:
 
 ```csharp
 var awsConfig = builder.AddAWSSDKConfig()
@@ -211,7 +211,7 @@ The lambdaHandler parameter specifies the Lambda handler in different formats de
 - For class library projects: use the format `{assembly}::{type}::{method}`.
 
 ### Amazon Lambda Test Tool Automatic Installation
-When adding Lambda functions to your .NET Aspire application, the integration automatically manages the installation and updates of the [`Amazon.Lambda.TestTool`](https://github.com/aws/aws-lambda-dotnet/tree/master/Tools/LambdaTestTool-v2). This tool is needed for local Lambda function emulation.
+When adding Lambda functions to your Aspire application, the integration automatically manages the installation and updates of the [`Amazon.Lambda.TestTool`](https://github.com/aws/aws-lambda-dotnet/tree/master/Tools/LambdaTestTool-v2). This tool is needed for local Lambda function emulation.
 
 You can customize the tool installation behavior by calling `AddAWSLambdaServiceEmulator` before any `AddAWSLambdaFunction` calls:
 
@@ -235,7 +235,7 @@ The `LambdaEmulatorOptions` provide the following customization:
 
 ### API Gateway Local Emulation
 
-To add an API Gateaway emulator to your .NET Aspire AppHost, use the `AddAWSAPIGatewayEmulator` method. 
+To add an API Gateaway emulator to your Aspire AppHost, use the `AddAWSAPIGatewayEmulator` method. 
 
 ```csharp
 // Add Lambda functions
@@ -290,7 +290,7 @@ By combining the [ASP.NET Core bridge library](https://github.com/aws/aws-lambda
 
 > **Note**: This feature is currently in preview and subject to change based on feedback. We encourage you to try it out and share your feedback!
 
-The AWS deployment feature for .NET Aspire enables you to deploy your Aspire applications directly to AWS. The deployment system transforms your Aspire AppHost resources into AWS CDK constructs, which are then synthesized into CloudFormation templates and deployed to your AWS account. This provides a seamless path from local development to cloud deployment.
+The AWS deployment feature for Aspire enables you to deploy your Aspire applications directly to AWS. The deployment system transforms your Aspire AppHost resources into AWS CDK constructs, which are then synthesized into CloudFormation templates and deployed to your AWS account. This provides a seamless path from local development to cloud deployment.
 
 For comprehensive documentation including advanced scenarios, implementation details, and architectural guidance, see the [Deployment Design Document](../../docs/deployment-design.md).
 
@@ -418,7 +418,7 @@ When resources are connected with `WithReference()`, the system automatically:
 * Attaches resources to the same VPC when required (e.g., for ElastiCache)
 * Sets up security groups to allow network access between resources
 
-Your application code can access the referenced resource using the standard .NET Aspire configuration patterns - no AWS-specific code required.
+Your application code can access the referenced resource using the standard Aspire configuration patterns - no AWS-specific code required.
 
 ### Advanced Scenarios
 
@@ -433,9 +433,9 @@ The design document provides detailed examples and implementation guidance for t
 
 ## Integrating Amazon DynamoDB Local
 
-Amazon DynamoDB provides a [local version of DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocalHistory.html) for development and testing that is distributed as a container. With version 9.1.0 of the Aspire.Hosting.AWS package, you can easily integrate the DynamoDB local container with your .NET Aspire project. This enables seamless transition between DynamoDB Local for development and the production DynamoDB service in AWS, without requiring any code changes in your application.
+Amazon DynamoDB provides a [local version of DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocalHistory.html) for development and testing that is distributed as a container. With version 9.1.0 of the Aspire.Hosting.AWS package, you can easily integrate the DynamoDB local container with your Aspire project. This enables seamless transition between DynamoDB Local for development and the production DynamoDB service in AWS, without requiring any code changes in your application.
 
-To get started in the .NET Aspire AppHost, call the `AddAWSDynamoDBLocal` method to add DynamoDB local as a resource to the .NET Aspire application.
+To get started in the Aspire AppHost, call the `AddAWSDynamoDBLocal` method to add DynamoDB local as a resource to the Aspire application.
 
 ```csharp
 var builder = DistributedApplication.CreateBuilder(args);
@@ -444,7 +444,7 @@ var builder = DistributedApplication.CreateBuilder(args);
 var localDynamoDB = builder.AddAWSDynamoDBLocal("DynamoDBLocal");
 ```
 
-For each .NET project in the .NET Aspire application using DynamoDB, add a reference to the DynamoDB local resource.
+For each .NET project in the Aspire application using DynamoDB, add a reference to the DynamoDB local resource.
 
 ```csharp
 // Reference DynamoDB local in project
@@ -461,9 +461,9 @@ The `AWS_ENDPOINT_URL_DYNAMODB` environment variable overrides other config se
 
 ### Options for DynamoDB Local
 
-When the `AddAWSDynamoDBLocal` method is called, any data and table definitions are stored in memory by default. This means that every time the .NET Aspire application is started, DynamoDB local is initiated with a fresh instance with no tables or data. The `AddAWSDynamoDBLocal` method takes in an optional `DynamoDBLocalOptions` object that exposes the [options](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.UsageNotes.html) that are available for DynamoDB local.
+When the `AddAWSDynamoDBLocal` method is called, any data and table definitions are stored in memory by default. This means that every time the Aspire application is started, DynamoDB local is initiated with a fresh instance with no tables or data. The `AddAWSDynamoDBLocal` method takes in an optional `DynamoDBLocalOptions` object that exposes the [options](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.UsageNotes.html) that are available for DynamoDB local.
 
-If you want the tables and data to persist between .NET Aspire debug sessions, set the `LocalStorageDirectory` property on the `DynamoDBLocalOptions` object to a local folder where the data will be persisted. The `AddAWSDynamoDBLocal` method will take care of mounting the local directory to the container and configuring the DynamoDB local process to use the mount point.
+If you want the tables and data to persist between Aspire debug sessions, set the `LocalStorageDirectory` property on the `DynamoDBLocalOptions` object to a local folder where the data will be persisted. The `AddAWSDynamoDBLocal` method will take care of mounting the local directory to the container and configuring the DynamoDB local process to use the mount point.
 
 ## Local Development with AgentCore (Experimental)
 

--- a/tests/Aspire.Hosting.AWS.UnitTests/Schema/aspire-8.0.json
+++ b/tests/Aspire.Hosting.AWS.UnitTests/Schema/aspire-8.0.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://json.schemastore.org/aspire-8.0.json",
   "type": "object",
-  "description": "Defines the .NET Aspire 8.0 deployment manifest JSON schema.",
+  "description": "Defines the Aspire 8.0 deployment manifest JSON schema.",
   "required": ["resources"],
   "properties": {
     "resources": {


### PR DESCRIPTION
Aspire has rebranded itself to be just "Aspire" instead of ".NET Aspire". This PR updates any references to ".NET Aspire". For now we will leave the repo name to have `dotnet` in it. Some of the name fixes were in C# code files but don't plan on doing a release for those changes. They can just go out as part of a future release.