### PR TITLE
fix(execute-release): persist the SSH deploy key so the push to main can authenticate

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -64,9 +64,10 @@ jobs:
           ref: main
           fetch-depth: '0'
           ssh-key: ${{ env.DEPLOY_KEY }}
-          # The later push to main uses the SSH deploy key, not the GITHUB_TOKEN, so
-          # don't persist the token in the local git config (avoids credential leakage).
-          persist-credentials: false
+          # Keep the SSH deploy-key config in the local git config so the later
+          # "git push origin HEAD:main" can authenticate with it. (There is no
+          # GITHUB_TOKEN persisted here to worry about - auth is the deploy key.)
+          persist-credentials: true
       # .NET 9 is needed for AutoVer.
       - name: Setup .NET 9.0
         uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 #v5


### PR DESCRIPTION
## Problem

After #235, the Execute Release workflow reaches the push step and fails ([run](https://github.com/aws/integrations-on-dotnet-aspire-for-aws/actions/runs/32881657081/job/97912352705)):

```
Run git push origin HEAD:main
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

## Root cause

The Checkout step authenticates with the SSH deploy key (`ssh-key: ${{ env.DEPLOY_KEY }}`) but sets **`persist-credentials: false`**. `actions/checkout` uses the key for the clone and then **removes** the key's git config afterward, so the later `git push origin HEAD:main` has no credential and SSH auth fails (`Permission denied (publickey)`).

The original comment assumed `persist-credentials` was about a persisted `GITHUB_TOKEN` — but when `ssh-key` is supplied there's no token involved; `persist-credentials` controls whether the **deploy-key** config survives. It needs to.

## Fix

```yaml
persist-credentials: true
```

so the SSH deploy-key config persists for the push. (The checkout already succeeded with this key, confirming it's valid for read; this lets the push reuse it. If the deploy key doesn't have write access enabled, that would surface next as a distinct "write access not granted" error — but the current failure is purely the key not being present.)

Follow-up to #235; this is the second and final blocker for the push-to-trunk step.