### PR TITLE
security: harden execute-release.yml per zizmor

### DIFF
--- a/.github/workflows/execute-release.yml
+++ b/.github/workflows/execute-release.yml
@@ -58,7 +58,7 @@ jobs:
           secret-ids: |
             DEPLOY_KEY, prod/devops/integrations-on-dotnet-aspire-for-aws-deploy-key
       # Full clone of the trunk using the deploy key.
-      - name: Checkout
+      - name: Checkout # zizmor: ignore[artipacked] persist-credentials must stay true for the deploy-key push
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
         with:
           ref: main
@@ -146,8 +146,12 @@ jobs:
         if: steps.freeze.outputs.frozen == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
+
+          RELEASE_TAG: ${{ steps.relmeta.outputs.tag }}
+
+          RELEASE_NAME: ${{ steps.relmeta.outputs.name }}
         run: |
-          gh release create "${{ steps.relmeta.outputs.tag }}" \
-            --title "${{ steps.relmeta.outputs.name }}" \
+          gh release create "$RELEASE_TAG" \
+            --title "$RELEASE_NAME" \
             --notes-file "$RUNNER_TEMP/release_notes.md" \
             --target "$(git rev-parse HEAD)"


### PR DESCRIPTION
Addresses zizmor findings on `.github/workflows/execute-release.yml`:

- **template-injection (info, ×2):** the GitHub release step interpolated `${{ steps.relmeta.outputs.tag/name }}` directly into the `run:` block. Now routed through `RELEASE_TAG`/`RELEASE_NAME` env vars and referenced as `$RELEASE_TAG`/`$RELEASE_NAME`.
- **artipacked (medium):** suppressed with `# zizmor: ignore[artipacked]` on the Checkout step. `persist-credentials: true` is intentional and required so the SSH deploy-key git config survives for the later `git push origin HEAD:main` — flipping it to false would break the release push.

No behavior change; same fixes are being applied to the fleet's `execute-release.yml` PRs.