### PR TITLE
chore: point dependabot at the default branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,8 @@ updates:
 
   - package-ecosystem: "github-actions"
     directory: "/"
+    cooldown:
+      default-days: 7
     schedule:
       # Check for updates to GitHub Actions every quarter
       interval: "quarterly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
       interval: "quarterly"
     labels:
       - "Release Not Needed"
-    target-branch: "dev"
     # Group all github-actions updates into a single PR
     groups:
       all-github-actions:


### PR DESCRIPTION
Removes `target-branch: "dev"` from .github/dependabot.yml so dependabot opens PRs against the default branch (`main`) now that the dev branch is retired.