### PR TITLE
Update to version Aspire 13.5

### DIFF
--- a/.autover/changes/4f293d71-52ee-4293-b5c3-d21990212e5f.json
+++ b/.autover/changes/4f293d71-52ee-4293-b5c3-d21990212e5f.json
@@ -1,0 +1,12 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Minor",
+      "ChangelogMessages": [
+        "Update to version Aspire 13.5",
+		"The AddAWSLambdaFunction method now uses Aspire 13.5's new WithProjectDefaults method to configure LambdaProject subclasses with the same defaults that AddProject applies to the base Project type"
+      ]
+    }
+  ]
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,6 +15,12 @@
     <RepositoryUrl>https://github.com/aws/integrations-on-dotnet-aspire-for-aws</RepositoryUrl>
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+	
+	<!-- 
+	Warning ASPIRE010 is about pushing users to always run the AppHost via the aspire cli. But the AppHost in this solution are 
+	often meant for debugging and unit/integ testing. The aspire cli is generally not used for these.
+	-->
+	<NoWarn>$(NoWarn);ASPIRE010</NoWarn>
   </PropertyGroup>
   
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -59,7 +59,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="JsonSchema.Net" Version="7.4.0" />
+    <PackageVersion Include="JsonSchema.Net" Version="9.4.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <!-- Added explicitly MessagePack reference to address NU1109 -->
     <PackageVersion Include="MessagePack" Version="2.5.302" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,48 +2,48 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <AspireSdkVersion>13.4.6</AspireSdkVersion>
+    <AspireSdkVersion>13.5.0</AspireSdkVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Aspire.Hosting" Version="13.4.6" />
-    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.4.6" />
-    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.4.6" />
-    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.4.6" />
-    <PackageVersion Include="Aspire.Hosting.Valkey" Version="13.4.6" />
-    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.4.6" />
-    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.4.6" />
-    <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.4.6" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Dns" Version="10.5.0" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.8" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageVersion Include="Aspire.Hosting" Version="13.5.0" />
+    <PackageVersion Include="Aspire.Hosting.AppHost" Version="13.5.0" />
+    <PackageVersion Include="Aspire.Hosting.Testing" Version="13.5.0" />
+    <PackageVersion Include="Aspire.Hosting.Redis" Version="13.5.0" />
+    <PackageVersion Include="Aspire.Hosting.Valkey" Version="13.5.0" />
+    <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.5.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis" Version="13.5.0" />
+    <PackageVersion Include="Aspire.StackExchange.Redis.OutputCaching" Version="13.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.9.0" />
+    <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery.Dns" Version="10.9.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.9.0" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <!-- AWS AgentCore local testing -->
-    <PackageVersion Include="AWS.AgentCore.Hosting" Version="0.0.1-preview" />
-    <PackageVersion Include="AWS.AgentCore.Testing" Version="0.0.1-preview" />
-    <PackageVersion Include="AWSSDK.BedrockAgentCore" Version="4.0.23.3" />
+    <PackageVersion Include="AWS.AgentCore.Hosting" Version="1.0.0" />
+    <PackageVersion Include="AWS.AgentCore.Testing" Version="1.0.0" />
     <!-- AWS SDK for .NET dependencies -->
-    <PackageVersion Include="AWSSDK.CloudFormation" Version="4.0.8.22" />
-    <PackageVersion Include="AWSSDK.Core" Version="4.0.7.1" />
-    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.18.1" />
-    <PackageVersion Include="AWSSDK.Lambda" Version="4.0.15.2" />
-    <PackageVersion Include="AWSSDK.S3" Version="4.0.21.2" />
-    <PackageVersion Include="AWSSDK.SecurityToken" Version="4.0.6.3" />
-    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.0.2.30" />
-    <PackageVersion Include="AWSSDK.SQS" Version="4.0.2.28" />
-    <PackageVersion Include="AWSSDK.Signin" Version="4.0.2" />
-    <PackageVersion Include="AWSSDK.SSO" Version="4.0.2.27" />
-    <PackageVersion Include="AWSSDK.SSOOIDC" Version="4.0.3.28" />
-    <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.3.40" />
-    <PackageVersion Include="AWS.Messaging" Version="1.3.0" />
-    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="2.0.0" />
-    <PackageVersion Include="Amazon.Lambda.Core" Version="3.0.0" />
-    <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.0" />
-    <PackageVersion Include="Amazon.Lambda.APIGatewayEvents" Version="3.0.0" />
+    <PackageVersion Include="AWSSDK.BedrockAgentCore" Version="4.0.105.1" />
+    <PackageVersion Include="AWSSDK.CloudFormation" Version="4.0.102.2" />
+    <PackageVersion Include="AWSSDK.Core" Version="4.0.101.1" />
+    <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.103.3" />
+    <PackageVersion Include="AWSSDK.Lambda" Version="4.0.105.2" />
+    <PackageVersion Include="AWSSDK.S3" Version="4.0.102.2" />
+    <PackageVersion Include="AWSSDK.SecurityToken" Version="4.0.100.9" />
+    <PackageVersion Include="AWSSDK.SimpleNotificationService" Version="4.0.100.9" />
+    <PackageVersion Include="AWSSDK.SQS" Version="4.0.100.9" />
+    <PackageVersion Include="AWSSDK.Signin" Version="4.0.100.9" />
+    <PackageVersion Include="AWSSDK.SSO" Version="4.0.100.9" />
+    <PackageVersion Include="AWSSDK.SSOOIDC" Version="4.0.100.9" />
+    <PackageVersion Include="AWSSDK.Extensions.NETCore.Setup" Version="4.0.100.9" />
+    <PackageVersion Include="AWS.Messaging" Version="1.6.0" />
+    <PackageVersion Include="Amazon.Lambda.RuntimeSupport" Version="2.2.0" />
+    <PackageVersion Include="Amazon.Lambda.Core" Version="3.3.0" />
+    <PackageVersion Include="Amazon.Lambda.Serialization.SystemTextJson" Version="3.0.1" />
+    <PackageVersion Include="Amazon.Lambda.APIGatewayEvents" Version="3.0.1" />
     <PackageVersion Include="Amazon.Lambda.DynamoDBEvents" Version="4.0.0" />
-    <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="3.0.0" />
+    <PackageVersion Include="Amazon.Lambda.SQSEvents" Version="3.0.1" />
     <PackageVersion Include="Amazon.AspNetCore.DataProtection.SSM" Version="4.0.1" />
     <!-- AWS CDK dependencies -->
     <PackageVersion Include="Amazon.CDK.Lib" Version="2.262.0" />

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaBeforeStartEventHandler.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaBeforeStartEventHandler.cs
@@ -140,12 +140,14 @@ internal class LambdaBeforeStartEventHandler(ILogger<LambdaEmulatorResource> log
                         continue;
                     }
 
-                    projectResource.Annotations.Remove(projectMetadata);
-
                     var projectPath =
                         ProjectUtilities.CreateExecutableWrapperProject(projectMetadata.ProjectPath, lambdaFunctionAnnotation.Handler, targetFramework);
 
-                    projectResource.Annotations.Add(new LambdaProjectMetadata(projectPath));
+                    if (projectMetadata is not LambdaProjectMetadata lambdaProjectMetadata)
+                    {
+                        throw new InvalidOperationException("Expected projectMetadata to be of type LambdaProjectMetadata. This was most likely an internal coding bug in the Add AddAWSLambdaFunction method.");
+                    }
+                    lambdaProjectMetadata.ProjectPath = projectPath;
 
                     var projectName = new FileInfo(projectPath).Name;
                     var workingDirectory = Directory.GetParent(projectPath)!.FullName;
@@ -343,7 +345,7 @@ internal class LambdaBeforeStartEventHandler(ILogger<LambdaEmulatorResource> log
 
 internal sealed class LambdaProjectMetadata(string projectPath, bool suppressBuild = true) : IProjectMetadata
 {
-    public string ProjectPath { get; } = projectPath;
+    public string ProjectPath { get; internal set; } = projectPath;
 
     // For the class library wrapper project the wrapper is already built explicitly before DCP starts it,
     // so SuppressBuild defaults to true. Setting SuppressBuild=true causes Aspire to pass --no-build to

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaExtensions.cs
@@ -102,15 +102,18 @@ public static class LambdaExtensions
             // we want to configure the Aspire resource to use a Launch Setting Profile that will be able to run the class library Lambda function.
             var project = new LambdaProjectResource(name);
             resource = builder.AddResource(project)
-                .WithAnnotation(new LaunchProfileAnnotation($"{Constants.LaunchSettingsNodePrefix}{name}"))
-                .WithAnnotation(metadata);
+                .WithAnnotation(new LaunchProfileAnnotation($"{Constants.LaunchSettingsNodePrefix}{name}"));
         }
         else
         {
             var project = new LambdaProjectResource(name);
-            resource = builder.AddResource(project)
-                            .WithAnnotation(metadata);
+            resource = builder.AddResource(project);
         }
+
+        // Wrap the IProjectMetadata with the LambdaProjectMetadata so that the project path can be changed in the LambdaBeforeStartEventHandler
+        // if it creates a wrapper project for class libraries. If the IProjectMetadata was replaced when the project path was changed, then
+        // the WithProjectDefaults will trigger an exception about the metadata being replaced.
+        resource.WithAnnotation(new LambdaProjectMetadata(metadata.ProjectPath, suppressBuild: metadata.SuppressBuild));
 
         ExecutableResource? serviceEmulator = null;
         if (builder.ExecutionContext.IsRunMode)

--- a/src/Aspire.Hosting.AWS/Lambda/LambdaExtensions.cs
+++ b/src/Aspire.Hosting.AWS/Lambda/LambdaExtensions.cs
@@ -119,7 +119,15 @@ public static class LambdaExtensions
             resource.WithParentRelationship(serviceEmulator);
         }
 
-        resource.WithOpenTelemetry();
+        // We are using a preview method to set the project defaults for the Lambda function resource. 
+        // Using the preview method is a safer choice then previous efforts where we tried to mimic what
+        // the project defaults were that caused issues.
+#pragma warning disable ASPIREPROJECTS001
+        resource.WithProjectDefaults(new ProjectResourceOptions
+        {
+            ExcludeKestrelEndpoints = true
+        });
+#pragma warning restore ASPIREPROJECTS001
 
         resource.WithEnvironment(context =>
         {
@@ -274,32 +282,5 @@ public static class LambdaExtensions
         }
 
         return serviceEmulator;
-    }
-
-    /// <summary>
-    /// This method is adapted from the Aspire WithProjectDefaults method.
-    /// https://github.com/dotnet/aspire/blob/157f312e39300912b37a14f59beda217c8195e14/src/Aspire.Hosting/ProjectResourceBuilderExtensions.cs#L287
-    /// </summary>
-    /// <param name="builder"></param>
-    /// <returns></returns>
-    private static IResourceBuilder<LambdaProjectResource> WithOpenTelemetry(this IResourceBuilder<LambdaProjectResource> builder)
-    {
-        builder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES", "true");
-        builder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES", "true");
-        // .NET SDK has experimental support for retries. Enable with env var.
-        // https://github.com/open-telemetry/opentelemetry-dotnet/pull/5495
-        // Remove once retry feature in opentelemetry-dotnet is enabled by default.
-        builder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY", "in_memory");
-
-        if (builder.ApplicationBuilder.ExecutionContext.IsRunMode && builder.ApplicationBuilder.Environment.IsDevelopment())
-        {
-            // Disable URL query redaction, e.g. ?myvalue=Redacted
-            builder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_ASPNETCORE_DISABLE_URL_QUERY_REDACTION", "true");
-            builder.WithEnvironment("OTEL_DOTNET_EXPERIMENTAL_HTTPCLIENT_DISABLE_URL_QUERY_REDACTION", "true");
-        }
-
-        builder.WithOtlpExporter();
-
-        return builder;
     }
 }

--- a/tests/Aspire.Hosting.AWS.UnitTests/AWSSchemaTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/AWSSchemaTests.cs
@@ -2,6 +2,7 @@
 
 using Amazon;
 using Json.Schema;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Xunit;
 using Xunit.Abstractions;
@@ -85,14 +86,14 @@ public class AWSSchemaTests(ITestOutputHelper output)
 
     private static void AssertValid(string manifestText)
     {
-        var manifestJson = JsonNode.Parse(manifestText);
+        var manifestJson = JsonDocument.Parse(manifestText);
         var schema = GetSchema();
-        var results = schema.Evaluate(manifestJson);
+        var results = schema.Evaluate(manifestJson.RootElement);
 
         if (!results.IsValid)
         {
-            var errorMessages = results.Details.Where(x => x.HasErrors).SelectMany(e => e.Errors!).Select(e => e.Value);
-            Assert.True(results.IsValid, string.Join(Environment.NewLine, errorMessages ?? ["Schema failed validation with no errors"]));
+            var errorMessages = results.Details?.Where(x => x.Errors?.Count > 0).SelectMany(e => e.Errors!).Select(e => e.Value);
+            Assert.True(results.IsValid, string.Join(Environment.NewLine, errorMessages ?? new[] { "Schema failed validation with no errors" }));
         }
     }
 }

--- a/tests/Aspire.Hosting.AWS.UnitTests/AgentCoreResourceBuilderExtensionsTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/AgentCoreResourceBuilderExtensionsTests.cs
@@ -245,7 +245,7 @@ public class AgentCoreResourceBuilderExtensionsTests
     {
         var result = new Dictionary<string, string>();
         var runContext = new DistributedApplicationExecutionContext(
-            new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run) { ServiceProvider = services });
+            new DistributedApplicationExecutionContextOptions(DistributedApplicationOperation.Run) { Services = services });
 
         foreach (var callback in resource.Annotations.OfType<EnvironmentCallbackAnnotation>())
         {


### PR DESCRIPTION
## Description
Update to Aspire 13.5.

The AddAWSLambdaFunction method now uses Aspire 13.5's new WithProjectDefaults method to configure LambdaProject subclasses with the same defaults that AddProject applies to the base Project type.

Switching to `WithProjectDefaults` address issue https://github.com/aws/integrations-on-dotnet-aspire-for-aws/issues/228 because we follow the same behavior of `AddProject` without attempting to mimic the behavior which has the discrepancy of how OTEL is setup.

