### PR TITLE
fix: canonicalize temp path for generated Lambda wrapper project to avoid MSB3202 on macOS

### DIFF
--- a/.autover/changes/5f9b52f2-497b-4c35-b574-724417568327.json
+++ b/.autover/changes/5f9b52f2-497b-4c35-b574-724417568327.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Fix MSB3202 build failure on macOS for class library Lambda functions with project references by canonicalizing the temp path of the generated wrapper project"
+      ]
+    }
+  ]
+}

--- a/src/Aspire.Hosting.AWS/Utils/ProjectUtilities.cs
+++ b/src/Aspire.Hosting.AWS/Utils/ProjectUtilities.cs
@@ -152,7 +152,11 @@ internal static class ProjectUtilities
     /// <returns>A project file path of the executable wrapper project</returns>
     public static string CreateExecutableWrapperProject(string classLibraryProjectPath, string lambdaHandler, string targetFramework)
     {
-        string tempPath = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        // The temp path must be canonicalized because on macOS Path.GetTempPath() returns a path under /var,
+        // which is a symlink to /private/var. NuGet restore records transitive ProjectReference paths in
+        // project.assets.json relative to the symlinked spelling, while MSBuild canonicalizes the project
+        // directory to /private/var, causing those relative paths to resolve to non-existent locations (MSB3202).
+        string tempPath = Path.Combine(ResolveCanonicalPath(Path.GetTempPath()), Guid.NewGuid().ToString());
         Directory.CreateDirectory(tempPath);
 
         var projectContent = $@"
@@ -183,6 +187,36 @@ await runtimeSupportInitializer.RunLambdaBootstrap();
         File.WriteAllText(programPath, programContent);
 
         return projectPath;
+    }
+
+    /// <summary>
+    /// Resolves every symlinked segment of the given path to produce its canonical form.
+    /// Segments that do not exist are kept as-is, and the method is a no-op on paths without symlinks.
+    /// </summary>
+    /// <param name="path">The path to canonicalize</param>
+    /// <returns>The canonical path with all symlinked segments resolved</returns>
+    internal static string ResolveCanonicalPath(string path)
+    {
+        var fullPath = Path.GetFullPath(path);
+        var current = Path.GetPathRoot(fullPath)!;
+        foreach (var segment in fullPath.Substring(current.Length).Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries))
+        {
+            current = Path.Combine(current, segment);
+            try
+            {
+                var linkTarget = Directory.ResolveLinkTarget(current, returnFinalTarget: true);
+                if (linkTarget != null)
+                {
+                    // The link target may itself contain symlinked segments (e.g. a target under /var on macOS).
+                    current = ResolveCanonicalPath(linkTarget.FullName);
+                }
+            }
+            catch (IOException)
+            {
+                // The segment does not exist or cannot be inspected; keep the original spelling.
+            }
+        }
+        return current;
     }
 
     internal static string? LookupTargetFrameworkFromProjectFile(string projectFile, string msBuildParameters = "")

--- a/tests/Aspire.Hosting.AWS.UnitTests/ProjectUtilitiesTests.cs
+++ b/tests/Aspire.Hosting.AWS.UnitTests/ProjectUtilitiesTests.cs
@@ -186,6 +186,64 @@ public class ProjectUtilitiesTests : IDisposable
     }
 
     [Fact]
+    public void ResolveCanonicalPath_ResolvesSymlinkedSegments()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            // Creating symlinks on Windows requires elevated privileges.
+            return;
+        }
+
+        // Arrange
+        string target = Path.Combine(_tempDirectory, "target");
+        Directory.CreateDirectory(Path.Combine(target, "sub"));
+        string link = Path.Combine(_tempDirectory, "link");
+        Directory.CreateSymbolicLink(link, target);
+
+        // Act
+        string result = ProjectUtilities.ResolveCanonicalPath(Path.Combine(link, "sub"));
+
+        // Assert
+        Assert.Equal(ProjectUtilities.ResolveCanonicalPath(Path.Combine(target, "sub")), result);
+        Assert.DoesNotContain($"{Path.DirectorySeparatorChar}link{Path.DirectorySeparatorChar}", result + Path.DirectorySeparatorChar);
+    }
+
+    [Fact]
+    public void ResolveCanonicalPath_IsNoOp_ForPathWithoutSymlinks()
+    {
+        // Arrange
+        string path = Path.Combine(_tempDirectory, "does", "not", "exist");
+
+        // Act
+        string result = ProjectUtilities.ResolveCanonicalPath(path);
+
+        // Assert: non-existent segments are kept as-is; existing segments may canonicalize (e.g. /var -> /private/var on macOS).
+        Assert.EndsWith(Path.Combine("does", "not", "exist"), result);
+    }
+
+    [Fact]
+    public void CreateExecutableWrapperProject_ReturnsCanonicalPath()
+    {
+        // Arrange
+        string classLibraryProjectPath = GetTempProjectPath();
+
+        // Act
+        string wrapperProjectPath = ProjectUtilities.CreateExecutableWrapperProject(classLibraryProjectPath, "TestNamespace.Function::Handler", "net8.0");
+
+        try
+        {
+            // Assert: the generated project path must contain no symlinked segments,
+            // otherwise NuGet restore and MSBuild disagree on relative ProjectReference paths (MSB3202 on macOS).
+            Assert.True(File.Exists(wrapperProjectPath));
+            Assert.Equal(ProjectUtilities.ResolveCanonicalPath(wrapperProjectPath), wrapperProjectPath);
+        }
+        finally
+        {
+            Directory.Delete(Path.GetDirectoryName(wrapperProjectPath)!, true);
+        }
+    }
+
+    [Fact]
     public void UpdateLaunchSettings_ReplacesMalformedLaunchSettingsJson_WithNewObject()
     {
         // Arrange


### PR DESCRIPTION
## Description

On macOS, running an AppHost via the aspire CLI fails to build the generated Lambda wrapper project when the class library Lambda project has a `ProjectReference` to another project:

```
error MSB3202: The project file "../../../../../../Users/<user>/.../MyLambda.Contracts.csproj"
was not found. [/var/folders/.../T/<guid>/WrapperMyLambda.csproj]
```

**Root cause:** `ProjectUtilities.CreateExecutableWrapperProject` writes the wrapper project into `Path.GetTempPath()`. On macOS that is `/var/folders/...`, and `/var` is a symlink to `/private/var`. NuGet restore records transitive `ProjectReference` paths in `project.assets.json` as relative paths computed from the symlinked spelling (6 segments up to the root), while MSBuild canonicalizes the project directory to `/private/var/...` (7 segments). The 6-hop relative path resolved from the 7-segment directory lands in `/private/Users/...`, which doesn't exist.

Single-project Lambdas are unaffected because the wrapper's direct `ProjectReference` is an absolute path; only transitive project references are stored as relative paths. IDEs (e.g. Rider) are unaffected because they launch with `TMPDIR` already set to the canonical `/private/var/...` spelling.

**Fix:** canonicalize the temp path (resolve every symlinked segment) before creating the wrapper project, so NuGet restore and MSBuild agree on the project directory. The new `ResolveCanonicalPath` helper walks the path segment by segment with `Directory.ResolveLinkTarget(returnFinalTarget: true)` (the symlink is a mid-path component, so a single call on the full path would not resolve it) and recursively canonicalizes link targets (a target's stored spelling can itself contain symlinked segments). It is a no-op on Windows/Linux where the temp directory contains no symlinks, and non-existent segments are kept as-is.

A `change file` is included per the contribution guide.

## Motivation and Context

Repro (macOS, shell with default `TMPDIR=/var/folders/...`):

1. Class library Lambda csproj with a `ProjectReference` to a sibling project.
2. AppHost registers it via `AddAWSLambdaFunction`.
3. `aspire run` (or `dotnet run` on the AppHost from a terminal): the wrapper resource fails with MSB3202.

Workaround that proves the cause: `TMPDIR=/private$TMPDIR aspire run` builds clean, because restore and build then both see the canonical spelling.

## Testing

- macOS (Darwin, arm64): full `Aspire.Hosting.AWS.UnitTests` suite passes (260/260).
- New unit tests in `ProjectUtilitiesTests`:
  - `ResolveCanonicalPath_ResolvesSymlinkedSegments` — creates a real directory symlink and asserts the resolved path contains no symlinked segment (skipped on Windows, where creating symlinks requires elevation).
  - `ResolveCanonicalPath_IsNoOp_ForPathWithoutSymlinks` — non-existent segments pass through unchanged.
  - `CreateExecutableWrapperProject_ReturnsCanonicalPath` — the generated wrapper project path equals its own canonical form.
- Manual verification of the original failure: with the fix, the wrapper project restores and builds cleanly from a shell with the default `TMPDIR`.

## Breaking Changes Assessment

None. The wrapper project keeps the same lifecycle and contents; only the spelling of its temp directory changes (symlink-free canonical form of the same location). The helper is `internal`. Behavior on Windows/Linux is unchanged.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have read the **README** document
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed

## License

- [x] I confirm that this pull request can be released under the Apache 2 license
