### PR TITLE
fix(execute-release): push autover's commits instead of an empty manual commit

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -78,23 +78,22 @@ jobs:
         run: |
           git config --global user.email "github-aws-sdk-dotnet-automation@amazon.com"
           git config --global user.name "aws-sdk-dotnet-automation"
-      # Bump the version from the change files (or an explicit override).
+      # Bump the version from the change files (or an explicit override). autover commits the
+      # version bump itself.
       - name: Increment Version
         run: autover version
         if: env.INPUT_OVERRIDE_VERSION == ''
       - name: Increment Version (override)
         run: autover version --use-version "$INPUT_OVERRIDE_VERSION"
         if: env.INPUT_OVERRIDE_VERSION != ''
+      # autover changelog updates CHANGELOG.md, deletes the consumed change files, and commits both.
       - name: Update Changelog
         run: autover changelog
-      # Commit version + changelog straight to the trunk. No release PR, and no tag
-      # push here: the pipeline tags and creates the GitHub Release after publish.
-      - name: Commit version and changelog
-        run: |
-          version=$(autover changelog --release-name)
-          git add -A
-          git commit -m "chore: release $version"
-          git push origin HEAD:main
+      # autover already committed the version bump + changelog (incl. the change-file deletions),
+      # so just push those commits straight to the trunk. No release PR, and no tag push here:
+      # the pipeline tags and creates the GitHub Release after publish.
+      - name: Push version and changelog
+        run: git push origin HEAD:main
       # Switch identities: assume the pipeline account's Execute Release role (GitHub OIDC)
       # so the pipeline calls below run same-account. The role above (release-workflow) only
       # reads the deploy key; this one only starts this pipeline.


### PR DESCRIPTION
## Problem

The Execute Release workflow fails at the **Commit version and changelog** step ([example run](https://github.com/aws/integrations-on-dotnet-aspire-for-aws/actions/runs/32878230559)):

```
On branch main
Your branch is ahead of 'origin/main' by 2 commits.
nothing to commit, working tree clean
##[error]Process completed with exit code 1.
```

**Root cause:** `autover` commits on its own —
- `autover version` stages + commits the version bump (`VersionCommand`: `if (!optionNoCommit) CommitChanges(...)`), and
- `autover changelog` writes `CHANGELOG.md`, **deletes the consumed `.autover/changes/*.json`** (`ResetUserConfiguration({ Changelog = true })` → `ResetChangeFiles`), and commits it all as `"Updated changelog"` (`ChangelogCommand`).

Those are the "2 commits ahead". The next step then ran `git add -A && git commit -m "chore: release $version"`, which exits 1 on the now-clean tree; the step runs under `bash -e`, so the job aborts. And because `git push` was the line *after* the failing commit, autover's commits were **never pushed** — so the release never started, and the change file was never removed from `main` (every re-run fails identically).

## Fix

The manual commit is redundant — autover already committed both the version bump and the changelog (including the change-file deletions). Reduce the step to just push those commits:

```yaml
- name: Push version and changelog
  run: git push origin HEAD:main
```

## Note

This same pattern is in the shared Execute Release template, so the fix should be applied there too before onboarding other repos.