### PR TITLE
Allow opting out of OTLP exporter wiring on AddAWSLambdaFunction

### DIFF
--- a/.autover/changes/cffc8829-e669-4515-92c4-176e543a8331.json
+++ b/.autover/changes/cffc8829-e669-4515-92c4-176e543a8331.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Add DisableOpenTelemetry option to AddAWSLambdaFunction to opt out of automatic OTLP exporter wiring"
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaExtensions.cs
@@ -57,6 +57,8 @@ public static class LambdaExtensions
             functionOptions.ApplicationLogLevel = Amazon.Lambda.ApplicationLogLevel.FindValue(options.ApplicationLogLevel);
         }
 
+        functionOptions.DisableOpenTelemetry = options?.DisableOpenTelemetry ?? false;
+
         // suppressBuild: false so Aspire builds the project as part of `dotnet run`. Unlike the class library
         // wrapper project (which is pre-built by LambdaBeforeStartEventHandler), a polyglot project is not built ahead of time.
         return AddAWSLambdaFunctionCore(builder, name, lambdaHandler, new LambdaProjectMetadata(ResolvePolyglotProjectPath(builder, projectPath), suppressBuild: false), functionOptions);
@@ -119,7 +121,10 @@ public static class LambdaExtensions
             resource.WithParentRelationship(serviceEmulator);
         }
 
-        resource.WithOpenTelemetry();
+        if (!options.DisableOpenTelemetry)
+        {
+            resource.WithOpenTelemetry();
+        }
 
         resource.WithEnvironment(context =>
         {

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaFunctionOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaFunctionOptions.cs
@@ -18,4 +18,10 @@ public class LambdaFunctionOptions
     /// The minimum log level captured from the Lambda function. Default log level is INFO.
     /// </summary>
     public Amazon.Lambda.ApplicationLogLevel ApplicationLogLevel { get; set; } = Amazon.Lambda.ApplicationLogLevel.INFO;
+
+    /// <summary>
+    /// Disables the automatic OpenTelemetry (OTLP exporter) wiring for this Lambda function. Useful when no collector
+    /// is listening, for example integration tests using DistributedApplicationTestingBuilder. Default is false.
+    /// </summary>
+    public bool DisableOpenTelemetry { get; set; }
 }

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaFunctionPolyglotOptions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaFunctionPolyglotOptions.cs
@@ -22,4 +22,9 @@ internal sealed class LambdaFunctionPolyglotOptions
     /// Default log level is INFO.
     /// </summary>
     public string? ApplicationLogLevel { get; set; }
+
+    /// <summary>
+    /// Disables the automatic OpenTelemetry (OTLP exporter) wiring for this Lambda function. Default is false.
+    /// </summary>
+    public bool DisableOpenTelemetry { get; set; }
 }

--- a/tests/Aspire.Hosting.AWS.UnitTests/LambdaOpenTelemetryTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/LambdaOpenTelemetryTests.cs
@@ -1,0 +1,41 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+using Aspire.Hosting.ApplicationModel;
+using Aspire.Hosting.AWS.Lambda;
+using Xunit;
+
+namespace Aspire.Hosting.AWS.UnitTests;
+
+/// <summary>
+/// Tests for the OpenTelemetry opt-out on <c>AddAWSLambdaFunction</c>. By default the Lambda resource is wired to
+/// export telemetry via OTLP; <see cref="LambdaFunctionOptions.DisableOpenTelemetry"/> skips that wiring for
+/// scenarios where no collector or dashboard is listening (for example integration tests).
+/// </summary>
+public class LambdaOpenTelemetryTests
+{
+    private sealed class FakeLambdaProject : IProjectMetadata
+    {
+        public string ProjectPath => "fakeLambda.csproj";
+    }
+
+    [Fact]
+    public void AddAWSLambdaFunction_WiresOtlpExporter_ByDefault()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var lambda = builder.AddAWSLambdaFunction<FakeLambdaProject>("MyFunction", "MyFunction::MyFunction.Function::Handler");
+        Assert.Single(lambda.Resource.Annotations.OfType<OtlpExporterAnnotation>());
+    }
+
+    [Fact]
+    public void AddAWSLambdaFunction_SkipsOtlpExporter_WhenDisabled()
+    {
+        var builder = DistributedApplication.CreateBuilder();
+        var lambda = builder.AddAWSLambdaFunction<FakeLambdaProject>(
+            "MyFunction",
+            "MyFunction::MyFunction.Function::Handler",
+            new LambdaFunctionOptions { DisableOpenTelemetry = true }
+        );
+
+        Assert.Empty(lambda.Resource.Annotations.OfType<OtlpExporterAnnotation>());
+    }
+}


### PR DESCRIPTION
Resolves #228 by adding a `DisableOpenTelemetry` option that skips the `WithOpenTelemetry` call (default is false so existing behavior is unchanged).

## License
- [X] I confirm that this pull request can be released under the Apache 2 license