### PR TITLE
fix: publish Aspire.Hosting.AWS with commit-pinned Source Link metadata

### DIFF
--- a/.autover/changes/9c45bdd0-4723-4adf-92cf-1ff443dbec82.json
+++ b/.autover/changes/9c45bdd0-4723-4adf-92cf-1ff443dbec82.json
@@ -1,0 +1,11 @@
+{
+  "Projects": [
+    {
+      "Name": "Aspire.Hosting.AWS",
+      "Type": "Patch",
+      "ChangelogMessages": [
+        "Enable commit-pinned Source Link and deterministic repository metadata so the published package links back to the exact GitHub source (fixes #244)."
+      ]
+    }
+  ]
+}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,8 +13,20 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)public.snk</AssemblyOriginatorKeyFile>
     <PackageProjectUrl>https://github.com/aws/integrations-on-dotnet-aspire-for-aws</PackageProjectUrl>
     <RepositoryUrl>https://github.com/aws/integrations-on-dotnet-aspire-for-aws</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+
+    <!--
+    Deterministic, commit-linked source metadata (Source Link). These enable the packed
+    assembly/PDB to carry the pinned Git commit and rewrite local (C:\build\...) document
+    paths to github.com URLs. ContinuousIntegrationBuild is enabled only on CI so local
+    developer builds keep full absolute paths for debugging.
+    -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <Deterministic>true</Deterministic>
+    <ContinuousIntegrationBuild Condition="'$(CI)' == 'true' or '$(TF_BUILD)' == 'true' or '$(CODEBUILD_BUILD_ID)' != ''">true</ContinuousIntegrationBuild>
 	
 	<!-- 
 	Warning ASPIRE010 is about pushing users to always run the AppHost via the aspire cli. But the AppHost in this solution are 
@@ -22,5 +34,9 @@
 	-->
 	<NoWarn>$(NoWarn);ASPIRE010</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
+  </ItemGroup>
   
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -38,5 +38,21 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" />
   </ItemGroup>
-  
+
+  <!--
+  Explicit SourceRoot for CI packing. The release pipeline hands the CodeBuild pack step
+  a source archive without a .git directory, so Source Link cannot derive the repository
+  root from git. Declaring SourceRoot from MSBuild properties (RepositoryUrl +
+  SourceRevisionId, supplied by the pipeline's build script) lets Source Link emit the
+  commit-pinned document -> raw.githubusercontent.com URL map and rewrite local build
+  paths to /_/... form WITHOUT requiring a full git clone. Guarded on SourceRevisionId so
+  local developer builds (which set no revision) are unaffected.
+  -->
+  <ItemGroup Condition="'$(SourceRevisionId)' != ''">
+    <SourceRoot Include="$(MSBuildThisFileDirectory)"
+                SourceControl="git"
+                RepositoryUrl="$(RepositoryUrl)"
+                RevisionId="$(SourceRevisionId)" />
+  </ItemGroup>
+
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,8 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
+    <!-- Source Link: emit commit-pinned repository metadata and rewrite local PDB paths -->
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <!-- AWS AgentCore local testing -->
     <PackageVersion Include="AWS.AgentCore.Hosting" Version="1.0.0" />
     <PackageVersion Include="AWS.AgentCore.Testing" Version="1.0.0" />

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -14,6 +14,9 @@ phases:
   build:
     commands:
       - dotnet test --verbosity normal integrations-on-aspire-for-aws.sln --configuration Release --logger "console;verbosity=detailed" --logger trx --results-directory ./testresults
+      # Pack with the resolved Git revision so the produced package carries commit-pinned
+      # Source Link metadata (empty <repository commit> and C:\build PDB paths otherwise).
+      - dotnet pack src/Aspire.Hosting.AWS/Aspire.Hosting.AWS.csproj --configuration Release -p:ContinuousIntegrationBuild=true -p:SourceRevisionId=$(git rev-parse HEAD) --output ./artifacts
 reports:
     integrations-on-aspire-for-aws-tests:
         file-format: VisualStudioTrx

--- a/buildtools/ci.buildspec.yml
+++ b/buildtools/ci.buildspec.yml
@@ -14,9 +14,6 @@ phases:
   build:
     commands:
       - dotnet test --verbosity normal integrations-on-aspire-for-aws.sln --configuration Release --logger "console;verbosity=detailed" --logger trx --results-directory ./testresults
-      # Pack with the resolved Git revision so the produced package carries commit-pinned
-      # Source Link metadata (empty <repository commit> and C:\build PDB paths otherwise).
-      - dotnet pack src/Aspire.Hosting.AWS/Aspire.Hosting.AWS.csproj --configuration Release -p:ContinuousIntegrationBuild=true -p:SourceRevisionId=$(git rev-parse HEAD) --output ./artifacts
 reports:
     integrations-on-aspire-for-aws-tests:
         file-format: VisualStudioTrx


### PR DESCRIPTION
Fixes #244

## Summary
Publish `Aspire.Hosting.AWS` with Source Link and immutable, commit-pinned repository metadata. Previously the published NuGet package lacked commit-linked source metadata: the `<repository>` element had no `commit`, `AssemblyInformationalVersion` had no source-revision suffix, the embedded PDB had no Source Link document mapping, and PDB document paths leaked build-agent paths like `C:\build\src\...`. This broke source-debugging and API-reference source links for consumers.

## Changes
1. **`Directory.Build.props`** — adds `RepositoryType=git`, `PublishRepositoryUrl`, `EmbedUntrackedSources`, `Deterministic`, a CI-gated `ContinuousIntegrationBuild`, a `Microsoft.SourceLink.GitHub` PackageReference, and an explicit **`<SourceRoot>`** (guarded on `SourceRevisionId`).
2. **`Directory.Packages.props`** — pins `Microsoft.SourceLink.GitHub` 8.0.0 via central package management.

### Why the explicit `<SourceRoot>`
The release CodePipeline packs from a source **archive without a `.git` directory** (the source action uses `full_clone: false`). Without `.git`, Source Link cannot derive the repository root, so the document→URL map and the `/_/...` path rewrite are not emitted. Declaring `<SourceRoot>` from MSBuild properties (`RepositoryUrl` + `SourceRevisionId`, supplied by the pipeline build script) makes Source Link produce commit-pinned output **without requiring a full clone**. Guarded on `SourceRevisionId` so local developer builds are unaffected.

## Depends on
The revision is supplied at build time by the shared pipeline build script. That change is aws/aws-dotnet-devex-pipelines#197 and must be deployed before a release of this package produces the Source Link metadata. The props here are correct and harmless to merge independently; the effect on published packages appears once #197 ships.

## Verification
Reproduced the release flow locally (`dotnet build` with `-p:ContinuousIntegrationBuild=true -p:PublishRepositoryUrl=true -p:SourceRevisionId=<sha>`, then `dotnet pack --no-build`), including with `.git` removed to simulate the pipeline's archive source. All four issue expectations hold:
- nuspec `<repository ... commit="<sha>" />`
- `AssemblyInformationalVersion` = `13.7.2+<sha>` (net8.0 and net10.0)
- embedded PDB Source Link map: `/_/* → https://raw.githubusercontent.com/aws/integrations-on-dotnet-aspire-for-aws/<sha>/*`
- 136 documents, all repository-relative `/_/src/...`, no `C:\build\...` paths

## Reviewer notes
- **Not on the PR-CI path:** `buildtools/ci.buildspec.yml` runs `dotnet test` only and does not pack/publish, so it is intentionally unchanged. Packing happens in the release pipeline's package step.
- **Unit tests:** None — this is build/packaging configuration and is not unit-testable in the conventional sense.
- **AutoVer change file:** Included (`.autover/changes/`), Patch bump.
